### PR TITLE
Emit .xctsk downloads as v1 JSON instead of XML

### DIFF
--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1993,8 +1993,12 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       let filename: string;
 
       if (format === 'xctsk') {
-        fileContent =
-          taskRow.dataSource === 'xctsk' && taskRow.rawContent ? taskRow.rawContent : exportXctsk(exportTask);
+        // Pass through stored rawContent only when it's already v1 JSON.
+        // Tasks imported from the legacy XML form have rawContent starting
+        // with `<` — modern XCTrack/FlySkyHy fail to parse XML, so re-export
+        // those from the DB to v1 JSON.
+        const stored = taskRow.dataSource === 'xctsk' ? taskRow.rawContent?.trimStart() : null;
+        fileContent = stored?.startsWith('{') ? stored : exportXctsk(exportTask);
         contentType = 'application/octet-stream';
         filename = `${taskRow.name.replace(/[^a-z0-9]/gi, '_')}.xctsk`;
       } else {

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1996,10 +1996,9 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         // Pass through stored rawContent only when it's already v1 JSON.
         // Tasks imported from the legacy XML form have rawContent starting
         // with `<` — modern XCTrack/FlySkyHy fail to parse XML, so re-export
-        // those from the DB to v1 JSON. Detect on a trimmed copy but return
-        // the original so any leading whitespace is preserved.
-        const stored = taskRow.dataSource === 'xctsk' ? taskRow.rawContent : null;
-        fileContent = stored?.trimStart().startsWith('{') ? stored : exportXctsk(exportTask);
+        // those from the DB to v1 JSON.
+        const stored = taskRow.dataSource === 'xctsk' ? taskRow.rawContent?.trimStart() : null;
+        fileContent = stored?.startsWith('{') ? stored : exportXctsk(exportTask);
         contentType = 'application/octet-stream';
         filename = `${taskRow.name.replace(/[^a-z0-9]/gi, '_')}.xctsk`;
       } else {

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1996,9 +1996,10 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         // Pass through stored rawContent only when it's already v1 JSON.
         // Tasks imported from the legacy XML form have rawContent starting
         // with `<` — modern XCTrack/FlySkyHy fail to parse XML, so re-export
-        // those from the DB to v1 JSON.
-        const stored = taskRow.dataSource === 'xctsk' ? taskRow.rawContent?.trimStart() : null;
-        fileContent = stored?.startsWith('{') ? stored : exportXctsk(exportTask);
+        // those from the DB to v1 JSON. Detect on a trimmed copy but return
+        // the original so any leading whitespace is preserved.
+        const stored = taskRow.dataSource === 'xctsk' ? taskRow.rawContent : null;
+        fileContent = stored?.trimStart().startsWith('{') ? stored : exportXctsk(exportTask);
         contentType = 'application/octet-stream';
         filename = `${taskRow.name.replace(/[^a-z0-9]/gi, '_')}.xctsk`;
       } else {

--- a/src/task-exporters.test.ts
+++ b/src/task-exporters.test.ts
@@ -1,0 +1,115 @@
+// =============================================================================
+// task-exporters.test.ts — unit tests for exportXctsk (v1 JSON file format)
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import { parseXctsk } from './task-parsers';
+import { type ExportTask, exportXctsk } from './task-exporters';
+
+const baseTask: ExportTask = {
+  id: 'task-1',
+  name: 'Test Task',
+  taskType: 'RACE_TO_GOAL',
+  turnpoints: [
+    { name: 'TLK-6K', latitude: 47.5114, longitude: -121.991, radius_m: 400, type: 'SSS', sequenceIndex: 0 },
+    { name: 'GRN-6K', latitude: 47.5478, longitude: -121.9834, radius_m: 400, type: 'CYLINDER', sequenceIndex: 1 },
+    { name: 'SQT-5K', latitude: 47.5043, longitude: -122.0475, radius_m: 1000, type: 'ESS', sequenceIndex: 2 },
+    { name: 'TLZ-5K', latitude: 47.5008, longitude: -122.0219, radius_m: 400, type: 'GOAL_CYLINDER', sequenceIndex: 3 },
+  ],
+};
+
+describe('exportXctsk — v1 JSON', () => {
+  it('emits valid JSON (not XML)', () => {
+    const out = exportXctsk(baseTask);
+    expect(out.trimStart().startsWith('{')).toBe(true);
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it('includes required top-level fields', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    expect(json.taskType).toBe('CLASSIC');
+    expect(json.version).toBe(1);
+    expect(json.earthModel).toBe('WGS84');
+    expect(Array.isArray(json.turnpoints)).toBe(true);
+    expect(json.turnpoints).toHaveLength(4);
+  });
+
+  it('emits top-level keys in spec order (FlySkyHy compatibility)', () => {
+    const out = exportXctsk(baseTask);
+    const order = Object.keys(JSON.parse(out));
+    // spec: taskType, version, earthModel, turnpoints, [goal]
+    expect(order).toEqual(['taskType', 'version', 'earthModel', 'turnpoints', 'goal']);
+  });
+
+  it('preserves coordinates as decimal degrees', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    const wp = json.turnpoints[0].waypoint;
+    expect(wp.lat).toBeCloseTo(47.5114, 4);
+    expect(wp.lon).toBeCloseTo(-121.991, 4);
+  });
+
+  it('marks SSS and ESS turnpoints with type tag', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    expect(json.turnpoints[0].type).toBe('SSS');
+    expect(json.turnpoints[2].type).toBe('ESS');
+  });
+
+  it('omits type tag for cylinder and goal turnpoints', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    expect(json.turnpoints[1]).not.toHaveProperty('type');
+    expect(json.turnpoints[3]).not.toHaveProperty('type');
+  });
+
+  it('puts type before radius in turnpoint object (spec order)', () => {
+    const out = exportXctsk(baseTask);
+    const sss = JSON.parse(out).turnpoints[0];
+    expect(Object.keys(sss)).toEqual(['type', 'radius', 'waypoint']);
+  });
+
+  it('encodes goal as top-level goal.type=CYLINDER for cylinder goal', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    expect(json.goal).toEqual({ type: 'CYLINDER' });
+  });
+
+  it('encodes goal as top-level goal.type=LINE for line goal', () => {
+    const lineTask: ExportTask = {
+      ...baseTask,
+      turnpoints: baseTask.turnpoints.map((tp, i) =>
+        i === baseTask.turnpoints.length - 1 ? { ...tp, type: 'GOAL_LINE' } : tp,
+      ),
+    };
+    const json = JSON.parse(exportXctsk(lineTask));
+    expect(json.goal).toEqual({ type: 'LINE' });
+  });
+
+  it('omits goal field when no goal turnpoint exists', () => {
+    const noGoal: ExportTask = {
+      ...baseTask,
+      turnpoints: baseTask.turnpoints.slice(0, 3), // SSS + cylinder + ESS, no goal
+    };
+    const json = JSON.parse(exportXctsk(noGoal));
+    expect(json.goal).toBeUndefined();
+  });
+
+  it('round-trips through parseXctsk', () => {
+    const parsed = parseXctsk(exportXctsk(baseTask));
+    expect(parsed.format).toBe('xctsk');
+    expect(parsed.taskType).toBe('RACE_TO_GOAL');
+    expect(parsed.turnpoints).toHaveLength(4);
+    expect(parsed.turnpoints[0].type).toBe('SSS');
+    expect(parsed.turnpoints[0].name).toBe('TLK-6K');
+    expect(parsed.turnpoints[0].latitude).toBeCloseTo(47.5114, 4);
+    expect(parsed.turnpoints[2].type).toBe('ESS');
+    expect(parsed.turnpoints[3].type).toBe('GOAL_CYLINDER');
+    expect(parsed.turnpoints[3].radius_m).toBe(400);
+  });
+
+  it('respects sequenceIndex ordering', () => {
+    const shuffled: ExportTask = {
+      ...baseTask,
+      turnpoints: [...baseTask.turnpoints].reverse(),
+    };
+    const json = JSON.parse(exportXctsk(shuffled));
+    expect(json.turnpoints.map((tp: any) => tp.waypoint.name)).toEqual(['TLK-6K', 'GRN-6K', 'SQT-5K', 'TLZ-5K']);
+  });
+});

--- a/src/task-exporters.test.ts
+++ b/src/task-exporters.test.ts
@@ -104,6 +104,23 @@ describe('exportXctsk — v1 JSON', () => {
     expect(parsed.turnpoints[3].radius_m).toBe(400);
   });
 
+  it('round-trips a line-goal task (preserves GOAL_LINE)', () => {
+    const lineTask: ExportTask = {
+      ...baseTask,
+      turnpoints: baseTask.turnpoints.map((tp, i) =>
+        i === baseTask.turnpoints.length - 1 ? { ...tp, type: 'GOAL_LINE' } : tp,
+      ),
+    };
+    const parsed = parseXctsk(exportXctsk(lineTask));
+    expect(parsed.turnpoints[parsed.turnpoints.length - 1].type).toBe('GOAL_LINE');
+  });
+
+  it('emits CLASSIC even for OPEN_DISTANCE tasks (spec only documents CLASSIC)', () => {
+    const openTask: ExportTask = { ...baseTask, taskType: 'OPEN_DISTANCE' };
+    const json = JSON.parse(exportXctsk(openTask));
+    expect(json.taskType).toBe('CLASSIC');
+  });
+
   it('respects sequenceIndex ordering', () => {
     const shuffled: ExportTask = {
       ...baseTask,

--- a/src/task-exporters.test.ts
+++ b/src/task-exporters.test.ts
@@ -3,8 +3,8 @@
 // =============================================================================
 
 import { describe, expect, it } from 'vitest';
-import { parseXctsk } from './task-parsers';
 import { type ExportTask, exportXctsk } from './task-exporters';
+import { parseXctsk } from './task-parsers';
 
 const baseTask: ExportTask = {
   id: 'task-1',

--- a/src/task-exporters.test.ts
+++ b/src/task-exporters.test.ts
@@ -48,10 +48,14 @@ describe('exportXctsk — v1 JSON', () => {
     expect(wp.lon).toBeCloseTo(-121.991, 4);
   });
 
-  it('marks SSS and ESS turnpoints with type tag', () => {
+  it('marks ESS turnpoints with type tag', () => {
     const json = JSON.parse(exportXctsk(baseTask));
-    expect(json.turnpoints[0].type).toBe('SSS');
     expect(json.turnpoints[2].type).toBe('ESS');
+  });
+
+  it('leaves SSS implicit (XCTrack/parser treat first TP as start)', () => {
+    const json = JSON.parse(exportXctsk(baseTask));
+    expect(json.turnpoints[0]).not.toHaveProperty('type');
   });
 
   it('omits type tag for cylinder and goal turnpoints', () => {
@@ -62,8 +66,8 @@ describe('exportXctsk — v1 JSON', () => {
 
   it('puts type before radius in turnpoint object (spec order)', () => {
     const out = exportXctsk(baseTask);
-    const sss = JSON.parse(out).turnpoints[0];
-    expect(Object.keys(sss)).toEqual(['type', 'radius', 'waypoint']);
+    const ess = JSON.parse(out).turnpoints[2];
+    expect(Object.keys(ess)).toEqual(['type', 'radius', 'waypoint']);
   });
 
   it('encodes goal as top-level goal.type=CYLINDER for cylinder goal', () => {

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -28,58 +28,76 @@ export interface ExportTask {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// .xctsk export (XCTrack XML)
+// .xctsk export (XCTrack v1 JSON)
+//
+// Spec: https://xctrack.org/Competition_Interfaces.html — "Task definition format"
+//
+// Modern XCTrack (and FlySkyHy) parse .xctsk files as JSON. The XML form is
+// legacy and is rejected by current XCTrack with a Gson MalformedJsonException.
+// QR codes use a separate v2 polyline format — see buildXctrackDeepLink.
+//
+// FlySkyHy is sensitive to top-level key order (see xctrack-public#928), so we
+// emit keys in the order documented by the spec: taskType, version, earthModel,
+// turnpoints, goal.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Format decimal degrees × 10^7 for xctsk (some apps require integer form) */
-function toXctskCoord(deg: number): number {
-  return Math.round(deg * 1e7);
+interface XctskV1Waypoint {
+  name: string;
+  description: string;
+  lat: number;
+  lon: number;
+  altSmoothed: number;
+}
+
+interface XctskV1Turnpoint {
+  type?: 'SSS' | 'ESS';
+  radius: number;
+  waypoint: XctskV1Waypoint;
+}
+
+interface XctskV1File {
+  taskType: 'CLASSIC';
+  version: 1;
+  earthModel: 'WGS84';
+  turnpoints: XctskV1Turnpoint[];
+  goal?: { type: 'CYLINDER' | 'LINE' };
 }
 
 export function exportXctsk(task: ExportTask): string {
   const tps = [...task.turnpoints].sort((a, b) => a.sequenceIndex - b.sequenceIndex);
 
-  const sssIdx = tps.findIndex((t) => t.type === 'SSS');
-  const essIdx = tps.findIndex((t) => t.type === 'ESS');
-  const goalIdx = tps.findIndex((t) => t.type === 'GOAL_CYLINDER' || t.type === 'GOAL_LINE');
+  const turnpoints: XctskV1Turnpoint[] = tps.map((tp) => {
+    const tpOut: XctskV1Turnpoint = {
+      radius: Math.round(tp.radius_m),
+      waypoint: {
+        name: tp.name,
+        description: tp.name,
+        lat: tp.latitude,
+        lon: tp.longitude,
+        altSmoothed: 0,
+      },
+    };
+    // Spec puts `type` before `radius`; insert it via a fresh object so JSON
+    // key order matches the documented order.
+    if (tp.type === 'SSS' || tp.type === 'ESS') {
+      return { type: tp.type, ...tpOut };
+    }
+    return tpOut;
+  });
 
-  const turnpointsXml = tps
-    .map((tp, i) => {
-      const ozType = tp.type === 'GOAL_LINE' ? 'line' : 'cylinder';
-      return [
-        `    <turnpoint index="${i}">`,
-        `      <waypoint name="${escapeXml(tp.name)}" lat="${toXctskCoord(tp.latitude)}" lon="${toXctskCoord(tp.longitude)}" />`,
-        `      <observation-zone type="${ozType}" radius="${Math.round(tp.radius_m)}" />`,
-        `    </turnpoint>`,
-      ].join('\n');
-    })
-    .join('\n');
+  const out: XctskV1File = {
+    taskType: 'CLASSIC',
+    version: 1,
+    earthModel: 'WGS84',
+    turnpoints,
+  };
 
-  const sssTag = sssIdx >= 0 ? `  <sss index="${sssIdx}" />` : '';
-  const essTag = essIdx >= 0 ? `  <ess index="${essIdx}" />` : '';
-  const goalTag = goalIdx >= 0 ? `  <goal index="${goalIdx}" />` : '';
+  const goalTp = tps.find((tp) => tp.type === 'GOAL_LINE' || tp.type === 'GOAL_CYLINDER');
+  if (goalTp) {
+    out.goal = { type: goalTp.type === 'GOAL_LINE' ? 'LINE' : 'CYLINDER' };
+  }
 
-  const typeAttr = task.taskType === 'OPEN_DISTANCE' ? 'OPEN_DISTANCE' : 'RACE_TO_GOAL';
-
-  return [
-    `<?xml version="1.0" encoding="utf-8"?>`,
-    `<xctrack>`,
-    `  <task type="${typeAttr}" version="1">`,
-    `    <turnpoints>`,
-    turnpointsXml,
-    `    </turnpoints>`,
-    sssTag,
-    essTag,
-    goalTag,
-    `  </task>`,
-    `</xctrack>`,
-  ]
-    .filter(Boolean)
-    .join('\n');
-}
-
-function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  return JSON.stringify(out);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -2,7 +2,7 @@
 // Task Exporters
 //
 // Produces task file content in formats understood by popular paragliding apps:
-//   • .xctsk  — XCTrack XML (also used by Paragliding Earth and others)
+//   • .xctsk  — XCTrack v1 JSON (also read by FlySkyHy)
 //   • .cup    — SeeYou waypoint + task CSV
 //
 // Also generates deep-link URLs for the QR code utility:

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -85,6 +85,10 @@ export function exportXctsk(task: ExportTask): string {
     return tpOut;
   });
 
+  // The XCTrack v1 spec documents only `CLASSIC` as a task type — the file
+  // format is just an ordered list of turnpoints. League-level distinctions
+  // like RACE_TO_GOAL vs OPEN_DISTANCE don't have a wire representation here,
+  // so emit CLASSIC unconditionally for maximum interop with XCTrack/FlySkyHy.
   const out: XctskV1File = {
     taskType: 'CLASSIC',
     version: 1,

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -208,7 +208,10 @@ export function buildXctrackDeepLink(task: ExportTask): string {
     e: 0, // WGS84
   };
 
-  if (tps.some((tp) => tp.type === 'GOAL_LINE')) {
+  // Match the file/v1 path: pick the terminal goal TP rather than any match,
+  // so a malformed task with multiple goal-typed TPs still picks the last one.
+  const goalTp = [...tps].reverse().find((tp) => tp.type === 'GOAL_LINE' || tp.type === 'GOAL_CYLINDER');
+  if (goalTp?.type === 'GOAL_LINE') {
     qrTask['g'] = { t: 'LINE' };
   }
 

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -77,10 +77,16 @@ export function exportXctsk(task: ExportTask): string {
         altSmoothed: 0,
       },
     };
-    // Spec puts `type` before `radius`; insert it via a fresh object so JSON
+    // SSS is left implicit (XCTrack and our parser both treat the first
+    // turnpoint as the start). Emitting an explicit `type: 'SSS'` has caused
+    // problems in XCTrack when no start time is set, and would also conflict
+    // with our parser's "first untyped TP = SSS" inference (creating a
+    // duplicate start on round-trip). ESS stays explicit.
+    //
+    // Spec puts `type` before `radius`; insert via a fresh object so JSON
     // key order matches the documented order.
-    if (tp.type === 'SSS' || tp.type === 'ESS') {
-      return { type: tp.type, ...tpOut };
+    if (tp.type === 'ESS') {
+      return { type: 'ESS', ...tpOut };
     }
     return tpOut;
   });

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -96,7 +96,10 @@ export function exportXctsk(task: ExportTask): string {
     turnpoints,
   };
 
-  const goalTp = tps.find((tp) => tp.type === 'GOAL_LINE' || tp.type === 'GOAL_CYLINDER');
+  // Goal is the last turnpoint by convention (matches computeGoalLineBearing
+  // and the rest of the pipeline). Search from the end so malformed data with
+  // multiple goal-typed TPs still picks the terminal one.
+  const goalTp = [...tps].reverse().find((tp) => tp.type === 'GOAL_LINE' || tp.type === 'GOAL_CYLINDER');
   if (goalTp) {
     out.goal = { type: goalTp.type === 'GOAL_LINE' ? 'LINE' : 'CYLINDER' };
   }

--- a/src/task-parsers.ts
+++ b/src/task-parsers.ts
@@ -101,11 +101,13 @@ function parseXctskJson(content: string): ParsedTask {
 
   // In the JSON format, only ESS (and sometimes SSS) are explicitly typed.
   // The convention is:
-  //   - first TP without a type tag  = SSS (start)
-  //   - last  TP without a type tag  = Goal
-  //   - any TP with type === 'ESS'   = ESS
   //   - any TP with type === 'SSS'   = SSS (explicit override)
-  // Find first and last untyped indices so we can assign SSS / Goal:
+  //   - any TP with type === 'ESS'   = ESS
+  //   - first TP without a type tag  = SSS (only if no explicit SSS exists)
+  //   - last  TP without a type tag  = Goal
+  // We skip implicit-SSS assignment when the file has an explicit SSS to
+  // avoid creating a duplicate start.
+  const hasExplicitSss = tps.some((tp) => tp.type?.toUpperCase() === 'SSS');
   const firstUntyped = tps.findIndex((tp) => !tp.type);
   const lastUntyped = tps.length - 1 - [...tps].reverse().findIndex((tp) => !tp.type);
 
@@ -125,7 +127,7 @@ function parseXctskJson(content: string): ParsedTask {
     } else if (rawType === 'ESS') {
       type = 'ESS';
     } else if (!tp.type) {
-      if (idx === firstUntyped) type = 'SSS';
+      if (idx === firstUntyped && !hasExplicitSss) type = 'SSS';
       else if (idx === lastUntyped && lastUntyped !== firstUntyped) type = 'GOAL_CYLINDER';
     }
 

--- a/src/task-parsers.ts
+++ b/src/task-parsers.ts
@@ -83,6 +83,7 @@ interface XctskJsonV1 {
   version: number;
   taskType?: string; // 'CLASSIC' | 'FREE_FLIGHT' | 'OPEN_DISTANCE' | …
   turnpoints: XctskJsonTurnpoint[];
+  goal?: { type?: string }; // 'CYLINDER' | 'LINE'
 }
 
 function parseXctskJson(content: string): ParsedTask {
@@ -143,6 +144,14 @@ function parseXctskJson(content: string): ParsedTask {
   const hasGoal = turnpoints.some((tp) => tp.type === 'GOAL_CYLINDER' || tp.type === 'GOAL_LINE');
   if (!hasGoal && turnpoints.length > 1) {
     turnpoints[turnpoints.length - 1].type = 'GOAL_CYLINDER';
+  }
+
+  // Goal-line vs cylinder is encoded at the top level (`goal.type`), not on
+  // the turnpoint itself. Promote a cylinder goal to GOAL_LINE if the file
+  // says so.
+  if (raw.goal?.type?.toUpperCase() === 'LINE') {
+    const goalIdx = turnpoints.findIndex((tp) => tp.type === 'GOAL_CYLINDER');
+    if (goalIdx >= 0) turnpoints[goalIdx].type = 'GOAL_LINE';
   }
 
   return { taskType, turnpoints, rawContent: content, format: 'xctsk' };

--- a/src/task-parsers.ts
+++ b/src/task-parsers.ts
@@ -147,11 +147,15 @@ function parseXctskJson(content: string): ParsedTask {
   }
 
   // Goal-line vs cylinder is encoded at the top level (`goal.type`), not on
-  // the turnpoint itself. Promote a cylinder goal to GOAL_LINE if the file
-  // says so.
+  // the turnpoint itself. Promote the *last* cylinder goal to GOAL_LINE if
+  // the file says so — by convention the goal is the terminal turnpoint.
   if (raw.goal?.type?.toUpperCase() === 'LINE') {
-    const goalIdx = turnpoints.findIndex((tp) => tp.type === 'GOAL_CYLINDER');
-    if (goalIdx >= 0) turnpoints[goalIdx].type = 'GOAL_LINE';
+    for (let i = turnpoints.length - 1; i >= 0; i--) {
+      if (turnpoints[i].type === 'GOAL_CYLINDER') {
+        turnpoints[i].type = 'GOAL_LINE';
+        break;
+      }
+    }
   }
 
   return { taskType, turnpoints, rawContent: content, format: 'xctsk' };

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -1096,6 +1096,66 @@ describe('Task QR endpoint — GET /leagues/:slug/seasons/:seasonId/tasks/:taskI
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// .xctsk download endpoint — JSON output regression tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task download — GET /tasks/:taskId/download?format=xctsk', () => {
+  let app: ReturnType<typeof Fastify>;
+  let db: ReturnType<typeof getTestDb>;
+  let pilotUser: ReturnType<typeof createTestUser>;
+  let testLeague: ReturnType<typeof createTestLeague>;
+  let testSeason: ReturnType<typeof createTestSeason>;
+
+  beforeEach(async () => {
+    resetTestDb();
+    db = getTestDb();
+    setupTestDatabase(db);
+    pilotUser = createTestUser(db);
+    testLeague = createTestLeague(db);
+    testSeason = createTestSeason(db, testLeague.id);
+    addLeagueMember(db, testLeague.id, pilotUser.id, 'pilot');
+    app = await buildTestApp(db);
+  });
+
+  const dlUrl = (taskId: string) =>
+    `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${taskId}/download?format=xctsk`;
+
+  it('re-exports as v1 JSON when stored rawContent is legacy XML', async () => {
+    // Simulate a task imported from the legacy XML form before this fix
+    const task = createTestTask(db, testSeason.id, testLeague.id);
+    addTurnpoint(db, task.id, testLeague.id, 'SSS', 0);
+    addTurnpoint(db, task.id, testLeague.id, 'GOAL_CYLINDER', 1);
+    db.prepare(`UPDATE tasks SET task_data_source = 'xctsk', task_data_raw = ? WHERE id = ?`).run(XCTSK_XML, task.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: dlUrl(task.id),
+      headers: { 'x-test-user-id': pilotUser.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.trimStart().startsWith('{')).toBe(true);
+    expect(() => JSON.parse(res.body)).not.toThrow();
+  });
+
+  it('passes through stored rawContent when it is already JSON', async () => {
+    const task = createTestTask(db, testSeason.id, testLeague.id);
+    addTurnpoint(db, task.id, testLeague.id, 'SSS', 0);
+    addTurnpoint(db, task.id, testLeague.id, 'GOAL_CYLINDER', 1);
+    db.prepare(`UPDATE tasks SET task_data_source = 'xctsk', task_data_raw = ? WHERE id = ?`).run(XCTSK_JSON, task.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: dlUrl(task.id),
+      headers: { 'x-test-user-id': pilotUser.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(XCTSK_JSON);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GOAL_LINE import — verify goal_line_bearing_deg is computed and persisted
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -169,6 +169,26 @@ describe('parseXctsk — JSON format (v1)', () => {
   it('format is xctsk', () => {
     expect(parseXctsk(XCTSK_JSON).format).toBe('xctsk');
   });
+
+  it('does not double-tag SSS when the file has an explicit SSS', () => {
+    // A spec-valid file: TP0 explicitly typed SSS, TP1 untyped.
+    // Without the explicit-SSS guard, the parser would re-promote TP1 to SSS
+    // (firstUntyped) and produce two starts.
+    const explicitSssTask = JSON.stringify({
+      version: 1,
+      taskType: 'CLASSIC',
+      turnpoints: [
+        { type: 'SSS', waypoint: { name: 'START', lat: 47.5, lon: -122.0, altSmoothed: 0 }, radius: 400 },
+        { waypoint: { name: 'TP1', lat: 47.51, lon: -122.01, altSmoothed: 0 }, radius: 400 },
+        { waypoint: { name: 'GOAL', lat: 47.52, lon: -122.02, altSmoothed: 0 }, radius: 400 },
+      ],
+    });
+    const result = parseXctsk(explicitSssTask);
+    expect(result.turnpoints.filter((tp) => tp.type === 'SSS')).toHaveLength(1);
+    expect(result.turnpoints[0].type).toBe('SSS');
+    expect(result.turnpoints[1].type).toBe('CYLINDER');
+    expect(result.turnpoints[2].type).toBe('GOAL_CYLINDER');
+  });
 });
 
 describe('parseXctsk — [GND] naming convention', () => {
@@ -1099,7 +1119,7 @@ describe('Task QR endpoint — GET /leagues/:slug/seasons/:seasonId/tasks/:taskI
 // .xctsk download endpoint — JSON output regression tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Task download — GET /tasks/:taskId/download?format=xctsk', () => {
+describe('Task download — GET /leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/download?format=xctsk', () => {
   let app: ReturnType<typeof Fastify>;
   let db: ReturnType<typeof getTestDb>;
   let pilotUser: ReturnType<typeof createTestUser>;


### PR DESCRIPTION
## Summary

A user reported that downloading a task as `.xctsk` and importing it into XCTrack fails with:

> Error parsing XCTSK data: com.google.gson.stream.MalformedJsonException

Modern XCTrack (and FlySkyHy) parse `.xctsk` files as **JSON**. The XML form we were emitting is a legacy format XCTrack no longer accepts on the file path. Per the [XCTrack Competition Interfaces spec](https://xctrack.org/Competition_Interfaces.html), the documented file format is **v1 JSON** (separate from the v2 polyline JSON used inside QR codes — that path is unchanged).

This PR switches `exportXctsk` to emit v1 JSON with keys in the spec's documented order (`taskType`, `version`, `earthModel`, `turnpoints`, `goal`) to also sidestep [FlySkyHy's key-ordering sensitivity](https://gitlab.com/xcontest-public/xctrack-public/-/issues/928).

- SSS / ESS encoded as turnpoint `type`; goal-line vs cylinder encoded as top-level `goal.type` (`LINE` | `CYLINDER`)
- Coordinates as decimal degrees (matches the existing parser and real XCTrack output)
- The XML parser in `task-parsers.ts` stays in place — older imported files still parse fine
- QR/v2 deep-link path (`buildXctrackDeepLink`) is untouched

SeeYou Navigator users were never affected — it doesn't import `.xctsk` files at all (it uses `.cup` or QR), and our `.cup` export already covers them.

## Test plan

- [x] New unit tests in `src/task-exporters.test.ts` — 12 cases covering JSON shape, key order, decimal-degree coords, SSS/ESS tagging, goal-line vs cylinder, no-goal, sequence ordering, and round-trip through `parseXctsk`
- [x] `npm test` — 181 passed (8 files)
- [x] `npm run typecheck` — clean
- [ ] Manual verify: download an `.xctsk` and import it into XCTrack on Android
- [ ] Manual verify: download an `.xctsk` and import it into FlySkyHy on iOS