### PR TITLE
Block LeagueShell until seasons load; handle no-seasons state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@
 // =============================================================================
 
 import { useQuery } from '@tanstack/react-query';
-import { Navigate, Outlet, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { leagueApi } from './api/leagues';
 import UserMenuPopout from './components/UserMenuPopout';
 import { useAuth } from './hooks/useAuth';
@@ -33,9 +33,10 @@ function LeagueLayout() {
   const { leagueSlug } = useParams<{ leagueSlug: string }>();
   const slug = leagueSlug ?? '';
   const { user, isFetched } = useAuth();
+  const location = useLocation();
 
   // Fetch seasons to get the active season ID
-  const { data: seasonsData } = useQuery({
+  const { data: seasonsData, isPending: seasonsPending } = useQuery({
     queryKey: ['seasons', slug],
     queryFn: () => leagueApi.listSeasons(slug),
     enabled: !!slug,
@@ -47,14 +48,57 @@ function LeagueLayout() {
     return <Navigate to="/onboarding" replace />;
   }
 
+  if (seasonsPending) {
+    return <LeagueLoadingState />;
+  }
+
   const seasons = seasonsData?.seasons ?? [];
   const activeSeason = seasons.find((s) => s.status === 'open') ?? seasons[0];
-  const seasonId = activeSeason?.id ?? '';
+
+  // League Settings manages seasons, so an admin must be able to reach it even
+  // when none exist yet — otherwise the "create one from League Settings"
+  // empty-state advice leads to a dead end.
+  const isSettingsRoute = location.pathname.endsWith('/league-settings');
+  if (!activeSeason && !isSettingsRoute) {
+    return <LeagueNoSeasonsState />;
+  }
 
   return (
-    <LeagueProvider leagueSlug={slug} seasonId={seasonId}>
+    <LeagueProvider leagueSlug={slug} seasonId={activeSeason?.id ?? ''}>
       <LeagueShell leagueSlug={slug} />
     </LeagueProvider>
+  );
+}
+
+function LeagueLoadingState() {
+  return (
+    <div style={{ padding: '2rem', maxWidth: 320 }}>
+      <div className="shimmer" style={{ height: 28, borderRadius: 6, marginBottom: 12 }} />
+      <div className="shimmer" style={{ height: 16, borderRadius: 4, width: '60%' }} />
+    </div>
+  );
+}
+
+function LeagueNoSeasonsState() {
+  return (
+    <div style={{ padding: '2rem', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div
+        style={{
+          maxWidth: 420,
+          padding: '2rem',
+          textAlign: 'center',
+          border: '1px dashed var(--border)',
+          borderRadius: 8,
+          color: 'var(--text2)',
+        }}
+      >
+        <div style={{ fontSize: 32, marginBottom: 12 }}>🪂</div>
+        <div style={{ fontWeight: 500, marginBottom: 8, color: 'var(--text)' }}>No seasons yet</div>
+        <div style={{ fontSize: 14, lineHeight: 1.5 }}>
+          This league hasn't opened a season yet. An admin can create one from League Settings.
+        </div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #19.

## Summary

\`LeagueLayout\` was rendering \`LeagueShell\` while the \`listSeasons\` query was still pending, so \`HomePage\` and its descendants would fire standings/tasks/leaderboard queries with an empty \`seasonId\` before the real one arrived and triggered a re-render. That produced a wave of silent 404s on every league navigation.

Now \`LeagueLayout\` gates on \`isPending\`:

- **Pending** → neutral loading shimmer in the shell
- **Resolved with no seasons** → dedicated empty-state card ("No seasons yet — an admin can create one from League Settings")
- **Resolved with at least one season** → render \`LeagueShell\` with a guaranteed real \`activeSeason.id\`

The onboarding redirect still runs before the pending gate so unprofiled users don't have to wait on the seasons fetch.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 158 pass
- [x] \`cd frontend && npm test\` — 21 pass
- [x] Manual: load \`/leagues/<slug>\` and confirm no 404s fire against \`.../seasons//standings\`-style URLs during the initial render
- [x] Manual: visit a league with no seasons (create one via \`leagueApi.create\` if needed) → empty state renders instead of a broken HomePage