### PR TITLE
Extract AppShell layout; drop duplicate Sign in from popout menu

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,16 @@
 //
 // URL structure:
 //   /                          → fetches league list, redirects to first league
-//   /leagues/:leagueSlug       → home page (leaderboard + tasks)
+//   /leagues                   → browse all leagues
+//   /leagues/:leagueSlug       → home page for one league (leaderboard + tasks)
 //   /leagues/:leagueSlug/:page → named page within a league
+//   /profile | /super-admin | /create-league | /onboarding → user/platform-scoped pages
+//
+// All routes render inside <AppShell> so the floating menu appears everywhere.
 // =============================================================================
 
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useParams } from 'react-router-dom';
 import { leagueApi } from './api/leagues';
 import UserMenuPopout from './components/UserMenuPopout';
 import { useAuth } from './hooks/useAuth';
@@ -56,44 +59,28 @@ function LeagueLayout() {
 }
 
 function LeagueShell({ leagueSlug }: { leagueSlug: string }) {
-  const { user } = useAuth();
-  const [isLeagueAdmin, setIsLeagueAdmin] = useState(false);
+  return (
+    <Routes>
+      <Route index element={<HomePage />} />
+      <Route path="tasks" element={<HomePage />} />
+      <Route path="season" element={<HomePage />} />
+      <Route path="league-settings" element={<LeagueSettingsPage />} />
+      {/* Catch-all: redirect unknown sub-paths to home */}
+      <Route path="*" element={<Navigate to={`/leagues/${leagueSlug}`} replace />} />
+    </Routes>
+  );
+}
 
-  // Check league admin status
-  useEffect(() => {
-    if (!user) {
-      setIsLeagueAdmin(false);
-      return;
-    }
-    if (user.isAdmin) {
-      setIsLeagueAdmin(true);
-      return;
-    }
+// ─────────────────────────────────────────────────────────────────────────────
+// AppShell — outer frame rendered on every route (floating menu + <main>)
+// ─────────────────────────────────────────────────────────────────────────────
 
-    leagueApi
-      .listMembers(leagueSlug)
-      .then((data) => {
-        const membership = data.members.find((m) => m.userId === user.id);
-        setIsLeagueAdmin(membership?.role === 'admin');
-      })
-      .catch(() => setIsLeagueAdmin(false));
-  }, [user, leagueSlug]);
-
+function AppShell() {
   return (
     <div className="app">
-      {/* Floating user menu — bottom left */}
-      <UserMenuPopout isLeagueAdmin={isLeagueAdmin} />
-
-      {/* Full-width main content */}
+      <UserMenuPopout />
       <main className="main" style={{ padding: 0 }}>
-        <Routes>
-          <Route index element={<HomePage />} />
-          <Route path="tasks" element={<HomePage />} />
-          <Route path="season" element={<HomePage />} />
-          <Route path="league-settings" element={<LeagueSettingsPage />} />
-          {/* Catch-all: redirect unknown sub-paths to home */}
-          <Route path="*" element={<Navigate to={`/leagues/${leagueSlug}`} replace />} />
-        </Routes>
+        <Outlet />
       </main>
     </div>
   );
@@ -106,13 +93,15 @@ function LeagueShell({ leagueSlug }: { leagueSlug: string }) {
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/leagues" replace />} />
-      <Route path="/leagues" element={<LeaguesListPage />} />
-      <Route path="/onboarding" element={<OnboardingPage />} />
-      <Route path="/create-league" element={<CreateLeaguePage />} />
-      <Route path="/profile" element={<ProfilePage />} />
-      <Route path="/super-admin" element={<SuperAdminPage />} />
-      <Route path="/leagues/:leagueSlug/*" element={<LeagueLayout />} />
+      <Route element={<AppShell />}>
+        <Route path="/" element={<Navigate to="/leagues" replace />} />
+        <Route path="/leagues" element={<LeaguesListPage />} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route path="/create-league" element={<CreateLeaguePage />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/super-admin" element={<SuperAdminPage />} />
+        <Route path="/leagues/:leagueSlug/*" element={<LeagueLayout />} />
+      </Route>
       <Route path="*" element={<Navigate to="/leagues" replace />} />
     </Routes>
   );

--- a/frontend/src/components/UserMenuPopout.tsx
+++ b/frontend/src/components/UserMenuPopout.tsx
@@ -1,20 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { leagueApi } from '../api/leagues';
 import { useAuth } from '../hooks/useAuth';
 import { useLeague } from '../hooks/useLeague';
 import { useTheme } from '../hooks/useTheme';
 
-interface UserMenuPopoutProps {
-  isLeagueAdmin: boolean;
-}
-
-export default function UserMenuPopout({ isLeagueAdmin }: UserMenuPopoutProps) {
+export default function UserMenuPopout() {
   const { user, isLoading, login, logout } = useAuth();
   const { leagueSlug } = useLeague();
   const { theme, toggle: toggleTheme } = useTheme();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Derive league-admin status from the current URL slug + user membership.
+  // useQuery dedups requests and ignores stale responses so rapid league
+  // navigation can't leave the menu showing the previous league's admin state.
+  const { data: membersData } = useQuery({
+    queryKey: ['members', leagueSlug],
+    queryFn: () => leagueApi.listMembers(leagueSlug),
+    enabled: !!user && !user.isAdmin && !!leagueSlug,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const isLeagueAdmin =
+    !!user &&
+    !!leagueSlug &&
+    (user.isAdmin || membersData?.members.find((m) => m.userId === user.id)?.role === 'admin');
 
   // Close on outside click
   useEffect(() => {
@@ -82,6 +95,16 @@ export default function UserMenuPopout({ isLeagueAdmin }: UserMenuPopoutProps) {
             padding: '8px 4px',
           }}
         >
+          <button
+            style={menuItemStyle}
+            onClick={() => go('/leagues')}
+            onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg3)')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
+          >
+            <span style={{ fontSize: 14 }}>◎</span>
+            Leagues
+          </button>
+
           {user && (
             <button
               style={menuItemStyle}
@@ -140,34 +163,22 @@ export default function UserMenuPopout({ isLeagueAdmin }: UserMenuPopoutProps) {
             {theme === 'dark' ? 'Light mode' : 'Dark mode'}
           </button>
 
-          <div style={dividerStyle} />
-
-          {user ? (
-            <button
-              style={{ ...menuItemStyle, color: 'var(--text3)' }}
-              onClick={() => {
-                setOpen(false);
-                logout?.();
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg3)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
-            >
-              <span style={{ fontSize: 14 }}>→</span>
-              Sign out
-            </button>
-          ) : (
-            <button
-              style={menuItemStyle}
-              onClick={() => {
-                setOpen(false);
-                login();
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg3)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
-            >
-              <span style={{ fontSize: 14 }}>→</span>
-              Sign in
-            </button>
+          {user && (
+            <>
+              <div style={dividerStyle} />
+              <button
+                style={{ ...menuItemStyle, color: 'var(--text3)' }}
+                onClick={() => {
+                  setOpen(false);
+                  logout?.();
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg3)')}
+                onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
+              >
+                <span style={{ fontSize: 14 }}>→</span>
+                Sign out
+              </button>
+            </>
           )}
         </div>
       )}

--- a/frontend/src/pages/LeaguesListPage.tsx
+++ b/frontend/src/pages/LeaguesListPage.tsx
@@ -5,7 +5,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { leagueApi } from '../api/leagues';
-import UserMenuPopout from '../components/UserMenuPopout';
 import { useAuth } from '../hooks/useAuth';
 
 export default function LeaguesListPage() {
@@ -21,157 +20,153 @@ export default function LeaguesListPage() {
   const leagues = data?.leagues ?? [];
 
   return (
-    <>
-      <UserMenuPopout isLeagueAdmin={false} />
+    <div style={{ minHeight: '100dvh', background: 'var(--bg)', width: '100%' }}>
+      <div className="page-container" style={{ maxWidth: 520 }}>
+        {/* Header */}
+        <div style={{ marginBottom: '2.5rem' }}>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, marginBottom: '0.5rem' }}>Leagues</h1>
+          <p style={{ fontSize: 14, color: 'var(--text2)' }}>Browse XC paragliding leagues and competitions.</p>
+        </div>
 
-      <div style={{ minHeight: '100dvh', background: 'var(--bg)', width: '100%' }}>
-        <div className="page-container" style={{ maxWidth: 520 }}>
-          {/* Header */}
-          <div style={{ marginBottom: '2.5rem' }}>
-            <h1 style={{ fontSize: '1.75rem', fontWeight: 700, marginBottom: '0.5rem' }}>Leagues</h1>
-            <p style={{ fontSize: 14, color: 'var(--text2)' }}>Browse XC paragliding leagues and competitions.</p>
+        {/* League list */}
+        {isLoading ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="shimmer" style={{ height: 80, borderRadius: 8 }} />
+            ))}
           </div>
-
-          {/* League list */}
-          {isLoading ? (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="shimmer" style={{ height: 80, borderRadius: 8 }} />
-              ))}
-            </div>
-          ) : leagues.length === 0 ? (
-            <div
-              style={{
-                padding: '3rem',
-                textAlign: 'center',
-                color: 'var(--text3)',
-                border: '1px dashed var(--border)',
-                borderRadius: 8,
-              }}
-            >
-              <div style={{ fontSize: 32, marginBottom: 12 }}>🪂</div>
-              <div style={{ fontWeight: 500, marginBottom: 8 }}>No leagues yet</div>
-              {user && (
-                <button
-                  onClick={() => navigate('/create-league')}
-                  style={{
-                    marginTop: 8,
-                    padding: '0.5rem 1.25rem',
-                    background: 'var(--primary)',
-                    color: '#fff',
-                    border: 'none',
-                    borderRadius: 6,
-                    cursor: 'pointer',
-                    fontSize: 14,
-                    fontWeight: 500,
-                  }}
-                >
-                  Create the first league
-                </button>
-              )}
-            </div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {leagues.map((league) => (
-                <button
-                  key={league.id}
-                  onClick={() => navigate(`/leagues/${league.slug}`)}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 16,
-                    padding: '1rem 1.25rem',
-                    background: 'var(--bg2)',
-                    border: '1px solid var(--border)',
-                    borderRadius: 8,
-                    cursor: 'pointer',
-                    textAlign: 'left',
-                    width: '100%',
-                    minWidth: 0,
-                    overflow: 'hidden',
-                    transition: 'border-color 0.15s, background 0.15s',
-                  }}
-                  onMouseEnter={(e) => {
-                    (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
-                    (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg3)';
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
-                    (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg2)';
-                  }}
-                >
-                  {/* Logo or placeholder */}
-                  <div
-                    style={{
-                      width: 48,
-                      height: 48,
-                      borderRadius: 8,
-                      background: 'var(--bg3)',
-                      border: '1px solid var(--border)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 22,
-                      flexShrink: 0,
-                      overflow: 'hidden',
-                    }}
-                  >
-                    {league.logoUrl ? (
-                      <img src={league.logoUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-                    ) : (
-                      '🪂'
-                    )}
-                  </div>
-
-                  {/* Text */}
-                  <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-                    <div style={{ fontWeight: 600, fontSize: 15, color: 'var(--text)', marginBottom: 2 }}>
-                      {league.name}
-                    </div>
-                    {league.shortDescription && (
-                      <div
-                        style={{
-                          fontSize: 13,
-                          color: 'var(--text3)',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                          minWidth: 0,
-                        }}
-                      >
-                        {league.shortDescription}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Arrow */}
-                  <div style={{ color: 'var(--text3)', fontSize: 18, flexShrink: 0 }}>›</div>
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* Create league CTA for logged-in users */}
-          {user && leagues.length > 0 && (
-            <div style={{ marginTop: '2rem', paddingTop: '1.5rem', borderTop: '1px solid var(--border)' }}>
+        ) : leagues.length === 0 ? (
+          <div
+            style={{
+              padding: '3rem',
+              textAlign: 'center',
+              color: 'var(--text3)',
+              border: '1px dashed var(--border)',
+              borderRadius: 8,
+            }}
+          >
+            <div style={{ fontSize: 32, marginBottom: 12 }}>🪂</div>
+            <div style={{ fontWeight: 500, marginBottom: 8 }}>No leagues yet</div>
+            {user && (
               <button
                 onClick={() => navigate('/create-league')}
                 style={{
-                  padding: '0.5rem 1rem',
-                  background: 'none',
-                  border: '1px solid var(--border)',
+                  marginTop: 8,
+                  padding: '0.5rem 1.25rem',
+                  background: 'var(--primary)',
+                  color: '#fff',
+                  border: 'none',
                   borderRadius: 6,
-                  color: 'var(--text2)',
                   cursor: 'pointer',
-                  fontSize: 13,
+                  fontSize: 14,
+                  fontWeight: 500,
                 }}
               >
-                + Create a new league
+                Create the first league
               </button>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {leagues.map((league) => (
+              <button
+                key={league.id}
+                onClick={() => navigate(`/leagues/${league.slug}`)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 16,
+                  padding: '1rem 1.25rem',
+                  background: 'var(--bg2)',
+                  border: '1px solid var(--border)',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  width: '100%',
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  transition: 'border-color 0.15s, background 0.15s',
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
+                  (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg3)';
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)';
+                  (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg2)';
+                }}
+              >
+                {/* Logo or placeholder */}
+                <div
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 8,
+                    background: 'var(--bg3)',
+                    border: '1px solid var(--border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 22,
+                    flexShrink: 0,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {league.logoUrl ? (
+                    <img src={league.logoUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                  ) : (
+                    '🪂'
+                  )}
+                </div>
+
+                {/* Text */}
+                <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                  <div style={{ fontWeight: 600, fontSize: 15, color: 'var(--text)', marginBottom: 2 }}>
+                    {league.name}
+                  </div>
+                  {league.shortDescription && (
+                    <div
+                      style={{
+                        fontSize: 13,
+                        color: 'var(--text3)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        minWidth: 0,
+                      }}
+                    >
+                      {league.shortDescription}
+                    </div>
+                  )}
+                </div>
+
+                {/* Arrow */}
+                <div style={{ color: 'var(--text3)', fontSize: 18, flexShrink: 0 }}>›</div>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Create league CTA for logged-in users */}
+        {user && leagues.length > 0 && (
+          <div style={{ marginTop: '2rem', paddingTop: '1.5rem', borderTop: '1px solid var(--border)' }}>
+            <button
+              onClick={() => navigate('/create-league')}
+              style={{
+                padding: '0.5rem 1rem',
+                background: 'none',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                color: 'var(--text2)',
+                cursor: 'pointer',
+                fontSize: 13,
+              }}
+            >
+              + Create a new league
+            </button>
+          </div>
+        )}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #20.

## Summary

Three menu/layout polish items bundled:

### 1. Menu now renders on every page

Introduced \`AppShell\` — a react-router layout component that renders the floating menu, \`<main>\`, and an \`<Outlet />\`. Every route is nested under it, so \`/profile\`, \`/super-admin\`, \`/create-league\`, and \`/onboarding\` regain the menu that was lost in #18.

\`\`\`tsx
<Route element={<AppShell />}>
  <Route path="/" element={...} />
  <Route path="/leagues" element={...} />
  <Route path="/onboarding" element={...} />
  <Route path="/create-league" element={...} />
  <Route path="/profile" element={...} />
  <Route path="/super-admin" element={...} />
  <Route path="/leagues/:leagueSlug/*" element={<LeagueLayout />} />
</Route>
\`\`\`

\`LeagueShell\` shrank to a bare \`<Routes>\` block, since \`AppShell\` owns the \`<div className="app">\` / \`<main>\` wrappers now. \`LeaguesListPage\` dropped its manual \`UserMenuPopout\` render.

### 2. Popout menu cleanup

- **Added "Leagues" item at the top** — one-click escape back to the league picker from any sub-page.
- **Removed the signed-out "Sign in" item** — the pill added in #15 is now the sole sign-in affordance.
- **Moved league-admin membership check into \`UserMenuPopout\`** — the component is now self-contained (no \`isLeagueAdmin\` prop), deriving admin status from \`useLeague()\` + the current user.

### 3. Fixed admin-state race (Copilot feedback)

Replaced the imperative \`useEffect\` + \`useState\` membership check with \`useQuery\`. TanStack Query handles request dedup and cancels stale responses automatically, so rapid league navigation can no longer leave the previous league's admin state stuck on the menu.

## Merge-order note

#21 is open alongside this PR. Its \`LeagueLoadingState\` / \`LeagueNoSeasonsState\` helpers each render their own \`<div className="app">\` + \`<UserMenuPopout isLeagueAdmin={false} />\`, which become redundant (and typecheck-broken, since the prop is gone) once #22 lands. Whichever merges second needs a small rebase to strip those wrappers.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 158 pass
- [x] \`cd frontend && npm test\` — 21 pass
- [x] Lint clean
- [ ] Manual: menu visible on every page (\`/\`, \`/leagues\`, \`/leagues/:slug\`, \`/leagues/:slug/league-settings\`, \`/profile\`, \`/super-admin\`, \`/create-league\`, \`/onboarding\`)
- [ ] Manual: "Leagues" item returns to the picker from anywhere
- [ ] Manual: signed-out users see the pill (not a popout item) as the Sign-in affordance
- [ ] Manual: admin of current league still sees "League Admin" and it routes to the correct league's settings
- [ ] Manual: switch leagues quickly — admin state doesn't briefly stick from the previous league