### PR TITLE
Address Copilot follow-ups from wing-rating rename

### DIFF
--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -11,7 +11,7 @@ export default function OnboardingPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [wingRating, setWindRating] = useState('');
+  const [wingRating, setWingRating] = useState('');
   const [gliderManufacturer, setGliderManufacturer] = useState('');
   const [gliderModel, setGliderModel] = useState('');
   const [gliderWeightRating, setGliderWeightRating] = useState<string>('');
@@ -72,7 +72,7 @@ export default function OnboardingPage() {
                 <button
                   key={r}
                   type="button"
-                  onClick={() => setWindRating(wingRating === r ? '' : r)}
+                  onClick={() => setWingRating(wingRating === r ? '' : r)}
                   style={{
                     padding: '0.375rem 0.875rem',
                     borderRadius: '0.375rem',

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -20,7 +20,7 @@ export default function ProfilePage() {
   const { data: standingsData } = useStandings();
   const queryClient = useQueryClient();
 
-  const [wingRating, setWindRating] = useState('');
+  const [wingRating, setWingRating] = useState('');
   const [gliderManufacturer, setGliderManufacturer] = useState('');
   const [gliderModel, setGliderModel] = useState('');
   const [gliderWeightRating, setGliderWeightRating] = useState<string>('');
@@ -30,7 +30,7 @@ export default function ProfilePage() {
   useEffect(() => {
     if (user && !initialized.current) {
       initialized.current = true;
-      setWindRating(user.wingRating ?? '');
+      setWingRating(user.wingRating ?? '');
       setGliderManufacturer(user.gliderManufacturer ?? '');
       setGliderModel(user.gliderModel ?? '');
       setGliderWeightRating(user.gliderWeightRating != null ? String(user.gliderWeightRating) : '');
@@ -150,7 +150,7 @@ export default function ProfilePage() {
                   <button
                     key={r}
                     type="button"
-                    onClick={() => setWindRating(wingRating === r ? '' : r)}
+                    onClick={() => setWingRating(wingRating === r ? '' : r)}
                     style={{
                       padding: '0.375rem 0.875rem',
                       borderRadius: '0.375rem',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -719,6 +719,43 @@ export async function handleGoogleAuthCallback(
   }
 }
 
+interface MeRow {
+  id: string;
+  email: string;
+  displayName: string;
+  avatarUrl: string | null;
+  isAdmin: number;
+  wingRating: string | null;
+  gliderManufacturer: string | null;
+  gliderModel: string | null;
+  gliderWeightRating: number | null;
+}
+
+interface MeResponse {
+  id: string;
+  email: string;
+  displayName: string;
+  avatarUrl: string | null;
+  isAdmin: boolean;
+  wingRating: string | null;
+  gliderManufacturer: string | null;
+  gliderModel: string | null;
+  gliderWeightRating: number | null;
+}
+
+function selectMe(db: any, userId: string): MeResponse | null {
+  const row = db
+    .prepare(
+      `SELECT id, email, display_name as displayName, avatar_url as avatarUrl, is_super_admin as isAdmin,
+            wing_rating as wingRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
+            glider_weight_rating as gliderWeightRating
+     FROM users WHERE id = ?`,
+    )
+    .get(userId) as MeRow | undefined;
+  if (!row) return null;
+  return { ...row, isAdmin: Boolean(row.isAdmin) };
+}
+
 /**
  * GET /auth/me
  *
@@ -727,20 +764,12 @@ export async function handleGoogleAuthCallback(
  */
 export async function handleGetMe(request: any, reply: any, db: any): Promise<void> {
   requireAuth(request, reply);
-  const user = db
-    .prepare(
-      `SELECT id, email, display_name as displayName, avatar_url as avatarUrl, is_super_admin as isAdmin,
-            wing_rating as wingRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
-            glider_weight_rating as gliderWeightRating
-     FROM users WHERE id = ?`,
-    )
-    .get(request.user!.userId) as UserRecord | undefined;
-
+  const user = selectMe(db, request.user!.userId);
   if (!user) {
     reply.status(404).send({ error: 'User not found' });
     return;
   }
-  reply.send({ user: { ...user, isAdmin: Boolean((user as any).isAdmin) } });
+  reply.send({ user });
 }
 
 /**
@@ -811,16 +840,12 @@ export async function handleUpdateMe(request: any, reply: any, db: any): Promise
     );
   }
 
-  const user = db
-    .prepare(
-      `SELECT id, email, display_name as displayName, avatar_url as avatarUrl, is_super_admin as isAdmin,
-            wing_rating as wingRating, glider_manufacturer as gliderManufacturer, glider_model as gliderModel,
-            glider_weight_rating as gliderWeightRating
-     FROM users WHERE id = ?`,
-    )
-    .get(request.user!.userId) as UserRecord | undefined;
-
-  reply.send({ user: user ? { ...user, isAdmin: Boolean((user as any).isAdmin) } : user });
+  const user = selectMe(db, request.user!.userId);
+  if (!user) {
+    reply.status(404).send({ error: 'User not found' });
+    return;
+  }
+  reply.send({ user });
 }
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -820,7 +820,7 @@ export async function handleUpdateMe(request: any, reply: any, db: any): Promise
     )
     .get(request.user!.userId) as UserRecord | undefined;
 
-  reply.send({ user });
+  reply.send({ user: user ? { ...user, isAdmin: Boolean((user as any).isAdmin) } : user });
 }
 
 /**


### PR DESCRIPTION
Follow-ups from Copilot's review on #28.

## Summary
- Rename `setWindRating` → `setWingRating` in `OnboardingPage.tsx` and `ProfilePage.tsx`. The earlier `replace_all("windRating" → "wingRating")` was case-sensitive and missed `WindRating` inside the setter name.
- Coerce `isAdmin` to boolean in `handleUpdateMe`'s response, matching `handleGetMe`. SQLite returns `0`/`1` for the `is_super_admin` column, and the frontend `User` type expects `boolean` — without this, a PATCH returns a numeric `isAdmin` that violates the type contract.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 169 tests pass
- [ ] Edit profile equipment → `useAuth` cache still has `isAdmin` as a proper boolean (no admin-gated UI regressions)