### PR TITLE
Make rebuildTaskResults authoritative; drop dead scoring jobs

### DIFF
--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -314,17 +314,18 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   }
   let bestList = Array.from(bestByPilot.values());
 
-  // Optional task-level normalisation: scale distance_points and time_points
-  // independently so the winner's total = normalized_score. Computing both
-  // components under the same scale and re-deriving total preserves the
-  // dp + tp = total invariant (the previous implementation rounded total and
-  // dp separately, then derived tp = total - dp, drifting by ±1).
+  // Task-level normalisation: scale distance_points and time_points
+  // independently so the winner's total = normalized_score (which defaults
+  // to 1000 if the column is NULL). Computing both components under the
+  // same scale and re-deriving total preserves the dp + tp = total
+  // invariant — the previous implementation rounded total and dp
+  // separately and derived tp = total - dp, drifting by ±1.
   const taskRow = db.prepare(`SELECT normalized_score FROM tasks WHERE id = ?`).get(taskId) as
     | { normalized_score: number | null }
     | undefined;
   const normalized = taskRow?.normalized_score ?? 1000;
 
-  if (normalized !== null && bestList.length > 0) {
+  if (bestList.length > 0) {
     const winnerTotal = Math.max(...bestList.map((r) => r.total_points));
     if (winnerTotal > 0) {
       const scale = normalized / winnerTotal;

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -2,7 +2,9 @@
 // XC / Hike & Fly League Platform — Job Queue
 //
 // Infrastructure: SQLiteJobQueue + JobWorker (better-sqlite3 native API).
-// Handlers: RESCORE_TASK, FREEZE_TASK_SCORES, REBUILD_STANDINGS, NOTIFY_PILOTS.
+// Scoring is fully synchronous (rebuildTaskResults runs inline on upload and
+// delete paths) so the queue currently has no registered handlers. The
+// infrastructure stays for future async work (notifications, reprocessing).
 //
 // Single-process design: Fastify API + worker loop share one SQLite connection.
 // Worker wakes immediately on job enqueue via EventEmitter; polling fallback
@@ -11,7 +13,7 @@
 
 import type { Database } from 'better-sqlite3';
 import { randomUUID } from 'crypto';
-import { computeTimePoints } from './shared/task-engine';
+import { computeDistancePoints, computeTimePoints } from './shared/task-engine';
 
 // ── Minimal typed EventEmitter (no @types/node dependency) ───────────────────
 
@@ -29,55 +31,14 @@ class TypedEmitter {
 
 // =============================================================================
 // JOB PAYLOAD TYPES
+//
+// No job types are registered today — scoring is synchronous. The generic
+// JobType / JobPayload aliases let future async work (notifications, IGC
+// re-parsing on turnpoint edits, etc.) plug into the same infrastructure.
 // =============================================================================
 
-export type JobType =
-  | 'RESCORE_TASK'
-  | 'FREEZE_TASK_SCORES'
-  | 'REBUILD_STANDINGS'
-  | 'REPROCESS_ALL_SUBMISSIONS'
-  | 'NOTIFY_PILOTS';
-
-/** Recalculate time points for all goal attempts on a task. */
-export interface RescoreTaskPayload {
-  taskId: string;
-  leagueId: string;
-  triggeredBySubmissionId: string;
-}
-
-/** Lock task scores at close_date. */
-export interface FreezeTaskScoresPayload {
-  taskId: string;
-  leagueId: string;
-}
-
-/** Recompute season_standings from task_results. */
-export interface RebuildStandingsPayload {
-  seasonId: string;
-  leagueId: string;
-}
-
-/** Re-parse and re-score all IGC files for a task after turnpoints change. */
-export interface ReprocessAllSubmissionsPayload {
-  taskId: string;
-  leagueId: string;
-  submissionIds: string[];
-}
-
-/** Fan-out notifications to pilots whose score changed. */
-export interface NotifyPilotsPayload {
-  taskId: string;
-  leagueId: string;
-  taskName: string;
-  scoreChanges: Record<string, { oldTotalPoints: number; newTotalPoints: number }>;
-}
-
-export type JobPayload =
-  | RescoreTaskPayload
-  | FreezeTaskScoresPayload
-  | RebuildStandingsPayload
-  | ReprocessAllSubmissionsPayload
-  | NotifyPilotsPayload;
+export type JobType = string;
+export type JobPayload = unknown;
 
 export interface JobRecord {
   id: string;
@@ -100,7 +61,7 @@ export interface EnqueueOptions {
 }
 
 export interface JobQueue {
-  enqueue<T extends JobPayload>(type: JobType, payload: T, options?: EnqueueOptions): Promise<string>;
+  enqueue<T>(type: string, payload: T, options?: EnqueueOptions): Promise<string>;
 }
 
 // =============================================================================
@@ -123,7 +84,7 @@ export class SQLiteJobQueue extends TypedEmitter implements JobQueue {
     super();
   }
 
-  async enqueue<T extends JobPayload>(type: JobType, payload: T, options: EnqueueOptions = {}): Promise<string> {
+  async enqueue<T>(type: string, payload: T, options: EnqueueOptions = {}): Promise<string> {
     const id = randomUUID();
     const scheduledAt = (options.scheduledAt ?? new Date()).toISOString();
     const maxAttempts = options.maxAttempts ?? 3;
@@ -144,12 +105,12 @@ export class SQLiteJobQueue extends TypedEmitter implements JobQueue {
 // WORKER
 // =============================================================================
 
-type JobHandler<T extends JobPayload> = (payload: T, jobId: string) => Promise<void>;
+type JobHandler<T> = (payload: T, jobId: string) => Promise<void>;
 
 export class JobWorker {
   private running = false;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
-  private handlers = new Map<JobType, JobHandler<any>>();
+  private handlers = new Map<string, JobHandler<any>>();
 
   constructor(
     private readonly db: Database,
@@ -158,7 +119,7 @@ export class JobWorker {
     (queue as TypedEmitter).on('job:enqueued', () => this.processNext());
   }
 
-  register<T extends JobPayload>(type: JobType, handler: JobHandler<T>): void {
+  register<T>(type: string, handler: JobHandler<T>): void {
     this.handlers.set(type, handler);
   }
 
@@ -252,75 +213,111 @@ export class JobWorker {
 // =============================================================================
 // SHARED UTILITY: rebuild task_results
 //
-// Materialised best-attempt-per-pilot cache for a task.
-// Called from: upload handler (immediate) + RESCORE_TASK (after rescore).
+// Materialised best-attempt-per-pilot cache for a task. Re-scores from
+// canonical inputs (current best distance + full goal-times set) every call,
+// so the result reflects the live state of the task. Safe to call after
+// any change to flight_attempts (upload, soft-delete, undelete).
 // Must be called inside an existing transaction or starts its own.
 // =============================================================================
 
+interface ScoredAttemptRow {
+  id: string;
+  user_id: string;
+  distance_flown_km: number;
+  reached_goal: number;
+  task_time_s: number | null;
+  has_flagged_crossings: number;
+  distance_points: number;
+  time_points: number;
+  total_points: number;
+}
+
+// Goal first, then highest points, then fastest time (NULLs last).
+// Returns negative if a is the better attempt.
+function compareBestAttempt(a: ScoredAttemptRow, b: ScoredAttemptRow): number {
+  if (a.reached_goal !== b.reached_goal) return b.reached_goal - a.reached_goal;
+  if (a.total_points !== b.total_points) return b.total_points - a.total_points;
+  const at = a.task_time_s ?? Number.POSITIVE_INFINITY;
+  const bt = b.task_time_s ?? Number.POSITIVE_INFINITY;
+  return at - bt;
+}
+
 export function rebuildTaskResults(db: Database, taskId: string): void {
-  // Full rebuild: delete old rows, recompute from flight_attempts.
   db.prepare('DELETE FROM task_results WHERE task_id = ?').run(taskId);
 
-  // Best attempt per pilot: goal first, then highest points, then fastest time.
-  // Then rank all pilots by total_points DESC.
-  const rows = db
-    .prepare(`
-    WITH ranked AS (
-      SELECT
-        id, user_id,
-        distance_flown_km, reached_goal, task_time_s,
-        distance_points, time_points, total_points, has_flagged_crossings,
-        ROW_NUMBER() OVER (
-          PARTITION BY user_id
-          ORDER BY reached_goal DESC, total_points DESC,
-                   CASE WHEN task_time_s IS NULL THEN 1 ELSE 0 END,
-                   task_time_s ASC
-        ) AS rn
-      FROM flight_attempts
-      WHERE task_id = ? AND deleted_at IS NULL
+  const attempts = db
+    .prepare(
+      `SELECT id, user_id, distance_flown_km, reached_goal, task_time_s, has_flagged_crossings
+       FROM flight_attempts
+       WHERE task_id = ? AND deleted_at IS NULL`,
     )
-    SELECT
-      id, user_id, distance_flown_km, reached_goal, task_time_s,
-      distance_points, time_points, total_points, has_flagged_crossings,
-      RANK() OVER (
-        ORDER BY total_points DESC,
-                 CASE WHEN task_time_s IS NULL THEN 1 ELSE 0 END,
-                 task_time_s ASC
-      ) AS pilot_rank
-    FROM ranked WHERE rn = 1
-  `)
     .all(taskId) as Array<{
     id: string;
     user_id: string;
     distance_flown_km: number;
     reached_goal: number;
     task_time_s: number | null;
-    distance_points: number;
-    time_points: number;
-    total_points: number;
     has_flagged_crossings: number;
-    pilot_rank: number;
   }>;
 
-  // Apply score normalization if configured on this task.
+  if (attempts.length === 0) return;
+
+  // Re-score from canonical inputs. The previously-stored point values on
+  // flight_attempts are ignored — they reflect submission-time state, not
+  // current task state. This is the single source of truth for scoring.
+  const bestDistKm = Math.max(...attempts.map((a) => a.distance_flown_km));
+  const goalTimes = attempts
+    .filter((a) => a.reached_goal === 1 && a.task_time_s !== null)
+    .map((a) => a.task_time_s as number);
+
+  const scored: ScoredAttemptRow[] = attempts.map((a) => {
+    const distance_points = computeDistancePoints(a.distance_flown_km, bestDistKm, a.reached_goal === 1);
+    const time_points =
+      a.reached_goal === 1 && a.task_time_s !== null ? computeTimePoints(a.task_time_s, goalTimes) : 0;
+    const total_points = Math.round((distance_points + time_points) * 10) / 10;
+    return { ...a, distance_points, time_points, total_points };
+  });
+
+  // Pick best attempt per pilot.
+  const bestByPilot = new Map<string, ScoredAttemptRow>();
+  for (const a of scored) {
+    const cur = bestByPilot.get(a.user_id);
+    if (!cur || compareBestAttempt(a, cur) < 0) bestByPilot.set(a.user_id, a);
+  }
+  let bestList = Array.from(bestByPilot.values());
+
+  // Optional task-level normalisation: scale distance_points and time_points
+  // independently so the winner's total = normalized_score. Computing both
+  // components under the same scale and re-deriving total preserves the
+  // dp + tp = total invariant (the previous implementation rounded total and
+  // dp separately, then derived tp = total - dp, drifting by ±1).
   const taskRow = db.prepare(`SELECT normalized_score FROM tasks WHERE id = ?`).get(taskId) as
     | { normalized_score: number | null }
     | undefined;
   const normalized = taskRow?.normalized_score ?? 1000;
 
-  let finalRows = rows;
-  if (normalized !== null && rows.length > 0) {
-    const winnerTotal = Math.max(...rows.map((r) => r.total_points));
+  if (normalized !== null && bestList.length > 0) {
+    const winnerTotal = Math.max(...bestList.map((r) => r.total_points));
     if (winnerTotal > 0) {
       const scale = normalized / winnerTotal;
-      finalRows = rows.map((r) => {
-        const total = Math.round(r.total_points * scale);
-        const dp = Math.round(r.distance_points * scale);
-        const tp = total - dp;
-        return { ...r, distance_points: dp, time_points: tp, total_points: total };
+      bestList = bestList.map((r) => {
+        const distance_points = Math.round(r.distance_points * scale * 10) / 10;
+        const time_points = Math.round(r.time_points * scale * 10) / 10;
+        const total_points = Math.round((distance_points + time_points) * 10) / 10;
+        return { ...r, distance_points, time_points, total_points };
       });
     }
   }
+
+  // Rank by total_points DESC, task_time_s ASC (NULLs last), reached_goal DESC.
+  // Ties share a rank (RANK semantics, matching the previous SQL window).
+  bestList.sort((a, b) => {
+    if (b.total_points !== a.total_points) return b.total_points - a.total_points;
+    const at = a.task_time_s ?? Number.POSITIVE_INFINITY;
+    const bt = b.task_time_s ?? Number.POSITIVE_INFINITY;
+    if (at !== bt) return at - bt;
+    return b.reached_goal - a.reached_goal;
+  });
 
   const now = new Date().toISOString();
   const ins = db.prepare(`
@@ -332,7 +329,14 @@ export function rebuildTaskResults(db: Database, taskId: string): void {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
-  for (const r of finalRows) {
+  let prevKey: string | null = null;
+  let prevRank = 0;
+  for (let i = 0; i < bestList.length; i++) {
+    const r = bestList[i];
+    const key = `${r.total_points}|${r.task_time_s ?? 'null'}|${r.reached_goal}`;
+    const rank = key === prevKey ? prevRank : i + 1;
+    prevKey = key;
+    prevRank = rank;
     ins.run(
       randomUUID(),
       taskId,
@@ -345,7 +349,7 @@ export function rebuildTaskResults(db: Database, taskId: string): void {
       r.time_points,
       r.total_points,
       r.has_flagged_crossings,
-      r.pilot_rank,
+      rank,
       now,
       now,
       now,
@@ -354,180 +358,9 @@ export function rebuildTaskResults(db: Database, taskId: string): void {
 }
 
 // =============================================================================
-// HANDLER: RESCORE_TASK
-//
-// 1. Bail if task is frozen or deleted.
-// 2. Load all goal attempts for the task.
-// 3. Recompute time_points using the full set of goal times.
-// 4. Write updated scores + rebuild task_results in one transaction.
-// 5. Enqueue REBUILD_STANDINGS.
-// =============================================================================
-
-async function handleRescoreTask(payload: RescoreTaskPayload, db: Database, queue: SQLiteJobQueue): Promise<void> {
-  const task = db
-    .prepare(`SELECT id, season_id, scores_frozen_at FROM tasks WHERE id = ? AND deleted_at IS NULL`)
-    .get(payload.taskId) as { id: string; season_id: string; scores_frozen_at: string | null } | undefined;
-
-  if (!task || task.scores_frozen_at !== null) return;
-
-  // Load all goal attempts (reached_goal = 1) with their current scores
-  const goalAttempts = db
-    .prepare(
-      `SELECT id, task_time_s, distance_points, total_points
-     FROM flight_attempts
-     WHERE task_id = ? AND reached_goal = 1 AND deleted_at IS NULL`,
-    )
-    .all(payload.taskId) as Array<{
-    id: string;
-    task_time_s: number | null;
-    distance_points: number;
-    total_points: number;
-  }>;
-
-  const goalTimes = goalAttempts.filter((a) => a.task_time_s != null).map((a) => a.task_time_s!);
-
-  db.transaction(() => {
-    const update = db.prepare(
-      `UPDATE flight_attempts
-       SET time_points = ?, total_points = ?, updated_at = datetime('now')
-       WHERE id = ?`,
-    );
-
-    for (const attempt of goalAttempts) {
-      const tp = computeTimePoints(attempt.task_time_s ?? 0, goalTimes);
-      update.run(tp, attempt.distance_points + tp, attempt.id);
-    }
-
-    rebuildTaskResults(db, payload.taskId);
-  })();
-
-  await queue.enqueue<RebuildStandingsPayload>('REBUILD_STANDINGS', {
-    seasonId: task.season_id,
-    leagueId: payload.leagueId,
-  });
-}
-
-// =============================================================================
-// HANDLER: FREEZE_TASK_SCORES
-//
-// Sets scores_frozen_at on the task, then enqueues a final RESCORE_TASK to
-// lock in time points at the exact moment of close.
-// =============================================================================
-
-async function handleFreezeTaskScores(
-  payload: FreezeTaskScoresPayload,
-  db: Database,
-  queue: SQLiteJobQueue,
-): Promise<void> {
-  const result = db
-    .prepare(
-      `UPDATE tasks SET scores_frozen_at = datetime('now'), updated_at = datetime('now')
-     WHERE id = ? AND scores_frozen_at IS NULL AND deleted_at IS NULL`,
-    )
-    .run(payload.taskId);
-
-  if (result.changes === 0) return; // already frozen or deleted
-
-  await queue.enqueue<RescoreTaskPayload>('RESCORE_TASK', {
-    taskId: payload.taskId,
-    leagueId: payload.leagueId,
-    triggeredBySubmissionId: 'FREEZE',
-  });
-}
-
-// =============================================================================
-// HANDLER: REBUILD_STANDINGS
-//
-// Aggregates task_results per pilot across all tasks in a season, then
-// upserts season_standings with updated totals and ranks.
-// =============================================================================
-
-async function handleRebuildStandings(payload: RebuildStandingsPayload, db: Database): Promise<void> {
-  const rows = db
-    .prepare(`
-    SELECT
-      tr.user_id,
-      SUM(tr.total_points)  AS total_points,
-      COUNT(tr.task_id)     AS tasks_flown,
-      SUM(tr.reached_goal)  AS tasks_with_goal
-    FROM task_results tr
-    JOIN tasks t ON t.id = tr.task_id
-    WHERE t.season_id = ? AND t.deleted_at IS NULL
-    GROUP BY tr.user_id
-    ORDER BY total_points DESC
-  `)
-    .all(payload.seasonId) as Array<{
-    user_id: string;
-    total_points: number;
-    tasks_flown: number;
-    tasks_with_goal: number;
-  }>;
-
-  const now = new Date().toISOString();
-
-  db.transaction(() => {
-    const upsert = db.prepare(`
-      INSERT INTO season_standings
-        (id, season_id, user_id, total_points, tasks_flown, tasks_with_goal,
-         rank, last_computed_at, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT (season_id, user_id) DO UPDATE SET
-        total_points     = excluded.total_points,
-        tasks_flown      = excluded.tasks_flown,
-        tasks_with_goal  = excluded.tasks_with_goal,
-        rank             = excluded.rank,
-        last_computed_at = excluded.last_computed_at,
-        updated_at       = excluded.updated_at
-    `);
-
-    rows.forEach((row, i) => {
-      upsert.run(
-        randomUUID(),
-        payload.seasonId,
-        row.user_id,
-        row.total_points,
-        row.tasks_flown,
-        row.tasks_with_goal,
-        i + 1,
-        now,
-        now,
-        now,
-      );
-    });
-  })();
-}
-
-// =============================================================================
-// HANDLER: NOTIFY_PILOTS
-// Placeholder — notification delivery not yet implemented.
-// =============================================================================
-
-async function handleNotifyPilots(_payload: NotifyPilotsPayload, _db: Database): Promise<void> {
-  // TODO: implement push / email notifications
-}
-
-// =============================================================================
 // BOOTSTRAP
-// Wires all handlers into the worker and returns it ready to start().
 // =============================================================================
 
 export function bootstrapWorker(db: Database, queue: SQLiteJobQueue): JobWorker {
-  const worker = new JobWorker(db, queue);
-
-  worker.register<RescoreTaskPayload>('RESCORE_TASK', (payload) => handleRescoreTask(payload, db, queue));
-
-  worker.register<FreezeTaskScoresPayload>('FREEZE_TASK_SCORES', (payload) =>
-    handleFreezeTaskScores(payload, db, queue),
-  );
-
-  worker.register<RebuildStandingsPayload>('REBUILD_STANDINGS', (payload) => handleRebuildStandings(payload, db));
-
-  worker.register<NotifyPilotsPayload>('NOTIFY_PILOTS', (payload) => handleNotifyPilots(payload, db));
-
-  // REPROCESS_ALL_SUBMISSIONS is not yet triggered by any API endpoint
-  worker.register<ReprocessAllSubmissionsPayload>('REPROCESS_ALL_SUBMISSIONS', async () => {
-    /* not yet implemented */
-  });
-
-  return worker;
+  return new JobWorker(db, queue);
 }

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -254,6 +254,16 @@ interface ScoredAttemptRow {
 
 // Goal first, then highest points, then fastest time (NULLs last).
 // Returns negative if a is the better attempt.
+//
+// Note: this priority order intentionally differs from the rank-sort below
+// (which is total_points → task_time_s → reached_goal). For the *picker*
+// goal-attempt > non-goal-attempt is meaningful even at equal total_points
+// because we want the goal-recording attempt's metadata (task_time_s,
+// crossings) preferred. For the *rank* a goal pilot's total_points already
+// exceeds any non-goal pilot's by construction, so the reached_goal tier is
+// never load-bearing — kept only as a final tiebreaker. If a future scoring
+// change ever lets non-goal pilots out-score goal pilots, this divergence
+// will need a second look.
 function compareBestAttempt(a: ScoredAttemptRow, b: ScoredAttemptRow): number {
   if (a.reached_goal !== b.reached_goal) return b.reached_goal - a.reached_goal;
   if (a.total_points !== b.total_points) return b.total_points - a.total_points;
@@ -289,7 +299,11 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   // Re-score from canonical inputs. The previously-stored point values on
   // flight_attempts are ignored — they reflect submission-time state, not
   // current task state. This is the single source of truth for scoring.
-  const bestDistKm = Math.max(...attempts.map((a) => a.distance_flown_km));
+  // (Use reduce instead of `Math.max(...arr)` — V8 throws RangeError on
+  // spreads of ~100k+ elements, and the boot-time backfill iterates every
+  // task in the DB.)
+  let bestDistKm = 0;
+  for (const a of attempts) if (a.distance_flown_km > bestDistKm) bestDistKm = a.distance_flown_km;
   // Build the goal-times set from the *fastest* goal time per pilot. Without
   // dedup, a pilot who uploads the same goal flight twice (or two different
   // goal flights) would contribute multiple entries and shift tMin/tMax for
@@ -330,7 +344,9 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   const normalized = taskRow?.normalized_score ?? 1000;
 
   if (bestList.length > 0) {
-    const winnerTotal = Math.max(...bestList.map((r) => r.total_points));
+    // reduce, not Math.max(...arr): see note at bestDistKm above.
+    let winnerTotal = 0;
+    for (const r of bestList) if (r.total_points > winnerTotal) winnerTotal = r.total_points;
     if (winnerTotal > 0) {
       const scale = normalized / winnerTotal;
       bestList = bestList.map((r) => {

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -187,7 +187,11 @@ export class JobWorker {
       )
       .run(row.id);
 
-    return { ...row, payload: JSON.parse(row.payload) };
+    // SELECT happened before the UPDATE that incremented attempts, so the
+    // in-memory row is one behind the DB. Bump it so handleJobError reads
+    // the post-claim count (otherwise nextScheduledAt(0) hits RETRY_DELAYS_MS[-1]
+    // on the first failure and the retry-then-fail counters are off by one).
+    return { ...row, attempts: row.attempts + 1, payload: JSON.parse(row.payload) };
   }
 
   private completeJob(jobId: string): void {

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -274,9 +274,17 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   // flight_attempts are ignored — they reflect submission-time state, not
   // current task state. This is the single source of truth for scoring.
   const bestDistKm = Math.max(...attempts.map((a) => a.distance_flown_km));
-  const goalTimes = attempts
-    .filter((a) => a.reached_goal === 1 && a.task_time_s !== null)
-    .map((a) => a.task_time_s as number);
+  // Build the goal-times set from the *fastest* goal time per pilot. Without
+  // dedup, a pilot who uploads the same goal flight twice (or two different
+  // goal flights) would contribute multiple entries and shift tMin/tMax for
+  // everyone — scoring should depend on one attempt per pilot.
+  const fastestGoalTimeByPilot = new Map<string, number>();
+  for (const a of attempts) {
+    if (a.reached_goal !== 1 || a.task_time_s === null) continue;
+    const cur = fastestGoalTimeByPilot.get(a.user_id);
+    if (cur === undefined || a.task_time_s < cur) fastestGoalTimeByPilot.set(a.user_id, a.task_time_s);
+  }
+  const goalTimes = Array.from(fastestGoalTimeByPilot.values());
 
   const scored: ScoredAttemptRow[] = attempts.map((a) => {
     const distance_points = computeDistancePoints(a.distance_flown_km, bestDistKm, a.reached_goal === 1);

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -157,11 +157,23 @@ export class JobWorker {
   }
 
   private claimNextJob(): JobRecord | null {
+    // Alias snake_case columns to the camelCase JobRecord shape. Without
+    // this, handleJobError() reads job.maxAttempts as undefined and the
+    // attempts >= maxAttempts check is always false, so jobs retry forever
+    // instead of terminally failing.
     const row = this.db
       .prepare(
-        `SELECT * FROM jobs
-       WHERE status = 'PENDING' AND datetime(scheduled_at) <= datetime('now')
-       ORDER BY datetime(scheduled_at) ASC LIMIT 1`,
+        `SELECT id, type, payload, status, attempts,
+                max_attempts AS maxAttempts,
+                last_error   AS lastError,
+                scheduled_at AS scheduledAt,
+                started_at   AS startedAt,
+                completed_at AS completedAt,
+                created_at   AS createdAt,
+                updated_at   AS updatedAt
+         FROM jobs
+         WHERE status = 'PENDING' AND datetime(scheduled_at) <= datetime('now')
+         ORDER BY datetime(scheduled_at) ASC LIMIT 1`,
       )
       .get() as any;
 

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -217,7 +217,11 @@ export class JobWorker {
 // canonical inputs (current best distance + full goal-times set) every call,
 // so the result reflects the live state of the task. Safe to call after
 // any change to flight_attempts (upload, soft-delete, undelete).
-// Must be called inside an existing transaction or starts its own.
+//
+// Wraps the DELETE + recompute + INSERTs in a transaction so callers never
+// see a partially-rebuilt cache. better-sqlite3 transactions are reentrant
+// (nested calls become savepoints), so this is safe whether or not the
+// caller has already opened one.
 // =============================================================================
 
 interface ScoredAttemptRow {
@@ -243,6 +247,10 @@ function compareBestAttempt(a: ScoredAttemptRow, b: ScoredAttemptRow): number {
 }
 
 export function rebuildTaskResults(db: Database, taskId: string): void {
+  db.transaction(() => rebuildTaskResultsInner(db, taskId))();
+}
+
+function rebuildTaskResultsInner(db: Database, taskId: string): void {
   db.prepare('DELETE FROM task_results WHERE task_id = ?').run(taskId);
 
   const attempts = db

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -179,13 +179,20 @@ export class JobWorker {
 
     if (!row) return null;
 
-    this.db
+    // Atomically claim by transitioning PENDING → RUNNING. The WHERE clause
+    // includes status = 'PENDING' so a concurrent claimNextJob that already
+    // grabbed this row reports `changes === 0` here — return null instead of
+    // running the handler twice. processNext is invoked from three places
+    // (start(), poll timer, job:enqueued event) without awaits, so concurrent
+    // calls are possible.
+    const claim = this.db
       .prepare(
         `UPDATE jobs SET status = 'RUNNING', started_at = datetime('now'),
          attempts = attempts + 1, updated_at = datetime('now')
        WHERE id = ? AND status = 'PENDING'`,
       )
       .run(row.id);
+    if (claim.changes === 0) return null;
 
     // SELECT happened before the UPDATE that incremented attempts, so the
     // in-memory row is one behind the DB. Bump it so handleJobError reads

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -9,7 +9,6 @@ import { randomUUID } from 'crypto';
 import type { FastifyInstance } from 'fastify';
 import QRCode from 'qrcode';
 import { makeResolveLeagueHook, requireAuth, requireLeagueAdmin, requireLeagueMember } from '../auth';
-import type { SQLiteJobQueue } from '../job-queue';
 import { parseAndValidate } from '../pipeline';
 import { type Cylinder, optimiseRoute } from '../shared/task-engine';
 import {
@@ -45,11 +44,10 @@ function computeGoalLineBearing(turnpoints: ParsedTurnpoint[]): number | null {
 
 interface LeagueRouteOptions {
   db: Database.Database;
-  queue: SQLiteJobQueue;
 }
 
 export async function registerLeagueRoutes(fastify: FastifyInstance, opts: LeagueRouteOptions): Promise<void> {
-  const { db, queue } = opts;
+  const { db } = opts;
 
   // ── Public league list ─────────────────────────────────────────────────────
   fastify.get('/leagues', async (request, reply) => {

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -391,7 +391,8 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
                 tr.distance_points, tr.time_points, tr.total_points,
                 tr.has_flagged_crossings,
                 fa.attempt_index, fa.last_turnpoint_index,
-                t.close_date AS task_close_date
+                t.close_date AS task_close_date,
+                t.scores_frozen_at AS task_scores_frozen_at
          FROM flight_submissions fs
          LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
          LEFT JOIN flight_attempts fa ON fa.id = tr.best_attempt_id
@@ -420,7 +421,11 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
               }
             : null;
 
-        const taskOpen = now <= new Date(row.task_close_date);
+        // Scores are provisional while the task is still accepting changes:
+        // close_date hasn't passed AND scores aren't manually frozen. An
+        // admin can freeze before close_date via /freeze, in which case
+        // task_results will no longer change even though now <= close_date.
+        const taskOpen = now <= new Date(row.task_close_date) && row.task_scores_frozen_at === null;
         return {
           id: row.id,
           status: row.status,
@@ -430,8 +435,6 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           igcDate: row.igc_date ?? null,
           bestAttempt,
           allAttempts: bestAttempt ? [bestAttempt] : [],
-          // Scores can change while the task is open: any new upload may
-          // shift the best distance or goal-times set and rescore everyone.
           timePointsProvisional: taskOpen,
         };
       });
@@ -482,17 +485,23 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         // Best attempt for score/goal metadata. Read from task_results (the
         // authoritative post-rebuild row) so the metadata matches the
         // leaderboard rather than the submission-time snapshot on
-        // flight_attempts.
+        // flight_attempts. Also pull tr.best_attempt_id so the crossings
+        // query below can scope to the same attempt that produced the score.
         const bestAttempt = db
           .prepare(
-            `SELECT tr.reached_goal, tr.total_points
+            `SELECT tr.reached_goal, tr.total_points, tr.best_attempt_id
          FROM task_results tr
          JOIN flight_submissions s ON s.task_id = tr.task_id AND s.user_id = tr.user_id
          WHERE s.id = ?`,
           )
-          .get(submission.id) as { reached_goal: number; total_points: number } | undefined;
+          .get(submission.id) as { reached_goal: number; total_points: number; best_attempt_id: string } | undefined;
 
-        // Turnpoint crossings from best attempt
+        // Turnpoint crossings for the *exact attempt that was scored*. If
+        // the IGC contained multiple SSS crossings (multiple attempts in one
+        // file), filtering only by submission_id would return crossings for
+        // all attempts and the displayed sequence wouldn't match the score.
+        // Scoping to best_attempt_id keeps the displayed turnpoint sequence
+        // consistent with bestAttempt.
         const crossings = bestAttempt
           ? (db
               .prepare(
@@ -508,12 +517,11 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
            tc.ground_confirmed       AS groundConfirmed,
            tc.ground_check_required  AS groundCheckRequired
          FROM turnpoint_crossings tc
-         JOIN flight_attempts fa ON fa.id = tc.attempt_id
          JOIN turnpoints t ON t.id = tc.turnpoint_id
-         WHERE fa.submission_id = ? AND fa.deleted_at IS NULL
+         WHERE tc.attempt_id = ?
          ORDER BY t.sequence_index`,
               )
-              .all(submission.id) as any[])
+              .all(bestAttempt.best_attempt_id) as any[])
           : [];
 
         return reply.send({

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -364,7 +364,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
       },
       async (request, reply) => {
-        return handleIgcUpload(request as any, reply, db, queue);
+        return handleIgcUpload(request as any, reply, db);
       },
     );
 

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -559,19 +559,25 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
 
       if (!season) return reply.status(404).send({ error: 'Season not found' });
 
+      // Live aggregate over task_results: sum per pilot across non-deleted
+      // tasks in this season. Single source of truth — no separate cache.
       const standings = db
         .prepare(
           `SELECT
-           ss.rank,
-           ss.user_id        AS pilotId,
-           u.display_name    AS pilotName,
-           ss.total_points   AS totalPoints,
-           ss.tasks_flown    AS tasksFlown,
-           ss.tasks_with_goal AS tasksWithGoal
-         FROM season_standings ss
-         JOIN users u ON u.id = ss.user_id
-         WHERE ss.season_id = ?
-         ORDER BY ss.rank`,
+           RANK() OVER (
+             ORDER BY SUM(tr.total_points) DESC
+           ) AS rank,
+           tr.user_id AS pilotId,
+           u.display_name AS pilotName,
+           ROUND(SUM(tr.total_points), 1) AS totalPoints,
+           COUNT(tr.task_id) AS tasksFlown,
+           SUM(tr.reached_goal) AS tasksWithGoal
+         FROM task_results tr
+         JOIN tasks t ON t.id = tr.task_id
+         JOIN users u ON u.id = tr.user_id
+         WHERE t.season_id = ? AND t.deleted_at IS NULL
+         GROUP BY tr.user_id
+         ORDER BY rank`,
         )
         .all(seasonId) as any[];
 
@@ -1745,24 +1751,21 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // Verify task belongs to this season/league
       const task = db
         .prepare(
-          `SELECT t.id, t.scores_frozen_at
+          `SELECT t.id
          FROM tasks t
          JOIN seasons s ON s.id = t.season_id
          WHERE t.id = ? AND t.season_id = ? AND s.league_id = ? AND t.deleted_at IS NULL`,
         )
-        .get(taskId, seasonId, league.id) as { id: string; scores_frozen_at: string | null } | undefined;
+        .get(taskId, seasonId, league.id) as { id: string } | undefined;
 
       if (!task) {
         return reply.status(404).send({ error: 'Task not found' });
       }
 
-      // Prevent deleting frozen tasks
-      if (task.scores_frozen_at) {
-        return reply.status(400).send({ error: 'Cannot delete a frozen task' });
-      }
-
       // Soft delete the task and cascade to related data in one transaction.
       // task_results has no deleted_at (computed data) so hard-delete those rows.
+      // Admin moderation (deleting closed tasks) is allowed; the cascade keeps
+      // standings in sync via the live aggregate.
       db.transaction(() => {
         db.prepare(`UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
           taskId,

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -375,23 +375,26 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       const userId = (request as any).user!.userId;
       const league = (request as any).league;
 
-      // Per-submission scores come from task_results (the authoritative
-      // post-rebuild row). All of a pilot's submissions for a task show the
-      // same score — that's correct: scoring is per-pilot per-task, not
-      // per-submission. Reading point columns from flight_attempts would
-      // return submission-time snapshots that go stale once another upload
-      // changes the best distance or goal-times set.
+      // Each row shows the pilot's *current* task state (their best attempt
+      // across all submissions for this task, scored against the live
+      // best-distance + goal-times set). Both the score columns and the
+      // attempt metadata are sourced via tr.best_attempt_id so attempt_index
+      // and turnpointsCrossed always describe the same attempt that produced
+      // the score — no risk of mixing metadata from one submission with
+      // scores from another. Every submission row therefore carries the
+      // same bestAttempt; that's correct because scoring is per-pilot
+      // per-task, not per-submission.
       const rows = db
         .prepare(
           `SELECT fs.id, fs.status, fs.igc_filename, fs.igc_size_bytes, fs.submitted_at, fs.igc_date,
-                fa.attempt_index, fa.last_turnpoint_index,
                 tr.reached_goal, tr.distance_flown_km, tr.task_time_s,
                 tr.distance_points, tr.time_points, tr.total_points,
                 tr.has_flagged_crossings,
+                fa.attempt_index, fa.last_turnpoint_index,
                 t.close_date AS task_close_date
          FROM flight_submissions fs
-         LEFT JOIN flight_attempts fa ON fa.id = fs.best_attempt_id
          LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
+         LEFT JOIN flight_attempts fa ON fa.id = tr.best_attempt_id
          JOIN tasks t ON t.id = fs.task_id
          JOIN seasons s ON s.id = t.season_id
          WHERE fs.task_id = ? AND s.id = ? AND s.league_id = ?

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -606,7 +606,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
          JOIN users u ON u.id = tr.user_id
          WHERE t.season_id = ? AND t.deleted_at IS NULL
          GROUP BY tr.user_id
-         ORDER BY rank`,
+         ORDER BY rank, pilotId`,
         )
         .all(seasonId) as any[];
 

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -375,14 +375,23 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       const userId = (request as any).user!.userId;
       const league = (request as any).league;
 
+      // Per-submission scores come from task_results (the authoritative
+      // post-rebuild row). All of a pilot's submissions for a task show the
+      // same score — that's correct: scoring is per-pilot per-task, not
+      // per-submission. Reading point columns from flight_attempts would
+      // return submission-time snapshots that go stale once another upload
+      // changes the best distance or goal-times set.
       const rows = db
         .prepare(
           `SELECT fs.id, fs.status, fs.igc_filename, fs.igc_size_bytes, fs.submitted_at, fs.igc_date,
-                fa.attempt_index, fa.reached_goal, fa.distance_flown_km, fa.task_time_s,
-                fa.distance_points, fa.time_points, fa.total_points,
-                fa.has_flagged_crossings, fa.last_turnpoint_index
+                fa.attempt_index, fa.last_turnpoint_index,
+                tr.reached_goal, tr.distance_flown_km, tr.task_time_s,
+                tr.distance_points, tr.time_points, tr.total_points,
+                tr.has_flagged_crossings,
+                t.close_date AS task_close_date
          FROM flight_submissions fs
          LEFT JOIN flight_attempts fa ON fa.id = fs.best_attempt_id
+         LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
          JOIN tasks t ON t.id = fs.task_id
          JOIN seasons s ON s.id = t.season_id
          WHERE fs.task_id = ? AND s.id = ? AND s.league_id = ?
@@ -391,6 +400,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         )
         .all(taskId, seasonId, league.id, userId) as any[];
 
+      const now = new Date();
       const submissions = rows.map((row) => {
         const bestAttempt =
           row.attempt_index != null
@@ -407,6 +417,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
               }
             : null;
 
+        const taskOpen = now <= new Date(row.task_close_date);
         return {
           id: row.id,
           status: row.status,
@@ -416,7 +427,9 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           igcDate: row.igc_date ?? null,
           bestAttempt,
           allAttempts: bestAttempt ? [bestAttempt] : [],
-          timePointsProvisional: Boolean(row.reached_goal),
+          // Scores can change while the task is open: any new upload may
+          // shift the best distance or goal-times set and rescore everyone.
+          timePointsProvisional: taskOpen,
         };
       });
 
@@ -463,13 +476,16 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         const lats = fixes.map((f: any) => f.lat);
         const lngs = fixes.map((f: any) => f.lng);
 
-        // Best attempt for score/goal metadata
+        // Best attempt for score/goal metadata. Read from task_results (the
+        // authoritative post-rebuild row) so the metadata matches the
+        // leaderboard rather than the submission-time snapshot on
+        // flight_attempts.
         const bestAttempt = db
           .prepare(
-            `SELECT reached_goal, total_points
-         FROM flight_attempts
-         WHERE submission_id = ? AND deleted_at IS NULL
-         ORDER BY total_points DESC LIMIT 1`,
+            `SELECT tr.reached_goal, tr.total_points
+         FROM task_results tr
+         JOIN flight_submissions s ON s.task_id = tr.task_id AND s.user_id = tr.user_id
+         WHERE s.id = ?`,
           )
           .get(submission.id) as { reached_goal: number; total_points: number } | undefined;
 
@@ -559,11 +575,15 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
 
       // Live aggregate over task_results: sum per pilot across non-deleted
       // tasks in this season. Single source of truth — no separate cache.
+      // Rank by ROUND(SUM, 1) — the same value we expose as totalPoints —
+      // so two pilots whose underlying float sums differ only by IEEE-754
+      // jitter (e.g. 799.99999 vs 800.0, both displayed as 800.0) are
+      // guaranteed to share a rank rather than flicker.
       const standings = db
         .prepare(
           `SELECT
            RANK() OVER (
-             ORDER BY SUM(tr.total_points) DESC
+             ORDER BY ROUND(SUM(tr.total_points), 1) DESC
            ) AS rank,
            tr.user_id AS pilotId,
            u.display_name AS pilotName,

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,27 +104,25 @@ async function main() {
   const worker = bootstrapWorker(db, queue);
   worker.start();
 
-  // ── Backfill task_results for any tasks that have attempts but no results ──
-  // Handles uploads that happened before the materialised-view logic was added.
-  const orphanedTasks = db
-    .prepare(
-      `SELECT DISTINCT fa.task_id
-     FROM flight_attempts fa
-     LEFT JOIN task_results tr ON tr.task_id = fa.task_id
-     WHERE tr.id IS NULL AND fa.deleted_at IS NULL`,
-    )
-    .all() as Array<{ task_id: string }>;
+  // ── Boot-time rebuild of task_results ──────────────────────────────────────
+  // rebuildTaskResults now re-scores from canonical inputs (current best
+  // distance, full goal-times set), so previously-cached rows can be stale
+  // under bug fixes. Run it once for every non-deleted task on boot — cheap
+  // (~1ms per task) and self-heals the leaderboard. Standings is now a live
+  // SQL aggregate, so no separate standings rebuild is needed.
+  const tasksToRebuild = db
+    .prepare(`SELECT id FROM tasks WHERE deleted_at IS NULL`)
+    .all() as Array<{ id: string }>;
+  for (const { id } of tasksToRebuild) rebuildTaskResults(db, id);
 
-  for (const { task_id } of orphanedTasks) {
-    rebuildTaskResults(db, task_id);
-    // Enqueue standings rebuild for the season this task belongs to
-    const row = db.prepare(`SELECT t.season_id, t.league_id FROM tasks t WHERE t.id = ?`).get(task_id) as
-      | { season_id: string; league_id: string }
-      | undefined;
-    if (row) {
-      queue.enqueue('REBUILD_STANDINGS', { seasonId: row.season_id, leagueId: row.league_id });
-    }
-  }
+  // Drop any pending jobs that referenced removed handler types so the worker
+  // doesn't fail-loop them after deploy.
+  db.prepare(
+    `DELETE FROM jobs
+     WHERE status = 'PENDING'
+       AND type IN ('RESCORE_TASK', 'FREEZE_TASK_SCORES', 'REBUILD_STANDINGS',
+                    'NOTIFY_PILOTS', 'REPROCESS_ALL_SUBMISSIONS')`,
+  ).run();
 
   // ── Fastify ────────────────────────────────────────────────────────────────
   const app = Fastify({

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,6 +102,16 @@ async function main() {
   // ── Job queue + worker ─────────────────────────────────────────────────────
   const queue = new SQLiteJobQueue(db);
   const worker = bootstrapWorker(db, queue);
+
+  // Drop any pending/failed jobs that referenced removed handler types
+  // *before* starting the worker, so it doesn't fail-loop them after deploy.
+  db.prepare(
+    `DELETE FROM jobs
+     WHERE status IN ('PENDING', 'FAILED')
+       AND type IN ('RESCORE_TASK', 'FREEZE_TASK_SCORES', 'REBUILD_STANDINGS',
+                    'NOTIFY_PILOTS', 'REPROCESS_ALL_SUBMISSIONS')`,
+  ).run();
+
   worker.start();
 
   // ── Boot-time rebuild of task_results ──────────────────────────────────────
@@ -110,19 +120,8 @@ async function main() {
   // under bug fixes. Run it once for every non-deleted task on boot — cheap
   // (~1ms per task) and self-heals the leaderboard. Standings is now a live
   // SQL aggregate, so no separate standings rebuild is needed.
-  const tasksToRebuild = db
-    .prepare(`SELECT id FROM tasks WHERE deleted_at IS NULL`)
-    .all() as Array<{ id: string }>;
+  const tasksToRebuild = db.prepare(`SELECT id FROM tasks WHERE deleted_at IS NULL`).all() as Array<{ id: string }>;
   for (const { id } of tasksToRebuild) rebuildTaskResults(db, id);
-
-  // Drop any pending jobs that referenced removed handler types so the worker
-  // doesn't fail-loop them after deploy.
-  db.prepare(
-    `DELETE FROM jobs
-     WHERE status = 'PENDING'
-       AND type IN ('RESCORE_TASK', 'FREEZE_TASK_SCORES', 'REBUILD_STANDINGS',
-                    'NOTIFY_PILOTS', 'REPROCESS_ALL_SUBMISSIONS')`,
-  ).run();
 
   // ── Fastify ────────────────────────────────────────────────────────────────
   const app = Fastify({

--- a/src/server.ts
+++ b/src/server.ts
@@ -123,8 +123,20 @@ async function main() {
   // under bug fixes. Run it once for every non-deleted task on boot — cheap
   // (~1ms per task) and self-heals the leaderboard. Standings is now a live
   // SQL aggregate, so no separate standings rebuild is needed.
+  //
+  // Wrap each task in try/catch so a single bad row (corrupted attempt, FK
+  // orphan, schema drift) can't crash startup before Fastify binds. Errors
+  // are logged with the offending taskId and the boot continues; the broken
+  // task's leaderboard stays at its prior cached state until the next
+  // upload triggers another rebuild.
   const tasksToRebuild = db.prepare(`SELECT id FROM tasks WHERE deleted_at IS NULL`).all() as Array<{ id: string }>;
-  for (const { id } of tasksToRebuild) rebuildTaskResults(db, id);
+  for (const { id } of tasksToRebuild) {
+    try {
+      rebuildTaskResults(db, id);
+    } catch (err) {
+      console.error(`[boot] rebuildTaskResults failed for task ${id}:`, err);
+    }
+  }
 
   // ── Fastify ────────────────────────────────────────────────────────────────
   const app = Fastify({

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,11 +103,14 @@ async function main() {
   const queue = new SQLiteJobQueue(db);
   const worker = bootstrapWorker(db, queue);
 
-  // Drop any pending/failed jobs that referenced removed handler types
-  // *before* starting the worker, so it doesn't fail-loop them after deploy.
+  // Drop any pending/failed/running jobs that referenced removed handler
+  // types *before* starting the worker. PENDING/FAILED would fail-loop;
+  // RUNNING rows are left over from a prior process that crashed mid-job
+  // (the worker only claims PENDING, so a stuck RUNNING row never advances)
+  // and would otherwise stay forever.
   db.prepare(
     `DELETE FROM jobs
-     WHERE status IN ('PENDING', 'FAILED')
+     WHERE status IN ('PENDING', 'FAILED', 'RUNNING')
        AND type IN ('RESCORE_TASK', 'FREEZE_TASK_SCORES', 'REBUILD_STANDINGS',
                     'NOTIFY_PILOTS', 'REPROCESS_ALL_SUBMISSIONS')`,
   ).run();

--- a/src/server.ts
+++ b/src/server.ts
@@ -224,7 +224,7 @@ async function main() {
 
       // League routes
       const { registerLeagueRoutes } = await import('./routes/leagues');
-      await registerLeagueRoutes(api, { db, queue });
+      await registerLeagueRoutes(api, { db });
     },
     { prefix: '/api/v1' },
   );

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -372,14 +372,22 @@ export async function handleIgcUpload(
   })();
 
   // ── Response ───────────────────────────────────────────────────────────────
+  // task_results holds the post-rebuild authoritative scores (normalised,
+  // rescored against the live goal-times set). flight_attempts has the
+  // attempt-level metadata we need (attempt_index, last_turnpoint_index).
+  // Reading point columns from flight_attempts would return submission-time
+  // snapshots that go stale once another upload changes the best distance
+  // or goal-times set.
   const row = db
     .prepare(
       `SELECT fs.id, fs.status, fs.igc_filename, fs.igc_size_bytes, fs.submitted_at, fs.igc_date,
-            fa.attempt_index, fa.reached_goal, fa.distance_flown_km, fa.task_time_s,
-            fa.distance_points, fa.time_points, fa.total_points,
-            fa.has_flagged_crossings, fa.last_turnpoint_index
+            fa.attempt_index, fa.last_turnpoint_index,
+            tr.reached_goal, tr.distance_flown_km, tr.task_time_s,
+            tr.distance_points, tr.time_points, tr.total_points,
+            tr.has_flagged_crossings
      FROM flight_submissions fs
      LEFT JOIN flight_attempts fa ON fa.id = fs.best_attempt_id
+     LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
      WHERE fs.id = ?`,
     )
     .get(submissionId) as any;

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -372,22 +372,24 @@ export async function handleIgcUpload(
   })();
 
   // ── Response ───────────────────────────────────────────────────────────────
-  // task_results holds the post-rebuild authoritative scores (normalised,
-  // rescored against the live goal-times set). flight_attempts has the
-  // attempt-level metadata we need (attempt_index, last_turnpoint_index).
-  // Reading point columns from flight_attempts would return submission-time
-  // snapshots that go stale once another upload changes the best distance
-  // or goal-times set.
+  // The response reflects the pilot's *current* task state after the upload:
+  // task_results holds their best attempt across all submissions for this
+  // task, scored against the live best-distance + goal-times set. Both the
+  // score columns AND the attempt metadata are sourced via tr.best_attempt_id
+  // so the bestAttempt object is internally consistent — attempt_index and
+  // turnpointsCrossed always describe the same attempt that produced the
+  // score. If the pilot had a previous-better submission, the response will
+  // show that one; that's correct, since it's what the leaderboard shows.
   const row = db
     .prepare(
       `SELECT fs.id, fs.status, fs.igc_filename, fs.igc_size_bytes, fs.submitted_at, fs.igc_date,
-            fa.attempt_index, fa.last_turnpoint_index,
             tr.reached_goal, tr.distance_flown_km, tr.task_time_s,
             tr.distance_points, tr.time_points, tr.total_points,
-            tr.has_flagged_crossings
+            tr.has_flagged_crossings,
+            fa.attempt_index, fa.last_turnpoint_index
      FROM flight_submissions fs
-     LEFT JOIN flight_attempts fa ON fa.id = fs.best_attempt_id
      LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
+     LEFT JOIN flight_attempts fa ON fa.id = tr.best_attempt_id
      WHERE fs.id = ?`,
     )
     .get(submissionId) as any;
@@ -414,7 +416,11 @@ export async function handleIgcUpload(
       igcDate: row.igc_date ?? null,
       bestAttempt,
       allAttempts: [bestAttempt],
-      timePointsProvisional: best.reachedGoal,
+      // Scores can shift while the task is open — any later upload may move
+      // the best distance or goal-times set and rescore everyone. The upload
+      // path only accepts submissions before close_date, so the task is
+      // necessarily still open here.
+      timePointsProvisional: true,
     },
   });
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -17,7 +17,7 @@ import type { Database } from 'better-sqlite3';
 import { createHash, randomUUID } from 'crypto';
 import type { FastifyReply, FastifyRequest as FastifyRequestBase } from 'fastify';
 import { requireAuth } from './auth';
-import { rebuildTaskResults, type SQLiteJobQueue } from './job-queue';
+import { rebuildTaskResults } from './job-queue';
 import { formatPipelineError, type PipelineInput, runPipeline, type TurnpointDef } from './pipeline';
 
 // =============================================================================
@@ -75,7 +75,6 @@ export async function handleIgcUpload(
   request: FastifyRequestBase<{ Params: UploadRouteParams }>,
   reply: FastifyReply,
   db: Database,
-  queue: SQLiteJobQueue,
 ): Promise<void> {
   requireAuth(request as any, reply);
 

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -9,14 +9,15 @@
 //  - Duplicate detection: SHA-256 of file content; same pilot+task+hash → 409
 //  - IGC stored as BLOB in flight_submissions alongside filename and size
 //  - Scored result written to flight_attempts (one per attempt detected)
-//  - RESCORE_TASK enqueued only when pilot reached goal (time pts provisional)
+//  - task_results rebuilt synchronously inside the upload txn (single source
+//    of truth for scoring); no async rescore jobs are enqueued.
 // =============================================================================
 
 import type { Database } from 'better-sqlite3';
 import { createHash, randomUUID } from 'crypto';
 import type { FastifyReply, FastifyRequest as FastifyRequestBase } from 'fastify';
 import { requireAuth } from './auth';
-import { type RescoreTaskPayload, rebuildTaskResults, type SQLiteJobQueue } from './job-queue';
+import { rebuildTaskResults, type SQLiteJobQueue } from './job-queue';
 import { formatPipelineError, type PipelineInput, runPipeline, type TurnpointDef } from './pipeline';
 
 // =============================================================================
@@ -365,18 +366,11 @@ export async function handleIgcUpload(
     // Link best attempt to submission
     db.prepare(`UPDATE flight_submissions SET best_attempt_id = ? WHERE id = ?`).run(bestAttemptId, submissionId);
 
-    // Immediately materialise task_results for this task so leaderboard is live
+    // Materialise task_results inside the same txn. rebuildTaskResults
+    // re-scores from canonical inputs (best distance, full goal-times set),
+    // so this single call is authoritative — no async rescore needed.
     rebuildTaskResults(db, taskId);
   })();
-
-  // ── Enqueue rescore if goal reached ───────────────────────────────────────
-  if (best.reachedGoal) {
-    queue.enqueue<RescoreTaskPayload>('RESCORE_TASK', {
-      taskId,
-      leagueId: task.league_id,
-      triggeredBySubmissionId: submissionId,
-    });
-  }
 
   // ── Response ───────────────────────────────────────────────────────────────
   const row = db

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -290,4 +290,3 @@ export function createTestTaskResult(
   );
   return id;
 }
-

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -291,37 +291,3 @@ export function createTestTaskResult(
   return id;
 }
 
-export function createTestSeasonStanding(
-  db: Database.Database,
-  seasonId: string,
-  userId: string,
-  leagueId: string,
-  opts: {
-    rank?: number;
-    totalPoints?: number;
-    tasksFlown?: number;
-    tasksWithGoal?: number;
-  } = {},
-) {
-  const id = randomUUID();
-  const now = new Date().toISOString();
-  db.prepare(
-    `INSERT INTO season_standings (
-       id, season_id, user_id,
-       total_points, tasks_flown, tasks_with_goal,
-       rank, last_computed_at, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    seasonId,
-    userId,
-    opts.totalPoints ?? 100,
-    opts.tasksFlown ?? 1,
-    opts.tasksWithGoal ?? 0,
-    opts.rank ?? 1,
-    now,
-    now,
-    now,
-  );
-  return id;
-}

--- a/tests/routes/leagues.test.ts
+++ b/tests/routes/leagues.test.ts
@@ -33,7 +33,7 @@ describe('League Settings API', () => {
     app = Fastify();
     authConfig = loadAuthConfig();
     await app.register(authPlugin, { config: authConfig, db });
-    await registerLeagueRoutes(app, { db, queue: null as any });
+    await registerLeagueRoutes(app, { db });
   });
 
   // ── GET /leagues/:leagueSlug ─────────────────────────────────────────────

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -34,7 +34,7 @@ describe('Season Management API', () => {
     authConfig = loadAuthConfig();
 
     await app.register(authPlugin, { config: authConfig, db });
-    await registerLeagueRoutes(app, { db, queue: null as any });
+    await registerLeagueRoutes(app, { db });
   });
 
   describe('POST /leagues/:slug/seasons', () => {

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -48,7 +48,7 @@ beforeEach(async () => {
 
   app = Fastify();
   await app.register(authPlugin, { config: loadAuthConfig(), db });
-  await registerLeagueRoutes(app, { db, queue: null as any });
+  await registerLeagueRoutes(app, { db });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -405,5 +405,52 @@ describe('rebuildTaskResults', () => {
     expect(byUser.get(pilot3.id).time_points).toBeCloseTo(0, 0); // slowest
     // distance_points are tied at 1000 (all four flew 50km of best=50km).
     for (const r of rows) expect(r.distance_points).toBeCloseTo(1000, 0);
+  });
+
+  // Regression: goalTimes is built per-pilot (fastest), not per-attempt.
+  // A pilot uploading two goal flights for the same task must not contribute
+  // two entries to the goal-time set — that would distort tMin/tMax for
+  // everyone else.
+  it('dedups goal times by pilot when computing time_points', () => {
+    const taskTime = createTestTask(db, season.id, league.id, { name: 'Dedup' });
+    db.prepare(`UPDATE tasks SET normalized_score = 2000 WHERE id = ?`).run(taskTime.id);
+
+    // Pilot A: two goal attempts in one submission — fastest=3600s, slower=4200s.
+    // (Could also be two different submissions; same bug either way since goalTimes
+    // is built from flight_attempts, not submissions.) If we don't dedup,
+    // goalTimes = [3600, 4200, 3000] → tMin=3000, tMax=4200. With dedup,
+    // goalTimes = [3600, 3000] → tMin=3000, tMax=3600.
+    const subA = createTestSubmission(db, taskTime.id, pilot.id, league.id);
+    createTestAttempt(db, subA, taskTime.id, pilot.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 3600,
+      attemptIndex: 0,
+    });
+    createTestAttempt(db, subA, taskTime.id, pilot.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 4200,
+      attemptIndex: 1,
+    });
+    const subB = createTestSubmission(db, taskTime.id, pilot2.id, league.id);
+    createTestAttempt(db, subB, taskTime.id, pilot2.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 3000,
+    });
+
+    rebuildTaskResults(db, taskTime.id);
+
+    const rows = db
+      .prepare('SELECT user_id, time_points FROM task_results WHERE task_id = ?')
+      .all(taskTime.id) as any[];
+    expect(rows).toHaveLength(2);
+    const byUser = new Map(rows.map((r) => [r.user_id, r]));
+    // tMin=3000, tMax=3600 → ratio = (t - 3000) / 600.
+    // Pilot B at 3000: 1000.
+    // Pilot A's *best* is 3600 (slower 4200 is ignored): ratio=1 → 0.
+    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(1000, 0);
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(0, 0);
   });
 });

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -12,7 +12,6 @@ import {
   createTestAttempt,
   createTestLeague,
   createTestSeason,
-  createTestSeasonStanding,
   createTestSubmission,
   createTestTask,
   createTestTaskResult,
@@ -71,17 +70,27 @@ describe('GET standings', () => {
   });
 
   it('returns pilots sorted by rank with correct fields', async () => {
-    createTestSeasonStanding(db, season.id, pilot.id, league.id, {
+    // Seed task_results across two tasks for pilot1, one task for pilot2.
+    // Standings is now a live aggregate over task_results.
+    const task2 = createTestTask(db, season.id, league.id, { name: 'Task 2' });
+    const sub1a = createTestSubmission(db, task.id, pilot.id, league.id);
+    const att1a = createTestAttempt(db, sub1a, task.id, pilot.id, league.id, { reachedGoal: true, taskTimeS: 4200 });
+    createTestTaskResult(db, task.id, pilot.id, league.id, att1a, {
       rank: 1,
-      totalPoints: 800,
-      tasksFlown: 2,
-      tasksWithGoal: 1,
+      reachedGoal: true,
+      totalPoints: 500,
     });
-    createTestSeasonStanding(db, season.id, pilot2.id, league.id, {
+    const sub1b = createTestSubmission(db, task2.id, pilot.id, league.id);
+    const att1b = createTestAttempt(db, sub1b, task2.id, pilot.id, league.id, { reachedGoal: false });
+    createTestTaskResult(db, task2.id, pilot.id, league.id, att1b, {
+      rank: 1,
+      totalPoints: 300,
+    });
+    const sub2a = createTestSubmission(db, task.id, pilot2.id, league.id);
+    const att2a = createTestAttempt(db, sub2a, task.id, pilot2.id, league.id, { reachedGoal: false });
+    createTestTaskResult(db, task.id, pilot2.id, league.id, att2a, {
       rank: 2,
       totalPoints: 500,
-      tasksFlown: 1,
-      tasksWithGoal: 0,
     });
 
     const res = await app.inject({ method: 'GET', url: url(), headers: { 'x-test-user-id': pilot.id } });
@@ -94,13 +103,27 @@ describe('GET standings', () => {
     expect(first.rank).toBe(1);
     expect(first.pilotId).toBe(pilot.id);
     expect(first.pilotName).toBe('Alice Smith');
-    expect(first.totalPoints).toBe(800);
+    expect(first.totalPoints).toBe(800); // 500 + 300
     expect(first.tasksFlown).toBe(2);
     expect(first.tasksWithGoal).toBe(1);
 
     expect(second.rank).toBe(2);
     expect(second.pilotId).toBe(pilot2.id);
     expect(second.totalPoints).toBe(500);
+    expect(second.tasksFlown).toBe(1);
+    expect(second.tasksWithGoal).toBe(0);
+  });
+
+  it('excludes results from soft-deleted tasks', async () => {
+    const taskDeleted = createTestTask(db, season.id, league.id, { name: 'Deleted' });
+    const sub = createTestSubmission(db, taskDeleted.id, pilot.id, league.id);
+    const att = createTestAttempt(db, sub, taskDeleted.id, pilot.id, league.id);
+    createTestTaskResult(db, taskDeleted.id, pilot.id, league.id, att, { totalPoints: 999 });
+    db.prepare(`UPDATE tasks SET deleted_at = datetime('now') WHERE id = ?`).run(taskDeleted.id);
+
+    const res = await app.inject({ method: 'GET', url: url(), headers: { 'x-test-user-id': pilot.id } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).standings).toEqual([]);
   });
 
   it('returns 404 for an unknown season', async () => {
@@ -286,5 +309,101 @@ describe('rebuildTaskResults', () => {
 
     const count = (db.prepare('SELECT COUNT(*) AS c FROM task_results WHERE task_id = ?').get(task.id) as any).c;
     expect(count).toBe(0);
+  });
+
+  // Regression for the stale-distance-points bug: rebuildTaskResults must
+  // re-score from the *current* best distance, not copy whatever was stored
+  // on flight_attempts at submission time.
+  it('rescales distance_points against the current best distance across all attempts', () => {
+    const taskNoNorm = createTestTask(db, season.id, league.id, { name: 'No-norm' });
+    db.prepare(`UPDATE tasks SET normalized_score = NULL WHERE id = ?`).run(taskNoNorm.id);
+
+    const sub1 = createTestSubmission(db, taskNoNorm.id, pilot.id, league.id);
+    const sub2 = createTestSubmission(db, taskNoNorm.id, pilot2.id, league.id);
+    // Pilot A first: 60km, distance_points stored as if they were the best.
+    createTestAttempt(db, sub1, taskNoNorm.id, pilot.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 60,
+      distancePoints: 1000, // stale snapshot — should be ignored
+      totalPoints: 1000,
+    });
+    // Pilot B then beats the best at 80km, also non-goal.
+    createTestAttempt(db, sub2, taskNoNorm.id, pilot2.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 80,
+      distancePoints: 1000,
+      totalPoints: 1000,
+    });
+
+    rebuildTaskResults(db, taskNoNorm.id);
+
+    const rows = db
+      .prepare('SELECT user_id, distance_points, total_points, rank FROM task_results WHERE task_id = ? ORDER BY rank')
+      .all(taskNoNorm.id) as any[];
+    expect(rows).toHaveLength(2);
+    // Pilot B (80km) is the new winner with full distance points.
+    expect(rows[0].user_id).toBe(pilot2.id);
+    expect(rows[0].distance_points).toBeCloseTo(1000, 0);
+    expect(rows[0].total_points).toBeCloseTo(1000, 0);
+    expect(rows[0].rank).toBe(1);
+    // Pilot A (60km) is rescaled against best=80km: 1000 * sqrt(60/80) ≈ 866.
+    expect(rows[1].user_id).toBe(pilot.id);
+    expect(rows[1].distance_points).toBeCloseTo(866, 0);
+    expect(rows[1].total_points).toBeCloseTo(866, 0);
+    expect(rows[1].rank).toBe(2);
+  });
+
+  // Regression for time-point staleness: when a new goal time enters the set,
+  // every goal pilot's time_points must reflect the full updated range.
+  it('rescores time_points across all goal pilots when the goal-times set changes', () => {
+    // normalized_score=2000 matches the unscaled winner total
+    // (distance_points=1000 + time_points=1000 for the fastest pilot),
+    // so the post-rebuild values are the raw computeTimePoints outputs.
+    const taskTime = createTestTask(db, season.id, league.id, { name: 'Time-points' });
+    db.prepare(`UPDATE tasks SET normalized_score = 2000 WHERE id = ?`).run(taskTime.id);
+
+    const pilot3 = createTestUser(db, { email: 'c@test.com', displayName: 'Carol' });
+    const pilot4 = createTestUser(db, { email: 'd@test.com', displayName: 'Dave' });
+    addLeagueMember(db, league.id, pilot3.id, 'pilot');
+    addLeagueMember(db, league.id, pilot4.id, 'pilot');
+
+    // Four goal pilots all at 50km (distance_points tied at 1000).
+    // Times: [3600, 4200, 5400, 3000]. Stored time_points are stale (mimic
+    // what would have been written before pilot4's faster entry).
+    for (const [p, t] of [
+      [pilot, 3600],
+      [pilot2, 4200],
+      [pilot3, 5400],
+      [pilot4, 3000],
+    ] as const) {
+      const sub = createTestSubmission(db, taskTime.id, p.id, league.id);
+      createTestAttempt(db, sub, taskTime.id, p.id, league.id, {
+        reachedGoal: true,
+        distanceFlownKm: 50,
+        taskTimeS: t,
+        distancePoints: 1000,
+        timePoints: 999,
+        totalPoints: 1999,
+      });
+    }
+
+    rebuildTaskResults(db, taskTime.id);
+
+    const rows = db
+      .prepare(
+        'SELECT user_id, distance_points, time_points, total_points, rank FROM task_results WHERE task_id = ? ORDER BY rank',
+      )
+      .all(taskTime.id) as any[];
+    expect(rows).toHaveLength(4);
+
+    // tMin=3000, tMax=5400; ratio = (t - 3000) / 2400.
+    // time_points = 1000 * (1 - ratio^(2/3)).
+    const byUser = new Map(rows.map((r) => [r.user_id, r]));
+    expect(byUser.get(pilot4.id).time_points).toBeCloseTo(1000, 0); // fastest
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(603, 0); // 3600
+    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(370, 0); // 4200
+    expect(byUser.get(pilot3.id).time_points).toBeCloseTo(0, 0); // slowest
+    // distance_points are tied at 1000 (all four flew 50km of best=50km).
+    for (const r of rows) expect(r.distance_points).toBeCloseTo(1000, 0);
   });
 });

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -98,7 +98,7 @@ async function buildTestApp(db: ReturnType<typeof getTestDb>) {
 
   await app.register(import('@fastify/multipart'), { limits: { fileSize: 5 * 1024 * 1024 } });
   await app.register(authPlugin, { config: loadAuthConfig(), db });
-  await registerLeagueRoutes(app, { db, queue: null as any });
+  await registerLeagueRoutes(app, { db });
   await app.ready();
   return app;
 }


### PR DESCRIPTION
## Summary

Production bug: on `https://league.nwparagliding.com/leagues/nwpc` the 2026 season's first task showed `pilotCount: 6` but only 3 pilots in the overall standings. Two bugs share one root cause — *scoring depends on cross-pilot state but was stored in per-pilot rows*:

1. **Stale `distance_points`.** `flight_attempts.distance_points` is `1000 * sqrt(d / bestDistKm)` and depends on the max distance any pilot has flown. It was written once at upload and never re-derived. `rebuildTaskResults` just *copied* those stale values; the post-hoc winner=1000 normalisation didn't recover correctness.
2. **`REBUILD_STANDINGS` gated on goal.** `src/upload.ts` only enqueued `RESCORE_TASK` (which then enqueued `REBUILD_STANDINGS`) when `best.reachedGoal === true`. Non-goal uploads never refreshed `season_standings`.

This PR makes scoring synchronous and authoritative, eliminating the bug class:

- `rebuildTaskResults` re-scores every pilot from canonical inputs (current best distance + full goal-times set) using `computeDistancePoints` / `computeTimePoints`. Runs inside the upload txn — single source of truth, no async rescore.
- Standings endpoint replaced with a live SQL aggregate over `task_results` (joined to non-deleted tasks). Field names preserved; <1ms at our scale.
- Boot backfill rebuilds every non-deleted task once on startup so existing standings self-heal under the new logic. Pending jobs of removed types are cleaned up so the worker doesn't fail-loop them.
- Dead job handlers (`RESCORE_TASK`, `FREEZE_TASK_SCORES`, `REBUILD_STANDINGS`, `NOTIFY_PILOTS`, `REPROCESS_ALL_SUBMISSIONS`) removed. `JobWorker` / `SQLiteJobQueue` stay for future async work.
- Task soft-delete guard on `scores_frozen_at` removed — admin moderation works on closed tasks; standings reflect the deletion via the live aggregate.

This is **PR 1 of 2**. PR 2 will drop the freeze concept end-to-end (`tasks.scores_frozen_at`, `flight_attempts.{distance,time,total}_points`, `season_standings` table) once this lands and is verified.

## Test plan

- [x] `npm test` (190/190 pass locally; includes two new regression tests)
- [x] `npm run typecheck`
- [ ] After deploy: `GET /api/v1/leagues/nwpc/seasons/480da9ad-cd9f-41a9-8164-b4a28d527a2d/standings` should now show 6+ pilots (was 3)
- [ ] After deploy: per-task `pilotCount` should match the standings entry count for affected tasks
- [ ] Non-goal pilots whose previously-stored `distance_points` was relative to a smaller best may see scores drop (e.g. 60km pilot in an 80km-best task: 1000 → 866). Pre-deploy diff recommended; post in the league channel if any individual delta exceeds expectations.

## Notes

- Pre-existing bug surfaced but not fixed here: `src/routes/leagues.ts:298` selects `tr.submitted_at` from `task_results` (no such column) → always `undefined`. Will fix separately.
- Three follow-up issues filed for tangential deletion-side cleanups (orphan turnpoint_crossings, selective submission delete, season-delete cascade).