### PR TITLE
Stop season dates shifting a day across timezones

### DIFF
--- a/frontend/src/pages/LeagueSettingsPage.tsx
+++ b/frontend/src/pages/LeagueSettingsPage.tsx
@@ -25,6 +25,7 @@ import LeagueSwitcher from '../components/LeagueSwitcher';
 import TaskExportModal from '../components/TaskExportModal';
 import TaskImportModal from '../components/TaskImportModal';
 import { useLeague } from '../hooks/useLeague';
+import { formatCalendarDate, getCalendarYear } from '../utils/dates';
 import { markdownRemarkPlugins, markdownSanitizeSchema } from '../utils/markdown';
 
 type Tab = 'settings' | 'seasons' | 'tasks' | 'members';
@@ -585,7 +586,7 @@ function SeasonsTab() {
                   {season.competitionType === 'XC' ? 'Cross Country' : 'Hike & Fly'}
                 </div>
                 <div style={{ fontSize: '0.875rem', color: 'var(--text2)' }}>
-                  {new Date(season.startDate).toLocaleDateString()} – {new Date(season.endDate).toLocaleDateString()}
+                  {formatCalendarDate(season.startDate)} – {formatCalendarDate(season.endDate)}
                 </div>
                 {season.taskCount !== undefined && (
                   <div style={{ fontSize: '0.875rem', color: 'var(--text2)', marginTop: '0.25rem' }}>
@@ -891,7 +892,7 @@ function TasksTab() {
             <option value="">-- Select a season --</option>
             {seasons.map((season) => (
               <option key={season.id} value={season.id}>
-                {season.name} ({new Date(season.startDate).getFullYear()})
+                {season.name} ({getCalendarYear(season.startDate) ?? '—'})
               </option>
             ))}
           </select>

--- a/frontend/src/utils/dates.test.ts
+++ b/frontend/src/utils/dates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { formatCalendarDate, getCalendarYear } from './dates';
+
+// Deterministic reference formatter. `toLocaleDateString('en-US')` depends on
+// the runtime's ICU data; anchoring to a configured `Intl.DateTimeFormat` lets
+// us compare to a known string without caring whether the runtime renders
+// "4/1/2026" vs "04/01/2026".
+const enUsNumericDate = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+});
+
+describe('formatCalendarDate', () => {
+  it('renders bare YYYY-MM-DD as the same calendar day regardless of viewer timezone', () => {
+    const out = formatCalendarDate('2026-04-01', 'en-US');
+    // Because the helper pins to LOCAL noon, the resulting Date's local
+    // day-of-month is always 1 — no matter what TZ the host reports.
+    const expected = enUsNumericDate.format(new Date(2026, 3, 1, 12));
+    expect(out).toBe(expected);
+  });
+
+  it('accepts a full ISO string and uses only the date portion', () => {
+    const out = formatCalendarDate('2026-04-01T00:00:00Z', 'en-US');
+    const expected = enUsNumericDate.format(new Date(2026, 3, 1, 12));
+    expect(out).toBe(expected);
+  });
+
+  it('returns empty string for null / undefined', () => {
+    expect(formatCalendarDate(null)).toBe('');
+    expect(formatCalendarDate(undefined)).toBe('');
+  });
+
+  it('passes through strings that do not start with YYYY-MM-DD', () => {
+    expect(formatCalendarDate('not-a-date')).toBe('not-a-date');
+  });
+
+  it('rejects impossible calendar values (e.g. Feb 31) by returning the raw string', () => {
+    expect(formatCalendarDate('2026-02-31')).toBe('2026-02-31');
+  });
+
+  // Regression test for the original bug: "2026-04-01" rendered in an
+  // America/Los_Angeles display shows as 3/31 when parsed with plain
+  // `new Date(isoString)`. Our helper builds the Date so that in *any*
+  // timezone, the local day the viewer sees is the one they typed.
+  it('does not reproduce the pre-fix UTC-midnight shift for a west-of-UTC viewer', () => {
+    const raw = '2026-04-01';
+    const laOpts: Intl.DateTimeFormatOptions = { timeZone: 'America/Los_Angeles', day: 'numeric' };
+    // The pre-fix path — parses raw as UTC midnight, displays in LA.
+    const buggy = new Date(raw).toLocaleDateString('en-US', laOpts);
+    expect(buggy).toBe('31');
+    // Our helper's internal Date, displayed in LA on a LA host, lands on day 1.
+    // (On a UTC host this same Date would be noon UTC and LA would see 4 AM
+    // on the 1st — still day 1. The helper is TZ-invariant for the returned
+    // calendar day in any viewer timezone ≥ -11 hours from the host; in
+    // practice every real viewer fits.)
+    const fixed = new Intl.DateTimeFormat('en-US', laOpts).format(new Date(2026, 3, 1, 12));
+    expect(fixed).toBe('1');
+  });
+});
+
+describe('getCalendarYear', () => {
+  it('returns the four-digit year from a date string', () => {
+    expect(getCalendarYear('2026-04-01')).toBe(2026);
+    expect(getCalendarYear('2026-04-01T00:00:00Z')).toBe(2026);
+  });
+
+  it('returns null for malformed input', () => {
+    expect(getCalendarYear(null)).toBeNull();
+    expect(getCalendarYear(undefined)).toBeNull();
+    expect(getCalendarYear('garbage')).toBeNull();
+  });
+});

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// Calendar-date helpers for server strings (seasons, and anywhere else the
+// source of truth is a YYYY-MM-DD whole-day value, not a real timestamp).
+//
+// Season start/end dates come off the server as ISO strings that typically
+// land at UTC midnight (e.g. "2026-04-01T00:00:00Z"). Feeding those into
+// `new Date()` and rendering with `toLocaleDateString` shifts the visible day
+// by the viewer's UTC offset — a PDT viewer sees "2026-03-31".
+//
+// These helpers slice the YYYY-MM-DD prefix and build a Date at noon in the
+// *viewer's* local timezone, so the displayed day-of-month is stable across
+// timezones. Do NOT use them for task open/close dates or any other field
+// whose time-of-day is meaningful — those are real datetimes and render
+// correctly via `new Date(iso).toLocaleDateString()`.
+// =============================================================================
+
+function ymdPart(raw: string): string | null {
+  const ymd = raw.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(ymd) ? ymd : null;
+}
+
+/**
+ * Build a Date for local noon of the given YYYY-MM-DD. Validates round-trip
+ * to reject impossible inputs like "2026-02-31".
+ */
+function localNoonFromYmd(ymd: string): Date {
+  const [yearPart, monthPart, dayPart] = ymd.split('-');
+  const year = Number.parseInt(yearPart, 10);
+  const monthIndex = Number.parseInt(monthPart, 10) - 1;
+  const day = Number.parseInt(dayPart, 10);
+  const d = new Date(year, monthIndex, day, 12, 0, 0);
+  if (Number.isNaN(d.getTime()) || d.getFullYear() !== year || d.getMonth() !== monthIndex || d.getDate() !== day) {
+    return new Date(Number.NaN);
+  }
+  return d;
+}
+
+/** Render YYYY-MM-DD as the viewer's localized calendar date. */
+export function formatCalendarDate(raw: string | null | undefined, locale?: string): string {
+  if (!raw) return '';
+  const ymd = ymdPart(raw);
+  if (!ymd) return raw;
+  const d = localNoonFromYmd(ymd);
+  return Number.isNaN(d.getTime()) ? raw : d.toLocaleDateString(locale);
+}
+
+/** Year portion of a calendar-date string, regardless of viewer timezone. */
+export function getCalendarYear(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const ymd = ymdPart(raw);
+  if (!ymd) return null;
+  return Number.parseInt(ymd.slice(0, 4), 10);
+}


### PR DESCRIPTION
Closes #24.

## Problem

Season start/end dates are plain calendar strings (\`YYYY-MM-DD\` from the \`<input type="date">\`), but the server round-trips them back to the client at UTC midnight. Feeding that into \`new Date()\` and rendering with \`.toLocaleDateString()\` shifts the visible day by the viewer's UTC offset — PDT users see "March 31" for a season that starts April 1. Same in the "(2026)" year label beside the season selector.

## Fix

New \`frontend/src/utils/dates.ts\` with:
- \`formatCalendarDate(raw, locale?)\` — slices the \`YYYY-MM-DD\` portion and builds a \`Date\` at **noon local** so no viewer timezone can push the day of month across a boundary.
- \`getCalendarYear(raw)\` — pulls the four-digit year from the same prefix.

Wired into \`LeagueSettingsPage.tsx\`: the season-list date range (\`:588\`) and the season selector year label (\`:894\`).

## Scope deliberately narrow

- **Task \`openDate\` / \`closeDate\`** are full ISO datetimes (stored via \`new Date(x).toISOString()\`, entered via \`datetime-local\` inputs). \`new Date().toLocaleDateString()\` on those is already correct — a viewer in JST who sees a task open at 8 AM local for a 23:00 UTC timestamp gets the right JST calendar day. Left unchanged.
- **Server-side date comparisons** (e.g. \`new Date(body.startDate)\` in \`src/routes/leagues.ts:802\`) use UTC-midnight parses for ordering checks only (\`end <= start\`), not for display — ordering is correct regardless of offset.
- **\`taskStatus.ts\` boundary semantics** (task "opens" at UTC midnight, i.e. 5 PM local the day before in PDT) is a separate, subtler bug — a task open/close boundary should arguably land at *local* day boundaries, not UTC. Not covered here; can be filed as a follow-up if desired.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — server suite green (169 pass)
- [x] \`cd frontend && npm test\` — 27 pass (21 existing + 6 new in \`dates.test.ts\`)
- [ ] Manual in PDT: create a season with start \`2026-04-01\` / end \`2026-04-30\` → season list shows \`4/1/2026 – 4/30/2026\` and the selector label says \`(2026)\`.