### PR TITLE
Add GitHub-style alert callouts to league descriptions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.1",
-        "rehype-sanitize": "^6.0.0"
+        "rehype-sanitize": "^6.0.0",
+        "remark-github-blockquote-alert": "^2.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -4440,6 +4441,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-github-blockquote-alert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-2.1.0.tgz",
+      "integrity": "sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/remark-parse": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
-    "rehype-sanitize": "^6.0.0"
+    "rehype-sanitize": "^6.0.0",
+    "remark-github-blockquote-alert": "^2.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,7 @@
   --success: #10b981;
   --warning: #f59e0b;
   --error: #ef4444;
+  --important: #a78bfa;
   --shadow: rgba(0, 0, 0, 0.4);
 }
 
@@ -38,6 +39,7 @@
   --success: #059669;
   --warning: #d97706;
   --error: #dc2626;
+  --important: #7c3aed;
   --shadow: rgba(0, 0, 0, 0.1);
 }
 
@@ -363,6 +365,66 @@ label {
 }
 .prose a {
   color: var(--accent);
+}
+
+/* GitHub-style alert callouts emitted by remark-github-blockquote-alert.
+ * One base block for shared layout + per-variant colour accents. */
+.markdown-alert {
+  padding: 12px 16px;
+  margin: 1em 0;
+  border-left: 4px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg3);
+  color: var(--text);
+}
+.markdown-alert .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  line-height: 1;
+}
+.markdown-alert .markdown-alert-title svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+.markdown-alert p {
+  margin: 0;
+}
+.markdown-alert p + p {
+  margin-top: 0.5em;
+}
+.markdown-alert-note {
+  border-left-color: var(--accent);
+}
+.markdown-alert-note .markdown-alert-title {
+  color: var(--accent);
+}
+.markdown-alert-tip {
+  border-left-color: var(--success);
+}
+.markdown-alert-tip .markdown-alert-title {
+  color: var(--success);
+}
+.markdown-alert-important {
+  border-left-color: var(--important);
+}
+.markdown-alert-important .markdown-alert-title {
+  color: var(--important);
+}
+.markdown-alert-warning {
+  border-left-color: var(--warning);
+}
+.markdown-alert-warning .markdown-alert-title {
+  color: var(--warning);
+}
+.markdown-alert-caution {
+  border-left-color: var(--error);
+}
+.markdown-alert-caution .markdown-alert-title {
+  color: var(--error);
 }
 
 /* Tooltip */

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import UploadZone from '../components/UploadZone';
 import { useAuth } from '../hooks/useAuth';
 import { useLeague } from '../hooks/useLeague';
 import { useSeasons } from '../hooks/useStandings';
+import { markdownRemarkPlugins, markdownSanitizeSchema } from '../utils/markdown';
 import { getTaskStatus, STATUS_STYLE } from '../utils/taskStatus';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -316,7 +317,12 @@ export default function HomePage() {
               color: 'var(--text2)',
             }}
           >
-            <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{leagueData.league.fullDescription}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={markdownRemarkPlugins}
+              rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema]]}
+            >
+              {leagueData.league.fullDescription}
+            </ReactMarkdown>
           </div>
         )}
         <div

--- a/frontend/src/pages/LeagueSettingsPage.tsx
+++ b/frontend/src/pages/LeagueSettingsPage.tsx
@@ -25,6 +25,7 @@ import LeagueSwitcher from '../components/LeagueSwitcher';
 import TaskExportModal from '../components/TaskExportModal';
 import TaskImportModal from '../components/TaskImportModal';
 import { useLeague } from '../hooks/useLeague';
+import { markdownRemarkPlugins, markdownSanitizeSchema } from '../utils/markdown';
 
 type Tab = 'settings' | 'seasons' | 'tasks' | 'members';
 
@@ -145,7 +146,12 @@ function SettingsTab() {
                   Full Description
                 </div>
                 <div style={{ fontSize: '0.875rem', color: 'var(--text1)', lineHeight: 1.6 }} className="prose">
-                  <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{leagueData.league.fullDescription}</ReactMarkdown>
+                  <ReactMarkdown
+                    remarkPlugins={markdownRemarkPlugins}
+                    rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema]]}
+                  >
+                    {leagueData.league.fullDescription}
+                  </ReactMarkdown>
                 </div>
               </div>
             )}

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,0 +1,26 @@
+// =============================================================================
+// Shared markdown rendering config for user-authored league descriptions.
+// Enables GitHub-style alert callouts (> [!NOTE] / [!TIP] / [!IMPORTANT]
+// / [!WARNING] / [!CAUTION]) while keeping sanitization turned on.
+// =============================================================================
+
+import { defaultSchema } from 'rehype-sanitize';
+import { remarkAlert } from 'remark-github-blockquote-alert';
+
+// The alert plugin emits <div class="markdown-alert markdown-alert-note"> and
+// an inline <svg><path /></svg> icon. The default sanitize schema strips
+// class attributes and unknown tags, so widen it just enough to keep alerts
+// intact.
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'svg', 'path'],
+  attributes: {
+    ...defaultSchema.attributes,
+    div: [...((defaultSchema.attributes ?? {}).div ?? []), 'className'],
+    p: [...((defaultSchema.attributes ?? {}).p ?? []), 'className'],
+    svg: ['className', 'viewBox', 'width', 'height', 'fill', 'xmlns', 'ariaHidden'],
+    path: ['d', 'fillRule', 'clipRule'],
+  },
+};
+
+export const markdownRemarkPlugins = [remarkAlert];


### PR DESCRIPTION
## Summary

Adds support for GitHub's alert syntax in league \`fullDescription\` markdown — league admins can now write:

\`\`\`markdown
> [!NOTE]
> Classes of pilots competing this season.

> [!WARNING]
> Registration closes 15 June.
\`\`\`

and the front-end renders them as coloured callout boxes instead of plain blockquotes.

Five variants supported: \`NOTE\` (blue), \`TIP\` (green), \`IMPORTANT\` (purple), \`WARNING\` (orange), \`CAUTION\` (red). Colours reuse the existing accent palette.

## Approach

- New dep: \`remark-github-blockquote-alert\` (a small remark plugin that parses only the GFM alert syntax).
- New shared helper \`frontend/src/utils/markdown.ts\` — exports \`markdownRemarkPlugins\` and a widened \`markdownSanitizeSchema\` so \`HomePage\` and \`LeagueSettingsPage\` stay in sync.
- \`rehype-sanitize\` schema extended just enough to keep the plugin's \`<div class="markdown-alert ...">\` + inline SVG icon intact. The general attribute allow-list is untouched.
- CSS added in \`index.css\` (base block + per-variant left-border/title colour).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 158 pass
- [x] \`cd frontend && npm test\` — 21 pass
- [x] Manual: set a league's full description to include all five alert types → confirm each renders with its colour accent on HomePage and in the LeagueSettingsPage preview pane.
- [x] Manual: try HTML injection (\`<script>\` inside an alert body) — sanitize should still strip it.