### PR TITLE
Let users view task map without a track overlay

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -153,12 +153,18 @@ function TaskLeftPanel({
 
       {/* Leaderboard */}
       <div style={{ marginBottom: 20 }}>
-        {activeEntry && (
+        {activeEntry ? (
           <div style={{ fontSize: 11, color: 'var(--text3)', marginBottom: 8, fontFamily: 'var(--font-mono)' }}>
             Showing track for{' '}
             <span style={{ color: '#a78bfa', fontWeight: 600 }}>{trackLoading ? '…' : activeEntry.pilotName}</span> —
-            click a row to switch
+            click again to hide, or click a row to switch
           </div>
+        ) : (
+          leaderboardEntries.some((e) => e.submissionId) && (
+            <div style={{ fontSize: 11, color: 'var(--text3)', marginBottom: 8, fontFamily: 'var(--font-mono)' }}>
+              Tip: click a pilot's row to view their track on the map
+            </div>
+          )
         )}
         <TaskLeaderboard
           entries={leaderboardEntries}
@@ -249,12 +255,11 @@ export default function HomePage() {
   const activeQuery = activeTaskIdx >= 0 ? leaderboardQueries[activeTaskIdx] : null;
   const activeEntries = activeQuery?.data?.entries ?? [];
 
-  // Auto-select default entry when leaderboard loads
-  const defaultEntry =
-    activeEntries.find((e) => e.pilotId === user?.id && e.submissionId) ??
-    activeEntries.find((e) => e.submissionId) ??
-    null;
-  const activeEntry = selectedEntry ?? defaultEntry;
+  const activeEntry = selectedEntry;
+
+  const handleSelectPilot = (entry: LeaderboardEntry) => {
+    setSelectedEntry((prev) => (prev?.pilotId === entry.pilotId ? null : entry));
+  };
 
   // Fetch track for selected pilot
   const { data: trackData, isFetching: trackLoading } = useQuery({
@@ -427,7 +432,7 @@ export default function HomePage() {
               myId={user?.id}
               selectedPilotId={activeEntry?.pilotId}
               trackLoading={trackLoading}
-              onSelectPilot={setSelectedEntry}
+              onSelectPilot={handleSelectPilot}
             />
           ) : null)}
 


### PR DESCRIPTION
## Summary

A user reported that once any pilot uploads a track, the task map always overlays someone's track — there's no way to see just the task. The page was auto-selecting the first entry with a submission.

- Task tab now opens with no track shown
- Click a pilot's row → their track appears
- Click the selected row again → track clears
- When no pilot is selected (and at least one track exists), the leaderboard shows a small tip: *"click a pilot's row to view their track on the map"*

## Test plan

- [x] Open a task with submissions → map shows turnpoints + route only, no row highlighted
- [x] Click a pilot's row → track appears, hint updates to "Showing track for …"
- [x] Click the same row again → track disappears
- [x] Click pilot A then pilot B → B's track replaces A's
- [x] Switch tabs and back → state resets, no track shown
- [x] Mobile Map view toggle → same behaviour
- [x] Task with no submissions → no tip shown, map shows task alone