### PR TITLE
Rename wind rating to wing rating

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,8 +43,8 @@ function LeagueLayout() {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Redirect authenticated users to onboarding until wind rating is set
-  if (isFetched && user && user.windRating === null) {
+  // Redirect authenticated users to onboarding until wing rating is set
+  if (isFetched && user && user.wingRating === null) {
     return <Navigate to="/onboarding" replace />;
   }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -6,7 +6,7 @@ export interface User {
   displayName: string;
   avatarUrl: string | null;
   isAdmin: boolean;
-  windRating: string | null;
+  wingRating: string | null;
   gliderManufacturer: string | null;
   gliderModel: string | null;
   gliderWeightRating: number | null;
@@ -19,7 +19,7 @@ export interface MeResponse {
 export interface UpdateMeBody {
   displayName?: string;
   avatarUrl?: string | null;
-  windRating?: string | null;
+  wingRating?: string | null;
   gliderManufacturer?: string | null;
   gliderModel?: string | null;
   gliderWeightRating?: number | null;

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -5,13 +5,13 @@ import { authApi } from '../api/auth';
 import { leagueApi } from '../api/leagues';
 import { AUTH_KEY } from '../hooks/useAuth';
 
-const WIND_RATINGS = ['A', 'B', 'C', 'D', 'CCC'] as const;
+const WING_RATINGS = ['A', 'B', 'C', 'D', 'CCC'] as const;
 
 export default function OnboardingPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [windRating, setWindRating] = useState('');
+  const [wingRating, setWindRating] = useState('');
   const [gliderManufacturer, setGliderManufacturer] = useState('');
   const [gliderModel, setGliderModel] = useState('');
   const [gliderWeightRating, setGliderWeightRating] = useState<string>('');
@@ -33,7 +33,7 @@ export default function OnboardingPage() {
 
   const handleContinue = () => {
     saveMutation.mutate({
-      windRating: windRating || null,
+      wingRating: wingRating || null,
       gliderManufacturer: gliderManufacturer || null,
       gliderModel: gliderModel || null,
       gliderWeightRating: gliderWeightRating ? parseFloat(gliderWeightRating) : null,
@@ -62,25 +62,25 @@ export default function OnboardingPage() {
         </div>
 
         <div className="card" style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-          {/* Wind rating */}
+          {/* Wing rating */}
           <div>
             <label style={{ marginBottom: 8 }}>
-              Wind Rating <span style={{ color: 'var(--error)', marginLeft: 2 }}>*</span>
+              Wing Rating <span style={{ color: 'var(--error)', marginLeft: 2 }}>*</span>
             </label>
             <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-              {WIND_RATINGS.map((r) => (
+              {WING_RATINGS.map((r) => (
                 <button
                   key={r}
                   type="button"
-                  onClick={() => setWindRating(windRating === r ? '' : r)}
+                  onClick={() => setWindRating(wingRating === r ? '' : r)}
                   style={{
                     padding: '0.375rem 0.875rem',
                     borderRadius: '0.375rem',
-                    border: `1px solid ${windRating === r ? 'var(--accent)' : 'var(--border)'}`,
-                    background: windRating === r ? 'var(--accent)' : 'var(--bg)',
-                    color: windRating === r ? '#fff' : 'var(--text2)',
+                    border: `1px solid ${wingRating === r ? 'var(--accent)' : 'var(--border)'}`,
+                    background: wingRating === r ? 'var(--accent)' : 'var(--bg)',
+                    color: wingRating === r ? '#fff' : 'var(--text2)',
                     fontSize: '0.875rem',
-                    fontWeight: windRating === r ? 600 : 400,
+                    fontWeight: wingRating === r ? 600 : 400,
                     cursor: 'pointer',
                     transition: 'all 0.15s ease',
                   }}
@@ -130,13 +130,13 @@ export default function OnboardingPage() {
             <button
               className="btn btn-primary"
               onClick={handleContinue}
-              disabled={!windRating || saveMutation.isPending}
+              disabled={!wingRating || saveMutation.isPending}
               style={{ minWidth: 120 }}
             >
               {saveMutation.isPending ? 'Saving…' : 'Get Started'}
             </button>
-            {!windRating && (
-              <span style={{ fontSize: 13, color: 'var(--text3)' }}>Select a wind rating to continue</span>
+            {!wingRating && (
+              <span style={{ fontSize: 13, color: 'var(--text3)' }}>Select a wing rating to continue</span>
             )}
             {saveMutation.isError && (
               <span style={{ fontSize: 13, color: 'var(--error)' }}>Failed to save — please try again</span>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -13,14 +13,14 @@ function initials(name: string) {
     .toUpperCase();
 }
 
-const WIND_RATINGS = ['A', 'B', 'C', 'D', 'CCC'] as const;
+const WING_RATINGS = ['A', 'B', 'C', 'D', 'CCC'] as const;
 
 export default function ProfilePage() {
   const { user, logout, login } = useAuth();
   const { data: standingsData } = useStandings();
   const queryClient = useQueryClient();
 
-  const [windRating, setWindRating] = useState('');
+  const [wingRating, setWindRating] = useState('');
   const [gliderManufacturer, setGliderManufacturer] = useState('');
   const [gliderModel, setGliderModel] = useState('');
   const [gliderWeightRating, setGliderWeightRating] = useState<string>('');
@@ -30,7 +30,7 @@ export default function ProfilePage() {
   useEffect(() => {
     if (user && !initialized.current) {
       initialized.current = true;
-      setWindRating(user.windRating ?? '');
+      setWindRating(user.wingRating ?? '');
       setGliderManufacturer(user.gliderManufacturer ?? '');
       setGliderModel(user.gliderModel ?? '');
       setGliderWeightRating(user.gliderWeightRating != null ? String(user.gliderWeightRating) : '');
@@ -44,7 +44,7 @@ export default function ProfilePage() {
 
   const saveEquipment = () => {
     updateMutation.mutate({
-      windRating: windRating || null,
+      wingRating: wingRating || null,
       gliderManufacturer: gliderManufacturer || null,
       gliderModel: gliderModel || null,
       gliderWeightRating: gliderWeightRating ? parseFloat(gliderWeightRating) : null,
@@ -53,7 +53,7 @@ export default function ProfilePage() {
 
   const savedWeight = user?.gliderWeightRating != null ? String(user.gliderWeightRating) : '';
   const equipmentDirty =
-    (user?.windRating ?? '') !== windRating ||
+    (user?.wingRating ?? '') !== wingRating ||
     (user?.gliderManufacturer ?? '') !== gliderManufacturer ||
     (user?.gliderModel ?? '') !== gliderModel ||
     savedWeight !== gliderWeightRating;
@@ -142,23 +142,23 @@ export default function ProfilePage() {
         </div>
         <div className="card" style={{ marginBottom: 24 }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            {/* Wind rating */}
+            {/* Wing rating */}
             <div>
-              <label style={{ marginBottom: 8 }}>Wind Rating</label>
+              <label style={{ marginBottom: 8 }}>Wing Rating</label>
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                {WIND_RATINGS.map((r) => (
+                {WING_RATINGS.map((r) => (
                   <button
                     key={r}
                     type="button"
-                    onClick={() => setWindRating(windRating === r ? '' : r)}
+                    onClick={() => setWindRating(wingRating === r ? '' : r)}
                     style={{
                       padding: '0.375rem 0.875rem',
                       borderRadius: '0.375rem',
-                      border: `1px solid ${windRating === r ? 'var(--accent)' : 'var(--border)'}`,
-                      background: windRating === r ? 'var(--accent)' : 'var(--bg)',
-                      color: windRating === r ? '#fff' : 'var(--text2)',
+                      border: `1px solid ${wingRating === r ? 'var(--accent)' : 'var(--border)'}`,
+                      background: wingRating === r ? 'var(--accent)' : 'var(--bg)',
+                      color: wingRating === r ? '#fff' : 'var(--text2)',
                       fontSize: '0.875rem',
-                      fontWeight: windRating === r ? 600 : 400,
+                      fontWeight: wingRating === r ? 600 : 400,
                       cursor: 'pointer',
                       transition: 'all 0.15s ease',
                     }}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -730,7 +730,7 @@ export async function handleGetMe(request: any, reply: any, db: any): Promise<vo
   const user = db
     .prepare(
       `SELECT id, email, display_name as displayName, avatar_url as avatarUrl, is_super_admin as isAdmin,
-            wind_rating as windRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
+            wing_rating as wingRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
             glider_weight_rating as gliderWeightRating
      FROM users WHERE id = ?`,
     )
@@ -754,13 +754,13 @@ export async function handleUpdateMe(request: any, reply: any, db: any): Promise
   const body = request.body as {
     displayName?: string;
     avatarUrl?: string | null;
-    windRating?: string | null;
+    wingRating?: string | null;
     gliderManufacturer?: string | null;
     gliderModel?: string | null;
     gliderWeightRating?: number | null;
   };
 
-  const VALID_WIND_RATINGS = new Set(['A', 'B', 'C', 'D', 'CCC']);
+  const VALID_WING_RATINGS = new Set(['A', 'B', 'C', 'D', 'CCC']);
 
   // Only update provided fields
   if (body.displayName !== undefined) {
@@ -775,13 +775,13 @@ export async function handleUpdateMe(request: any, reply: any, db: any): Promise
       request.user!.userId,
     );
   }
-  if (body.windRating !== undefined) {
-    if (body.windRating !== null && !VALID_WIND_RATINGS.has(body.windRating)) {
-      reply.status(400).send({ error: 'Invalid wind rating. Must be A, B, C, D, or CCC.' });
+  if (body.wingRating !== undefined) {
+    if (body.wingRating !== null && !VALID_WING_RATINGS.has(body.wingRating)) {
+      reply.status(400).send({ error: 'Invalid wing rating. Must be A, B, C, D, or CCC.' });
       return;
     }
-    db.prepare(`UPDATE users SET wind_rating = ?, updated_at = datetime('now') WHERE id = ?`).run(
-      body.windRating,
+    db.prepare(`UPDATE users SET wing_rating = ?, updated_at = datetime('now') WHERE id = ?`).run(
+      body.wingRating,
       request.user!.userId,
     );
   }
@@ -814,7 +814,7 @@ export async function handleUpdateMe(request: any, reply: any, db: any): Promise
   const user = db
     .prepare(
       `SELECT id, email, display_name as displayName, avatar_url as avatarUrl, is_super_admin as isAdmin,
-            wind_rating as windRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
+            wing_rating as wingRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
             glider_weight_rating as gliderWeightRating
      FROM users WHERE id = ?`,
     )

--- a/src/migrations/0012_rename_wind_rating_to_wing_rating.sql
+++ b/src/migrations/0012_rename_wind_rating_to_wing_rating.sql
@@ -1,0 +1,3 @@
+-- Rename wind_rating to wing_rating (the EN A/B/C/D/CCC column is a paraglider
+-- wing certification, not a wind rating — the original name was a typo).
+ALTER TABLE users RENAME COLUMN wind_rating TO wing_rating;


### PR DESCRIPTION
## Summary
- The EN A/B/C/D/CCC field on pilot profiles is a paraglider **wing** certification, not a wind rating — the original naming was a typo.
- Renames user-visible labels ("Wind Rating" → "Wing Rating") on the onboarding and profile forms.
- Renames identifiers for consistency: DB column (`wind_rating` → `wing_rating` via new migration `0012`), backend TS types/SQL, frontend React state (`windRating` → `wingRating`), and the `WIND_RATINGS` constant.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 169 tests pass
- [ ] After deploy: verify migration runs cleanly and existing pilots' ratings are preserved
- [ ] Sign-up / onboarding form shows "Wing Rating"
- [ ] Profile page shows "Wing Rating" and saves correctly