### PR TITLE
Scoring improvements: normalize winner to 1000, season URL state, task value

### DIFF
--- a/frontend/src/api/leagues.ts
+++ b/frontend/src/api/leagues.ts
@@ -86,7 +86,7 @@ export interface Task {
   closeDate: string;
   isFrozen?: boolean;
   scoresFrozenAt?: string;
-  normalizedScore?: number | null;
+  taskValue?: number | null;
   status?: 'draft' | 'published';
   createdAt: string;
   updatedAt?: string;
@@ -124,7 +124,7 @@ export interface UpdateTaskInput {
   taskType?: 'RACE_TO_GOAL' | 'OPEN_DISTANCE';
   openDate?: string;
   closeDate?: string;
-  normalizedScore?: number | null;
+  taskValue?: number | null;
 }
 
 export const leagueApi = {

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -23,7 +23,7 @@ export interface Task {
   closeDate:      string;
   isFrozen:       boolean;
   scoresFrozenAt:      string | null;
-  normalizedScore:     number | null;
+  taskValue:           number | null;
   pilotCount:          number;
   goalCount:           number;
   turnpoints:          Turnpoint[];

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -168,24 +168,28 @@ function TaskLeftPanel({
 export default function HomePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedEntry, setSelectedEntry] = useState<LeaderboardEntry | null>(null);
-  const [selectedSeasonId, setSelectedSeasonId] = useState<string | null>(null);
 
   const activeTab = searchParams.get('task') ?? 'overall';
   const setActiveTab = (tab: 'overall' | string) => {
     setSelectedEntry(null);
-    if (tab === 'overall') {
-      setSearchParams({}, { replace: true });
-    } else {
-      setSearchParams({ task: tab }, { replace: true });
-    }
+    const season = searchParams.get('season');
+    const next: Record<string, string> = {};
+    if (season) next.season = season;
+    if (tab !== 'overall') next.task = tab;
+    setSearchParams(next, { replace: true });
   };
 
   const { user }                    = useAuth();
   const { leagueSlug, seasonId: contextSeasonId } = useLeague();
   const { data: seasons }           = useSeasons();
 
-  // Default to the context season (active/open), allow override via dropdown
-  const seasonId = selectedSeasonId ?? contextSeasonId;
+  // Use ?season= param if present, otherwise fall back to the active season from context
+  const seasonId = searchParams.get('season') ?? contextSeasonId;
+
+  const setSeasonId = (id: string) => {
+    setSelectedEntry(null);
+    setSearchParams({ season: id }, { replace: true });
+  };
 
   const { data: tasks, isLoading: tasksLoading } = useQuery({
     queryKey: ['tasks', leagueSlug, seasonId],
@@ -289,7 +293,7 @@ export default function HomePage() {
           <div style={{ marginBottom: '0.75rem' }}>
             <select
               value={seasonId}
-              onChange={e => { setSelectedSeasonId(e.target.value); setActiveTab('overall'); }}
+              onChange={e => setSeasonId(e.target.value)}
               style={{
                 padding: '0.3rem 0.6rem',
                 border: '1px solid var(--border)',

--- a/frontend/src/pages/LeagueSettingsPage.tsx
+++ b/frontend/src/pages/LeagueSettingsPage.tsx
@@ -886,20 +886,20 @@ function TaskForm({ task, defaultOpenDate, defaultCloseDate, onSubmit, onCancel,
   };
   const [openDate, setOpenDate] = useState(fmt(task?.openDate ?? defaultOpenDate));
   const [closeDate, setCloseDate] = useState(fmt(task?.closeDate ?? defaultCloseDate, '23:59'));
-  const [normalizedScore, setNormalizedScore] = useState(
-    task?.normalizedScore != null ? String(task.normalizedScore) : ''
+  const [taskValue, setTaskValue] = useState(
+    task?.taskValue != null ? String(task.taskValue) : ''
   );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const ns = normalizedScore !== '' ? parseInt(normalizedScore, 10) : null;
+    const tv = taskValue !== '' ? parseInt(taskValue, 10) : null;
     onSubmit({
       name,
       description: description || undefined,
       taskType,
       openDate: new Date(openDate).toISOString(),
       closeDate: new Date(closeDate).toISOString(),
-      normalizedScore: ns,
+      taskValue: tv,
     } as any);
   };
 
@@ -935,17 +935,17 @@ function TaskForm({ task, defaultOpenDate, defaultCloseDate, onSubmit, onCancel,
           </div>
         </div>
         <div>
-          <label style={labelStyle}>Normalized Score (optional)</label>
+          <label style={labelStyle}>Task Value (optional)</label>
           <input
             type="number"
             min="1"
-            value={normalizedScore}
-            onChange={(e) => setNormalizedScore(e.target.value)}
-            placeholder="e.g. 1000 — winner gets this score, others scaled proportionally"
+            value={taskValue}
+            onChange={(e) => setTaskValue(e.target.value)}
+            placeholder="Default: 1000"
             style={{ ...inputStyle, fontFamily: 'monospace' }}
           />
           <div style={{ fontSize: '0.75rem', color: 'var(--text2)', marginTop: '0.25rem' }}>
-            Leave blank to use raw GAP scores (~938 max). Set to e.g. 1000 to normalize the winner's score to that value.
+            How many points the task winner receives. Other pilots score proportionally less. Leave blank for 1000.
           </div>
         </div>
         <FormActions

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -299,17 +299,18 @@ export function rebuildTaskResults(db: Database, taskId: string): void {
   const taskRow = db.prepare(
     `SELECT normalized_score FROM tasks WHERE id = ?`
   ).get(taskId) as { normalized_score: number | null } | undefined;
-  const normalized = taskRow?.normalized_score ?? null;
+  const normalized = taskRow?.normalized_score ?? 1000;
 
   let finalRows = rows;
   if (normalized !== null && rows.length > 0) {
     const winnerTotal = Math.max(...rows.map(r => r.total_points));
     if (winnerTotal > 0) {
+      const scale = normalized / winnerTotal;
       finalRows = rows.map(r => {
-        const scale = normalized / winnerTotal;
-        const dp = Math.round(r.distance_points * scale);
-        const tp = Math.round(r.time_points * scale);
-        return { ...r, distance_points: dp, time_points: tp, total_points: dp + tp };
+        const total = Math.round(r.total_points * scale);
+        const dp    = Math.round(r.distance_points * scale);
+        const tp    = total - dp;
+        return { ...r, distance_points: dp, time_points: tp, total_points: total };
       });
     }
   }

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -163,7 +163,7 @@ export async function registerLeagueRoutes(
            t.close_date as closeDate,
            CASE WHEN t.scores_frozen_at IS NOT NULL THEN 1 ELSE 0 END as isFrozen,
            t.scores_frozen_at as scoresFrozenAt,
-           t.normalized_score as normalizedScore,
+           t.normalized_score as taskValue,
            (SELECT COUNT(DISTINCT user_id) FROM flight_submissions WHERE task_id = t.id AND deleted_at IS NULL) as pilotCount,
            (SELECT COUNT(DISTINCT fs.user_id)
             FROM flight_submissions fs
@@ -1427,7 +1427,7 @@ export async function registerLeagueRoutes(
         taskType?: 'RACE_TO_GOAL' | 'OPEN_DISTANCE';
         openDate?: string;
         closeDate?: string;
-        normalizedScore?: number | null;
+        taskValue?: number | null;
       };
       
       // Verify task belongs to this season/league
@@ -1487,9 +1487,9 @@ export async function registerLeagueRoutes(
         updates.push('close_date = ?');
         params.push(body.closeDate);
       }
-      if (body.normalizedScore !== undefined) {
+      if (body.taskValue !== undefined) {
         updates.push('normalized_score = ?');
-        params.push(body.normalizedScore ?? null);
+        params.push(body.taskValue ?? null);
       }
 
       if (updates.length === 0) {
@@ -1509,7 +1509,7 @@ export async function registerLeagueRoutes(
           task_type as taskType,
           open_date as openDate,
           close_date as closeDate,
-          normalized_score as normalizedScore,
+          normalized_score as taskValue,
           updated_at as updatedAt
         FROM tasks WHERE id = ?`
       ).get(taskId);

--- a/src/shared/SCORING.md
+++ b/src/shared/SCORING.md
@@ -1,0 +1,89 @@
+# XC League Scoring
+
+## Overview
+
+Scoring is based on a simplified GAP (Glide And Aim for Paragliding) model with no task validity, no leading points, and no arrival points. Every task is normalized so the winner scores **1000 points**.
+
+---
+
+## Components
+
+### Distance Points
+
+Every pilot who crosses the SSS receives distance points.
+
+| Pilot | Formula |
+|---|---|
+| Reached goal | `1000` |
+| Did not reach goal | `1000 × √(dist / bestDist)` |
+
+- `dist` — the pilot's best distance along the optimal route from SSS to goal
+- `bestDist` — the furthest distance flown by any pilot on the task (= task distance if anyone reached goal)
+
+The square root curve rewards pilots who fly further but does not linearly scale, providing some separation among non-goal pilots.
+
+### Time Points
+
+Only goal pilots receive time points.
+
+| Condition | Formula |
+|---|---|
+| Sole finisher, or all goal pilots finish in the same time | `1000` |
+| Otherwise | `1000 × (1 - ((t − t_min) / (t_max − t_min))^(2/3))` |
+
+- `t` — this pilot's task time (SSS crossing → goal crossing)
+- `t_min` — fastest goal time
+- `t_max` — slowest goal time
+
+The `^(2/3)` exponent gives more weight to the faster end — a pilot 50% of the way through the time spread loses much less than 500 points.
+
+Non-goal pilots receive **0 time points**.
+
+### Total (raw)
+
+```
+totalPoints = distancePoints + timePoints
+```
+
+For the fastest goal pilot this is `1000 + 1000 = 2000` before normalization.
+
+---
+
+## Normalization
+
+After scoring, all scores are scaled so the highest-scoring pilot gets exactly **1000 points**:
+
+```
+scale = 1000 / winnerTotal
+finalPoints = round(rawPoints × scale)
+```
+
+This means:
+- The winner always scores 1000 regardless of how many pilots flew or whether anyone reached goal.
+- Relative gaps between pilots are preserved.
+- Tasks with only distance scoring (no goal finishers) and tasks with both distance + time scoring are comparable on the same 0–1000 scale.
+
+A custom `normalized_score` can be set per task to override the default 1000 cap.
+
+---
+
+## When Nobody Reaches Goal
+
+If no pilot crosses the ESS/goal:
+- All pilots receive distance points only (no time points).
+- The furthest pilot gets `1000 × √(bestDist/bestDist) = 1000` before normalization, which normalizes to **1000**.
+- Everyone else scales down from there.
+
+---
+
+## Standings
+
+The season standings sum each pilot's best result per task. If a pilot has multiple submissions for the same task (re-flies), only the highest-scoring attempt counts.
+
+Pilots are ranked by total points descending. Tie-breaking is not currently implemented.
+
+---
+
+## Rescoring
+
+Time points are recalculated every time a new result is submitted while a task is open. This means a pilot's score can change when other pilots submit results that shift `t_min` or `t_max`. Scores are finalized when an admin freezes the task.

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -262,7 +262,7 @@ export function computePartialDistanceKm(
 // GAP SCORING  (no validity, no lead-out)
 // =============================================================================
 
-export const MAX_POINTS = 938;
+export const MAX_POINTS = 1000;
 
 /**
  * Distance points for one pilot.

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -187,7 +187,7 @@ describe('rebuildTaskResults', () => {
     const rows = db.prepare('SELECT * FROM task_results WHERE task_id = ?').all(task.id) as any[];
     expect(rows).toHaveLength(1);
     expect(rows[0].user_id).toBe(pilot.id);
-    expect(rows[0].total_points).toBe(500);
+    expect(rows[0].total_points).toBe(1000);
     expect(rows[0].rank).toBe(1);
   });
 
@@ -201,7 +201,7 @@ describe('rebuildTaskResults', () => {
     const rows = db.prepare('SELECT * FROM task_results WHERE task_id = ?').all(task.id) as any[];
     expect(rows).toHaveLength(1);
     expect(rows[0].reached_goal).toBe(1);
-    expect(rows[0].total_points).toBe(847);
+    expect(rows[0].total_points).toBe(1000);
   });
 
   it('ranks pilots correctly: goal pilot ranks above non-goal', () => {


### PR DESCRIPTION
## Summary

- **Winner always scores 1000**: `MAX_POINTS` raised from 938 → 1000; normalization now always runs (default target = 1000, overridable per-task via Task Value field)
- **Fixed normalization math**: Previously scaled `dp` and `tp` independently, causing `dp + tp ≠ expected total` due to rounding. Now scales `total_points` directly and derives `tp = total - dp`
- **`normalizedScore` → `taskValue`**: Renamed in API response, TypeScript interfaces, and UI label/field (DB column `normalized_score` unchanged)
- **Season in URL**: Season selection on home page now encoded in `?season=<id>` so links are shareable and survive page refresh. Tab switches preserve the season param
- **SCORING.md**: Added documentation explaining the GAP-derived scoring model (distance points, time points, normalization, standings)

## Test plan

- [ ] All 130 tests pass (`npm test`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Upload an IGC to a task with no custom task value — verify winner gets 1000 pts
- [ ] Set a custom task value (e.g. 500) — verify winner gets 500 pts
- [ ] Navigate to a task tab, then switch season via dropdown — verify season param persists in URL and task resets to Overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)