### PR TITLE
Apply FAI §9.1.3 cylinder tolerance + boot-time IGC reprocess

### DIFF
--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1,11 +1,11 @@
 // =============================================================================
-// Unit tests for pipeline Stage 4 (classifyGroundState).
-// Focuses on the HAF sustained-stillness ground check.
+// Unit tests for pipeline Stage 4 (classifyGroundState) and the §9.1.3
+// cylinder tolerance helper.
 // =============================================================================
 
 import { describe, expect, it } from 'vitest';
 import type { CylinderCrossing, Fix, TaskDefinition } from './pipeline';
-import { classifyGroundState } from './pipeline';
+import { classifyGroundState, SCORER_VERSION, tagToleranceM } from './pipeline';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -167,5 +167,33 @@ describe('classifyGroundState', () => {
     const nonGround: CylinderCrossing = { ...groundCrossing(60_000), groundCheckRequired: false };
     const out = classifyGroundState([], buildAttempt([sssCrossing, nonGround]), 'HIKE_AND_FLY', task);
     expect(out[0].turnpointCrossings[1]).toBe(nonGround);
+  });
+});
+
+// =============================================================================
+// FAI §9.1.3 tolerance: max(5 m, 0.5% × radius). Documents the contract that
+// the detection code in pipeline.ts depends on.
+// =============================================================================
+
+describe('tagToleranceM', () => {
+  it('floors at 5 m for small cylinders', () => {
+    expect(tagToleranceM(200)).toBe(5);
+    expect(tagToleranceM(500)).toBe(5);
+    expect(tagToleranceM(999)).toBe(5);
+    // 1000 m × 0.5% = 5 m exactly — still 5 m at the boundary
+    expect(tagToleranceM(1000)).toBe(5);
+  });
+
+  it('uses 0.5% of radius once it exceeds the floor', () => {
+    expect(tagToleranceM(2000)).toBeCloseTo(10, 9);
+    expect(tagToleranceM(4000)).toBeCloseTo(20, 9);
+    expect(tagToleranceM(10000)).toBeCloseTo(50, 9);
+  });
+});
+
+describe('SCORER_VERSION', () => {
+  it('is set so the boot reprocess loop has a concrete current value to compare', () => {
+    // If you bump the version intentionally, update this expectation.
+    expect(SCORER_VERSION).toBe('1.1');
   });
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -17,6 +17,31 @@ import {
 } from './shared/task-engine';
 
 // =============================================================================
+// SCORER VERSION
+//
+// Bump on any change that affects detection or scoring numbers. The boot
+// re-process loop in src/server.ts re-runs the pipeline against every IGC
+// whose stored flight_attempts.scorer_version differs from this constant.
+// =============================================================================
+
+export const SCORER_VERSION = '1.1';
+
+// =============================================================================
+// FAI §9.1.3 cylinder tolerance
+//
+// "Tolerance is applied separately to the straight portion and to the
+// semi-circle." Standard practice across FAI scoring tools is 0.5% of the
+// radius with a minimum of 5 m. The boundary effectively shifts outward by
+// `tagToleranceM(r)` — a fix at distance ≤ r + tolerance is considered
+// inside. The optimised-route geometry continues to use the strict radius;
+// tolerance only governs whether a track tags the cylinder.
+// =============================================================================
+
+export function tagToleranceM(radiusM: number): number {
+  return Math.max(5, radiusM * 0.005);
+}
+
+// =============================================================================
 // SHARED TYPES
 // =============================================================================
 
@@ -285,7 +310,13 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
   const sss = task.turnpoints[0];
 
   // ── Step 1: Find all SSS outward crossings ──────────────────────────────────
+  // FAI Sporting Code S7F §9.1.3 tolerance: a fix at distance d from the
+  // cylinder centre is "inside" iff d ≤ r + tolerance. The boundary effectively
+  // shifts outward by `tolerance(r)`. For SSS this means the exit gate widens
+  // — pilots get the benefit of the doubt that they are still inside near the
+  // boundary.
   const sssCrossings: Array<{ fixIndex: number; t: number; crossingTime: number }> = [];
+  const sssEffectiveR = sss.radiusM + tagToleranceM(sss.radiusM);
 
   for (let i = 0; i < fixes.length - 1; i++) {
     const a = fixes[i];
@@ -295,9 +326,9 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
     const distA = Math.sqrt(aLocal.x ** 2 + aLocal.y ** 2);
     const distB = Math.sqrt(bLocal.x ** 2 + bLocal.y ** 2);
 
-    // Outward: inside → outside
-    if (distA <= sss.radiusM && distB > sss.radiusM) {
-      const t = segmentIntersectsCircle(aLocal, bLocal, sss.radiusM);
+    // Outward: inside → outside (against the effective boundary)
+    if (distA <= sssEffectiveR && distB > sssEffectiveR) {
+      const t = segmentIntersectsCircle(aLocal, bLocal, sssEffectiveR);
       if (t !== null) {
         sssCrossings.push({ fixIndex: i, t, crossingTime: interpolateCrossingTime(a, b, t) });
       }
@@ -369,21 +400,28 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
       let crossed = false;
       let crossT: number | null = null;
 
+      // Apply FAI §9.1.3 tolerance to the inward tag detection. The boundary
+      // is treated as r + tolerance for the in/out check; the optimised route
+      // and partial-distance geometry continue to use the strict radius.
+      const effectiveR = tp.radiusM + tagToleranceM(tp.radiusM);
+
       if (tp.type === 'GOAL_LINE' && cachedGoalBearing != null) {
         const bearingDeg = cachedGoalBearing;
-        const tChord = segmentIntersectsGoalLine(aLocal, bLocal, { x: 0, y: 0 }, tp.radiusM, bearingDeg);
-        const tArc = segmentEntersGoalSemiCircle(aLocal, bLocal, { x: 0, y: 0 }, tp.radiusM, bearingDeg);
+        // Per §9.1.3 tolerance applies separately to the chord and the
+        // semi-circle; we widen both by the same tolerance value.
+        const tChord = segmentIntersectsGoalLine(aLocal, bLocal, { x: 0, y: 0 }, effectiveR, bearingDeg);
+        const tArc = segmentEntersGoalSemiCircle(aLocal, bLocal, { x: 0, y: 0 }, effectiveR, bearingDeg);
         if (tChord !== null || tArc !== null) {
           crossT = Math.min(tChord !== null ? tChord : Infinity, tArc !== null ? tArc : Infinity);
           crossed = true;
         }
-      } else if (distA < tp.radiusM) {
-        // Already inside this cylinder — count as immediately achieved
+      } else if (distA < effectiveR) {
+        // Already inside this cylinder (within tolerance) — immediately tagged
         crossT = 0;
         crossed = true;
       } else {
         // Look for inward crossing (outside → inside, or graze-through)
-        const t = segmentIntersectsCircle(aLocal, bLocal, tp.radiusM);
+        const t = segmentIntersectsCircle(aLocal, bLocal, effectiveR);
         if (t !== null) {
           crossT = t;
           crossed = true;
@@ -679,8 +717,12 @@ export function classifyGroundState(
       if (!tp) return { ...crossing, groundConfirmed: false };
 
       // Fixes that are geographically inside the cylinder after the crossing.
+      // Use the same effective radius as the tag-detection step so a pilot
+      // who tagged "within tolerance" has their fixes counted for the
+      // ground-state check too.
+      const groundCheckR = tp.radiusM + tagToleranceM(tp.radiusM);
       const insideFixes = fixes.filter(
-        (f) => f.timestamp >= crossing.crossingTime && fixDistanceToTpM(f, tp) <= tp.radiusM,
+        (f) => f.timestamp >= crossing.crossingTime && fixDistanceToTpM(f, tp) <= groundCheckR,
       );
 
       // Slowest observed ground speed — informational, stored on the crossing.

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -312,9 +312,9 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
   // ── Step 1: Find all SSS outward crossings ──────────────────────────────────
   // FAI Sporting Code S7F §9.1.3 tolerance: a fix at distance d from the
   // cylinder centre is "inside" iff d ≤ r + tolerance. The boundary effectively
-  // shifts outward by `tolerance(r)`. For SSS this means the exit gate widens
-  // — pilots get the benefit of the doubt that they are still inside near the
-  // boundary.
+  // shifts outward by `tagToleranceM(r)`. For SSS this means the exit gate
+  // widens — pilots get the benefit of the doubt that they are still inside
+  // near the boundary.
   const sssCrossings: Array<{ fixIndex: number; t: number; crossingTime: number }> = [];
   const sssEffectiveR = sss.radiusM + tagToleranceM(sss.radiusM);
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -571,38 +571,20 @@ export function segmentIntersectsGoalLine(
 }
 
 /**
- * Closest distance from a point to a finite line segment, plus the
- * parametric position [0,1] along that segment of the foot of the
- * perpendicular (clamped to the endpoints).
- */
-function pointToSegmentDistAndT(p: Point2D, segA: Point2D, segB: Point2D): { dist: number; tOnSeg: number } {
-  const dx = segB.x - segA.x;
-  const dy = segB.y - segA.y;
-  const lenSq = dx * dx + dy * dy;
-  if (lenSq < 1e-10) {
-    return { dist: Math.hypot(p.x - segA.x, p.y - segA.y), tOnSeg: 0 };
-  }
-  const tRaw = ((p.x - segA.x) * dx + (p.y - segA.y) * dy) / lenSq;
-  const tClamped = Math.max(0, Math.min(1, tRaw));
-  const cx = segA.x + tClamped * dx;
-  const cy = segA.y + tClamped * dy;
-  return { dist: Math.hypot(p.x - cx, p.y - cy), tOnSeg: tClamped };
-}
-
-/**
- * Does segment A→B come within `toleranceM` of the goal-line chord?
+ * Does segment A→B enter the goal-line "stadium"?
  *
  * Per FAI §9.1.3 the chord gets its own benefit-of-doubt tolerance applied
  * separately from the semi-circle. Treating that tolerance as a perpendicular
  * thickness — i.e. the chord becomes a "stadium" (chord segment Minkowski-
- * summed with a disk of radius toleranceM) — handles two cases the bare
+ * summed with a disk of radius toleranceM) — handles two cases that bare
  * line-line intersection misses:
  *   - a track segment ending just short of the chord (GPS noise)
  *   - a track segment passing parallel to the chord at < tolerance offset.
  *
- * Returns the parametric t ∈ [0,1] on segment A→B at the closest approach
- * (or the intersection itself), or null if no point on A→B is within
- * tolerance of the chord.
+ * Returns the smallest t ∈ [0,1] on A→B at which the segment first enters
+ * the stadium (matching the entry-time semantics of `segmentIntersectsCircle`
+ * and `segmentEntersGoalSemiCircle`), or null if no point on A→B is within
+ * tolerance of the chord. Returns 0 if A is already inside the stadium.
  */
 export function segmentNearGoalLine(
   a: Point2D,
@@ -612,36 +594,82 @@ export function segmentNearGoalLine(
   bearingDeg: number,
   toleranceM: number,
 ): number | null {
-  // Fast path: actual crossing of the chord (tolerance irrelevant).
-  const tIntersect = segmentIntersectsGoalLine(a, b, lineMidpoint, halfLengthM, bearingDeg);
-  if (tIntersect !== null) return tIntersect;
-
-  // Build chord endpoints (same as inside segmentIntersectsGoalLine).
+  // Rotate into a local frame where the chord lies along the x-axis from
+  // (-L, 0) to (+L, 0). Bearing is clockwise from north → chord direction
+  // unit vector is (sin, cos); the perpendicular (rotated -90° so positive
+  // y is "right of the chord direction") is (cos, -sin).
   const rad = (bearingDeg * Math.PI) / 180;
-  const dx = Math.sin(rad) * halfLengthM;
-  const dy = Math.cos(rad) * halfLengthM;
-  const p1: Point2D = { x: lineMidpoint.x - dx, y: lineMidpoint.y - dy };
-  const p2: Point2D = { x: lineMidpoint.x + dx, y: lineMidpoint.y + dy };
+  const ux = Math.sin(rad);
+  const uy = Math.cos(rad);
+  const px = uy;
+  const py = -ux;
+  const toLocal = (pt: Point2D): Point2D => {
+    const dx = pt.x - lineMidpoint.x;
+    const dy = pt.y - lineMidpoint.y;
+    return { x: dx * ux + dy * uy, y: dx * px + dy * py };
+  };
 
-  // Min distance between two non-intersecting segments lives at one of the
-  // four endpoint-to-other-segment distances. Pick the smallest one whose
-  // distance is within tolerance, and use its t-on-AB for time interpolation.
-  const candidates: Array<{ dist: number; tOnAB: number }> = [
-    { dist: pointToSegmentDistAndT(a, p1, p2).dist, tOnAB: 0 },
-    { dist: pointToSegmentDistAndT(b, p1, p2).dist, tOnAB: 1 },
-  ];
-  const fromP1 = pointToSegmentDistAndT(p1, a, b);
-  candidates.push({ dist: fromP1.dist, tOnAB: fromP1.tOnSeg });
-  const fromP2 = pointToSegmentDistAndT(p2, a, b);
-  candidates.push({ dist: fromP2.dist, tOnAB: fromP2.tOnSeg });
+  const A = toLocal(a);
+  const B = toLocal(b);
+  const L = halfLengthM;
+  const tol = toleranceM;
+  const tol2 = tol * tol;
 
-  let best: { dist: number; tOnAB: number } | null = null;
-  for (const c of candidates) {
-    if (c.dist <= toleranceM && (best === null || c.dist < best.dist)) {
-      best = c;
+  // The stadium = {(x, y) | distance((x, y), chord segment) ≤ tol}, which
+  // decomposes into a 2L × 2*tol rectangle plus two end-cap disks of
+  // radius tol centred at (±L, 0).
+  const insideStadium = (p: Point2D): boolean => {
+    if (Math.abs(p.x) <= L) return Math.abs(p.y) <= tol;
+    const dxCap = p.x > L ? p.x - L : p.x + L;
+    return dxCap * dxCap + p.y * p.y <= tol2;
+  };
+
+  if (insideStadium(A)) return 0;
+
+  // Collect every t ∈ [0,1] at which AB crosses the stadium boundary, then
+  // return the earliest. The boundary has 4 pieces:
+  //   - top edge:    y = +tol, |x| ≤ L
+  //   - bottom edge: y = -tol, |x| ≤ L
+  //   - right cap:   (x - L)² + y² = tol², x ≥ L
+  //   - left cap:    (x + L)² + y² = tol², x ≤ -L
+  const dxAB = B.x - A.x;
+  const dyAB = B.y - A.y;
+  const candidates: number[] = [];
+
+  // Top / bottom edges
+  if (dyAB !== 0) {
+    for (const yEdge of [tol, -tol]) {
+      const t = (yEdge - A.y) / dyAB;
+      if (t < 0 || t > 1) continue;
+      const xAtT = A.x + t * dxAB;
+      if (xAtT >= -L && xAtT <= L) candidates.push(t);
     }
   }
-  return best?.tOnAB ?? null;
+
+  // End caps (right at x = L, left at x = -L)
+  const a2 = dxAB * dxAB + dyAB * dyAB;
+  if (a2 >= 1e-12) {
+    for (const xCenter of [-L, L]) {
+      const b2 = 2 * ((A.x - xCenter) * dxAB + A.y * dyAB);
+      const c2 = (A.x - xCenter) * (A.x - xCenter) + A.y * A.y - tol2;
+      const disc = b2 * b2 - 4 * a2 * c2;
+      if (disc < 0) continue;
+      const sqd = Math.sqrt(disc);
+      for (const t of [(-b2 - sqd) / (2 * a2), (-b2 + sqd) / (2 * a2)]) {
+        if (t < 0 || t > 1) continue;
+        const xAtT = A.x + t * dxAB;
+        // Only count the part of each disk that lives outside the rectangle —
+        // the half inside is already covered by the top/bottom edges and
+        // counting it would yield a t past the actual boundary.
+        if (xCenter === -L && xAtT > -L) continue;
+        if (xCenter === L && xAtT < L) continue;
+        candidates.push(t);
+      }
+    }
+  }
+
+  if (candidates.length === 0) return null;
+  return Math.min(...candidates);
 }
 
 /**

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -403,13 +403,16 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
       // Apply FAI §9.1.3 tolerance to the inward tag detection. The boundary
       // is treated as r + tolerance for the in/out check; the optimised route
       // and partial-distance geometry continue to use the strict radius.
-      const effectiveR = tp.radiusM + tagToleranceM(tp.radiusM);
+      const tolerance = tagToleranceM(tp.radiusM);
+      const effectiveR = tp.radiusM + tolerance;
 
       if (tp.type === 'GOAL_LINE' && cachedGoalBearing != null) {
         const bearingDeg = cachedGoalBearing;
         // Per §9.1.3 tolerance applies separately to the chord and the
-        // semi-circle; we widen both by the same tolerance value.
-        const tChord = segmentIntersectsGoalLine(aLocal, bLocal, { x: 0, y: 0 }, effectiveR, bearingDeg);
+        // semi-circle. The chord gets a perpendicular "stadium" thickness
+        // of `tolerance` (segmentNearGoalLine); the semi-circle gets the
+        // same tolerance as a radius extension (effectiveR).
+        const tChord = segmentNearGoalLine(aLocal, bLocal, { x: 0, y: 0 }, tp.radiusM, bearingDeg, tolerance);
         const tArc = segmentEntersGoalSemiCircle(aLocal, bLocal, { x: 0, y: 0 }, effectiveR, bearingDeg);
         if (tChord !== null || tArc !== null) {
           crossT = Math.min(tChord !== null ? tChord : Infinity, tArc !== null ? tArc : Infinity);
@@ -565,6 +568,80 @@ export function segmentIntersectsGoalLine(
 
   if (t >= 0 && t <= 1 && u >= 0 && u <= 1) return t;
   return null;
+}
+
+/**
+ * Closest distance from a point to a finite line segment, plus the
+ * parametric position [0,1] along that segment of the foot of the
+ * perpendicular (clamped to the endpoints).
+ */
+function pointToSegmentDistAndT(p: Point2D, segA: Point2D, segB: Point2D): { dist: number; tOnSeg: number } {
+  const dx = segB.x - segA.x;
+  const dy = segB.y - segA.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq < 1e-10) {
+    return { dist: Math.hypot(p.x - segA.x, p.y - segA.y), tOnSeg: 0 };
+  }
+  const tRaw = ((p.x - segA.x) * dx + (p.y - segA.y) * dy) / lenSq;
+  const tClamped = Math.max(0, Math.min(1, tRaw));
+  const cx = segA.x + tClamped * dx;
+  const cy = segA.y + tClamped * dy;
+  return { dist: Math.hypot(p.x - cx, p.y - cy), tOnSeg: tClamped };
+}
+
+/**
+ * Does segment A→B come within `toleranceM` of the goal-line chord?
+ *
+ * Per FAI §9.1.3 the chord gets its own benefit-of-doubt tolerance applied
+ * separately from the semi-circle. Treating that tolerance as a perpendicular
+ * thickness — i.e. the chord becomes a "stadium" (chord segment Minkowski-
+ * summed with a disk of radius toleranceM) — handles two cases the bare
+ * line-line intersection misses:
+ *   - a track segment ending just short of the chord (GPS noise)
+ *   - a track segment passing parallel to the chord at < tolerance offset.
+ *
+ * Returns the parametric t ∈ [0,1] on segment A→B at the closest approach
+ * (or the intersection itself), or null if no point on A→B is within
+ * tolerance of the chord.
+ */
+export function segmentNearGoalLine(
+  a: Point2D,
+  b: Point2D,
+  lineMidpoint: Point2D,
+  halfLengthM: number,
+  bearingDeg: number,
+  toleranceM: number,
+): number | null {
+  // Fast path: actual crossing of the chord (tolerance irrelevant).
+  const tIntersect = segmentIntersectsGoalLine(a, b, lineMidpoint, halfLengthM, bearingDeg);
+  if (tIntersect !== null) return tIntersect;
+
+  // Build chord endpoints (same as inside segmentIntersectsGoalLine).
+  const rad = (bearingDeg * Math.PI) / 180;
+  const dx = Math.sin(rad) * halfLengthM;
+  const dy = Math.cos(rad) * halfLengthM;
+  const p1: Point2D = { x: lineMidpoint.x - dx, y: lineMidpoint.y - dy };
+  const p2: Point2D = { x: lineMidpoint.x + dx, y: lineMidpoint.y + dy };
+
+  // Min distance between two non-intersecting segments lives at one of the
+  // four endpoint-to-other-segment distances. Pick the smallest one whose
+  // distance is within tolerance, and use its t-on-AB for time interpolation.
+  const candidates: Array<{ dist: number; tOnAB: number }> = [
+    { dist: pointToSegmentDistAndT(a, p1, p2).dist, tOnAB: 0 },
+    { dist: pointToSegmentDistAndT(b, p1, p2).dist, tOnAB: 1 },
+  ];
+  const fromP1 = pointToSegmentDistAndT(p1, a, b);
+  candidates.push({ dist: fromP1.dist, tOnAB: fromP1.tOnSeg });
+  const fromP2 = pointToSegmentDistAndT(p2, a, b);
+  candidates.push({ dist: fromP2.dist, tOnAB: fromP2.tOnSeg });
+
+  let best: { dist: number; tOnAB: number } | null = null;
+  for (const c of candidates) {
+    if (c.dist <= toleranceM && (best === null || c.dist < best.dist)) {
+      best = c;
+    }
+  }
+  return best?.tOnAB ?? null;
 }
 
 /**

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -415,8 +415,9 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
           crossT = Math.min(tChord !== null ? tChord : Infinity, tArc !== null ? tArc : Infinity);
           crossed = true;
         }
-      } else if (distA < effectiveR) {
-        // Already inside this cylinder (within tolerance) — immediately tagged
+      } else if (distA <= effectiveR) {
+        // Already inside this cylinder (within tolerance) — immediately tagged.
+        // §9.1.3 contract: a fix at distance d is "inside" iff d ≤ r + tolerance.
         crossT = 0;
         crossed = true;
       } else {

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -57,14 +57,12 @@ export async function reprocessStaleSubmissions(db: Database): Promise<{ reproce
     `[reprocess] re-running pipeline against ${stale.length} submissions for SCORER_VERSION=${SCORER_VERSION}`,
   );
 
-  const affectedTasks = new Set<string>();
   let reprocessed = 0;
   let failed = 0;
 
   for (const sub of stale) {
     try {
       await reprocessOne(db, sub);
-      affectedTasks.add(sub.task_id);
       reprocessed++;
     } catch (err) {
       // Log and skip: a single bad IGC must not block the rest of the boot.
@@ -73,15 +71,11 @@ export async function reprocessStaleSubmissions(db: Database): Promise<{ reproce
     }
   }
 
-  for (const taskId of affectedTasks) {
-    try {
-      rebuildTaskResults(db, taskId);
-    } catch (err) {
-      console.error(`[reprocess] rebuildTaskResults failed for task ${taskId}:`, err);
-    }
-  }
-
-  console.log(`[reprocess] done: ${reprocessed} re-scored, ${failed} failed, ${affectedTasks.size} tasks touched`);
+  // No post-loop rebuildTaskResults needed: each reprocessOne rebuilds
+  // task_results inside its own transaction (required for FK ordering — see
+  // comment in reprocessOne), and server.ts boot sweeps rebuildTaskResults
+  // for every non-deleted task immediately after this returns.
+  console.log(`[reprocess] done: ${reprocessed} re-scored, ${failed} failed`);
   return { reprocessed, failed };
 }
 
@@ -163,9 +157,17 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
   const nowIso = new Date().toISOString();
 
   db.transaction(() => {
-    // Drop old attempt + crossing rows for this submission. flight_attempts
-    // has soft-delete but the upload path overwrites in place; do the same
-    // here. turnpoint_crossings has no soft-delete column so hard-delete.
+    // Drop task_results for this task FIRST. Without this the next DELETE
+    // FROM flight_attempts trips the FK constraint
+    //   task_results.best_attempt_id REFERENCES flight_attempts(id)
+    // because the cached task_results row still points at the old attempt.
+    // The rebuildTaskResults call at the end of this txn re-creates
+    // task_results from the new flight_attempts.
+    db.prepare(`DELETE FROM task_results WHERE task_id = ?`).run(sub.task_id);
+
+    // Drop old attempt + crossing rows for this submission. turnpoint_crossings
+    // has no soft-delete column so hard-delete; flight_attempts has one but
+    // the upload path overwrites in place — do the same here.
     db.prepare(
       `DELETE FROM turnpoint_crossings
        WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
@@ -237,5 +239,11 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
       nowIso,
       sub.id,
     );
+
+    // Re-create task_results for this task from the new flight_attempts,
+    // inside the same txn so the FK constraint stays satisfied at commit.
+    // better-sqlite3 transactions are reentrant via savepoints, so the
+    // nested rebuildTaskResults transaction is safe here.
+    rebuildTaskResults(db, sub.task_id);
   })();
 }

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -1,0 +1,241 @@
+// =============================================================================
+// Reprocess existing IGC submissions against the current pipeline.
+//
+// Triggered at boot when any flight_attempts.scorer_version differs from the
+// pipeline's current SCORER_VERSION constant. Re-parses each affected IGC
+// blob, replaces its flight_attempts + turnpoint_crossings rows, and rebuilds
+// the touched tasks' task_results. All writes per-submission are inside a
+// transaction so a parse failure on one IGC leaves the rest intact.
+// =============================================================================
+
+import type { Database } from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import { rebuildTaskResults } from './job-queue';
+import { type PipelineInput, runPipeline, SCORER_VERSION, type TurnpointDef } from './pipeline';
+
+interface SubmissionRow {
+  id: string;
+  task_id: string;
+  user_id: string;
+  league_id: string;
+  igc_data: Buffer;
+}
+
+interface TaskConfigRow {
+  id: string;
+  open_date: string;
+  close_date: string;
+  competition_type: string;
+}
+
+interface TurnpointRow {
+  id: string;
+  sequence_index: number;
+  latitude: number;
+  longitude: number;
+  radius_m: number;
+  type: string;
+  force_ground: number;
+  goal_line_bearing_deg: number | null;
+}
+
+export async function reprocessStaleSubmissions(db: Database): Promise<{ reprocessed: number; failed: number }> {
+  // Distinct submissions whose flight_attempts are at an older scorer version.
+  // Soft-deleted submissions/attempts are excluded.
+  const stale = db
+    .prepare(
+      `SELECT DISTINCT fs.id, fs.task_id, fs.user_id, fs.league_id, fs.igc_data
+       FROM flight_submissions fs
+       JOIN flight_attempts fa ON fa.submission_id = fs.id
+       WHERE fa.scorer_version != ? AND fs.deleted_at IS NULL AND fa.deleted_at IS NULL`,
+    )
+    .all(SCORER_VERSION) as SubmissionRow[];
+
+  if (stale.length === 0) return { reprocessed: 0, failed: 0 };
+
+  console.log(
+    `[reprocess] re-running pipeline against ${stale.length} submissions for SCORER_VERSION=${SCORER_VERSION}`,
+  );
+
+  const affectedTasks = new Set<string>();
+  let reprocessed = 0;
+  let failed = 0;
+
+  for (const sub of stale) {
+    try {
+      await reprocessOne(db, sub);
+      affectedTasks.add(sub.task_id);
+      reprocessed++;
+    } catch (err) {
+      // Log and skip: a single bad IGC must not block the rest of the boot.
+      console.error(`[reprocess] failed for submission ${sub.id}:`, err instanceof Error ? err.message : err);
+      failed++;
+    }
+  }
+
+  for (const taskId of affectedTasks) {
+    try {
+      rebuildTaskResults(db, taskId);
+    } catch (err) {
+      console.error(`[reprocess] rebuildTaskResults failed for task ${taskId}:`, err);
+    }
+  }
+
+  console.log(`[reprocess] done: ${reprocessed} re-scored, ${failed} failed, ${affectedTasks.size} tasks touched`);
+  return { reprocessed, failed };
+}
+
+async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
+  const task = db
+    .prepare(
+      `SELECT t.id, t.open_date, t.close_date, s.competition_type
+       FROM tasks t JOIN seasons s ON s.id = t.season_id
+       WHERE t.id = ? AND t.deleted_at IS NULL`,
+    )
+    .get(sub.task_id) as TaskConfigRow | undefined;
+  if (!task) throw new Error(`task ${sub.task_id} missing or deleted`);
+
+  const turnpointRows = db
+    .prepare(
+      `SELECT id, sequence_index, latitude, longitude, radius_m, type, force_ground, goal_line_bearing_deg
+       FROM turnpoints WHERE task_id = ? AND deleted_at IS NULL ORDER BY sequence_index ASC`,
+    )
+    .all(sub.task_id) as TurnpointRow[];
+  if (turnpointRows.length < 2) throw new Error(`task ${sub.task_id} has fewer than 2 turnpoints`);
+
+  const turnpointDefs: TurnpointDef[] = turnpointRows.map((tp) => ({
+    id: tp.id,
+    sequenceIndex: tp.sequence_index,
+    lat: tp.latitude,
+    lng: tp.longitude,
+    radiusM: tp.radius_m,
+    type: tp.type as TurnpointDef['type'],
+    forceGround: tp.force_ground === 1,
+    goalLineBearingDeg: tp.goal_line_bearing_deg ?? undefined,
+  }));
+
+  // Goal times from *other* submissions on the same task — needed for time-points
+  // scoring, even though rebuildTaskResults will overwrite the score columns.
+  const otherGoalTimes = db
+    .prepare(
+      `SELECT task_time_s FROM flight_attempts
+       WHERE task_id = ? AND submission_id != ?
+         AND reached_goal = 1 AND task_time_s IS NOT NULL AND deleted_at IS NULL`,
+    )
+    .all(sub.task_id, sub.id) as Array<{ task_time_s: number }>;
+  const existingGoalTimes = otherGoalTimes.map((r) => r.task_time_s);
+
+  const otherBest = db
+    .prepare(
+      `SELECT MAX(distance_flown_km) AS best FROM flight_attempts
+       WHERE task_id = ? AND submission_id != ? AND deleted_at IS NULL`,
+    )
+    .get(sub.task_id, sub.id) as { best: number | null };
+  const taskBestDistanceKm = otherBest.best ?? 0;
+
+  const input: PipelineInput = {
+    igcText: sub.igc_data.toString('utf8'),
+    task: { id: sub.task_id, turnpoints: turnpointDefs, closeDate: new Date(task.close_date).getTime() },
+    existingGoalTimes,
+    competitionType: task.competition_type === 'HIKE_AND_FLY' ? 'HIKE_AND_FLY' : 'XC',
+  };
+
+  // scoresFrozenAt = null: re-processing should not be blocked by freeze state
+  // (the original upload already passed the gate; we're only re-scoring).
+  const result = await runPipeline(
+    input,
+    task.open_date.slice(0, 10),
+    task.close_date.slice(0, 10),
+    null,
+    taskBestDistanceKm,
+  );
+  if (!result.ok) {
+    // The original upload succeeded against the prior scorer; failure here
+    // means the IGC is somehow incompatible with the current code (e.g. a
+    // header parser tightened). Skip without modifying stored data so the
+    // pilot's existing flight_attempts stay intact.
+    throw new Error(`pipeline rejected IGC: ${result.error.stage}/${(result.error.error as { code: string }).code}`);
+  }
+
+  const { scoredAttempts, bestAttemptIndex } = result.value;
+  const attemptIds = scoredAttempts.map(() => randomUUID());
+  const bestAttemptId = attemptIds[bestAttemptIndex];
+  const nowIso = new Date().toISOString();
+
+  db.transaction(() => {
+    // Drop old attempt + crossing rows for this submission. flight_attempts
+    // has soft-delete but the upload path overwrites in place; do the same
+    // here. turnpoint_crossings has no soft-delete column so hard-delete.
+    db.prepare(
+      `DELETE FROM turnpoint_crossings
+       WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
+    ).run(sub.id);
+    db.prepare(`DELETE FROM flight_attempts WHERE submission_id = ?`).run(sub.id);
+
+    for (let i = 0; i < scoredAttempts.length; i++) {
+      const attempt = scoredAttempts[i];
+      const attemptId = attemptIds[i];
+      const sssTs = new Date(attempt.sssCrossing.crossingTime).toISOString();
+      const essTs = attempt.essCrossing ? new Date(attempt.essCrossing.crossingTime).toISOString() : null;
+      const goalTs = attempt.goalCrossing ? new Date(attempt.goalCrossing.crossingTime).toISOString() : null;
+
+      db.prepare(
+        `INSERT INTO flight_attempts (
+          id, submission_id, task_id, user_id,
+          sss_crossing_time, ess_crossing_time, goal_crossing_time, task_time_s,
+          reached_goal, last_turnpoint_index,
+          distance_flown_km, distance_points, time_points, total_points,
+          has_flagged_crossings, attempt_index, scorer_version,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        attemptId,
+        sub.id,
+        sub.task_id,
+        sub.user_id,
+        sssTs,
+        essTs,
+        goalTs,
+        attempt.taskTimeS !== null ? Math.round(attempt.taskTimeS) : null,
+        attempt.reachedGoal ? 1 : 0,
+        attempt.lastTurnpointIndex,
+        attempt.distanceFlownKm,
+        attempt.distancePoints,
+        attempt.timePoints,
+        attempt.totalPoints,
+        attempt.hasFlaggedCrossings ? 1 : 0,
+        attempt.attemptIndex,
+        SCORER_VERSION,
+        nowIso,
+        nowIso,
+      );
+
+      for (const crossing of attempt.turnpointCrossings) {
+        db.prepare(
+          `INSERT INTO turnpoint_crossings (
+            id, attempt_id, turnpoint_id, sequence_index, crossing_time,
+            ground_check_required, ground_confirmed, detected_max_speed_kmh,
+            created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          randomUUID(),
+          attemptId,
+          crossing.turnpointId,
+          crossing.sequenceIndex,
+          new Date(crossing.crossingTime).toISOString(),
+          crossing.groundCheckRequired ? 1 : 0,
+          crossing.groundConfirmed ? 1 : 0,
+          crossing.detectedMaxSpeedKmh,
+          nowIso,
+          nowIso,
+        );
+      }
+    }
+
+    db.prepare(`UPDATE flight_submissions SET best_attempt_id = ?, updated_at = ? WHERE id = ?`).run(
+      bestAttemptId,
+      nowIso,
+      sub.id,
+    );
+  })();
+}

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -41,14 +41,22 @@ interface TurnpointRow {
 }
 
 export async function reprocessStaleSubmissions(db: Database): Promise<{ reprocessed: number; failed: number }> {
-  // Distinct submissions whose flight_attempts are at an older scorer version.
-  // Soft-deleted submissions/attempts are excluded.
+  // Submissions whose flight_attempts are at an older scorer version.
+  // Soft-deleted submissions/attempts are excluded. Use EXISTS rather than
+  // a JOIN + SELECT DISTINCT so SQLite de-dupes on the submission id alone
+  // — a JOIN would force the planner to compare full igc_data BLOBs to
+  // collapse the per-attempt rows.
   const stale = db
     .prepare(
-      `SELECT DISTINCT fs.id, fs.task_id, fs.user_id, fs.league_id, fs.igc_data
+      `SELECT fs.id, fs.task_id, fs.user_id, fs.league_id, fs.igc_data
        FROM flight_submissions fs
-       JOIN flight_attempts fa ON fa.submission_id = fs.id
-       WHERE fa.scorer_version != ? AND fs.deleted_at IS NULL AND fa.deleted_at IS NULL`,
+       WHERE fs.deleted_at IS NULL
+         AND EXISTS (
+           SELECT 1 FROM flight_attempts fa
+           WHERE fa.submission_id = fs.id
+             AND fa.scorer_version != ?
+             AND fa.deleted_at IS NULL
+         )`,
     )
     .all(SCORER_VERSION) as SubmissionRow[];
 

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -3,14 +3,15 @@
 //
 // Triggered at boot when any flight_attempts.scorer_version differs from the
 // pipeline's current SCORER_VERSION constant. Re-parses each affected IGC
-// blob, replaces its flight_attempts + turnpoint_crossings rows, and rebuilds
-// the touched tasks' task_results. All writes per-submission are inside a
-// transaction so a parse failure on one IGC leaves the rest intact.
+// blob and replaces its flight_attempts + turnpoint_crossings rows. The
+// boot-time task_results sweep in server.ts runs immediately afterward and
+// re-derives per-task scores once over the new full attempt set. All writes
+// per-submission are inside a transaction so a failure on one IGC leaves
+// the rest intact.
 // =============================================================================
 
 import type { Database } from 'better-sqlite3';
 import { randomUUID } from 'crypto';
-import { rebuildTaskResults } from './job-queue';
 import { type PipelineInput, runPipeline, SCORER_VERSION, type TurnpointDef } from './pipeline';
 
 interface SubmissionRow {
@@ -71,10 +72,9 @@ export async function reprocessStaleSubmissions(db: Database): Promise<{ reproce
     }
   }
 
-  // No post-loop rebuildTaskResults needed: each reprocessOne rebuilds
-  // task_results inside its own transaction (required for FK ordering — see
-  // comment in reprocessOne), and server.ts boot sweeps rebuildTaskResults
-  // for every non-deleted task immediately after this returns.
+  // No post-loop rebuildTaskResults needed: server.ts boot sweeps
+  // rebuildTaskResults for every non-deleted task immediately after this
+  // returns, which is the single point that re-derives task_results.
   console.log(`[reprocess] done: ${reprocessed} re-scored, ${failed} failed`);
   return { reprocessed, failed };
 }
@@ -108,8 +108,26 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
     goalLineBearingDeg: tp.goal_line_bearing_deg ?? undefined,
   }));
 
-  // Goal times from *other* submissions on the same task — needed for time-points
-  // scoring, even though rebuildTaskResults will overwrite the score columns.
+  // turnpoint_overrides has hard FKs to crossings/attempts with no
+  // ON DELETE CASCADE — if any exist for this submission we'd trip the FK
+  // mid-txn and abort. Overrides are immutable audit records, so the
+  // correct behaviour is to skip and surface them for manual reconciliation
+  // rather than silently rewrite the world out from under the audit row.
+  const hasOverrides = db
+    .prepare(
+      `SELECT 1 FROM turnpoint_overrides
+       WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)
+       LIMIT 1`,
+    )
+    .get(sub.id);
+  if (hasOverrides) {
+    throw new Error(`submission has turnpoint_overrides — manual reconciliation required`);
+  }
+
+  // Goal times from *other* submissions on the same task — needed by the
+  // pipeline's time-points calculation when scoring this submission's
+  // attempts. The boot-time task_results sweep in server.ts re-derives
+  // per-task scores afterward from the full attempt set.
   const otherGoalTimes = db
     .prepare(
       `SELECT task_time_s FROM flight_attempts
@@ -157,13 +175,15 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
   const nowIso = new Date().toISOString();
 
   db.transaction(() => {
-    // Drop task_results for this task FIRST. Without this the next DELETE
-    // FROM flight_attempts trips the FK constraint
-    //   task_results.best_attempt_id REFERENCES flight_attempts(id)
-    // because the cached task_results row still points at the old attempt.
-    // The rebuildTaskResults call at the end of this txn re-creates
-    // task_results from the new flight_attempts.
-    db.prepare(`DELETE FROM task_results WHERE task_id = ?`).run(sub.task_id);
+    // Drop only the task_results rows that point at this submission's
+    // attempts — the FK is task_results.best_attempt_id → flight_attempts(id),
+    // and we're about to delete those attempts. A full per-task DELETE +
+    // rebuild here would be O(N²) when many stale submissions share a task;
+    // the boot sweep in server.ts re-derives the whole table once afterward.
+    db.prepare(
+      `DELETE FROM task_results
+       WHERE best_attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
+    ).run(sub.id);
 
     // Drop old attempt + crossing rows for this submission. turnpoint_crossings
     // has no soft-delete column so hard-delete; flight_attempts has one but
@@ -239,11 +259,5 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
       nowIso,
       sub.id,
     );
-
-    // Re-create task_results for this task from the new flight_attempts,
-    // inside the same txn so the FK constraint stays satisfied at commit.
-    // better-sqlite3 transactions are reentrant via savepoints, so the
-    // nested rebuildTaskResults transaction is safe here.
-    rebuildTaskResults(db, sub.task_id);
   })();
 }

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -185,9 +185,12 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
        WHERE best_attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
     ).run(sub.id);
 
-    // Drop old attempt + crossing rows for this submission. turnpoint_crossings
-    // has no soft-delete column so hard-delete; flight_attempts has one but
-    // the upload path overwrites in place — do the same here.
+    // Drop old attempt + crossing rows for this submission. Reprocess is
+    // re-scoring the same IGC against a newer SCORER_VERSION, so we need
+    // to replace the existing rows wholesale; soft-delete would leave the
+    // stale attempts visible alongside the freshly-scored ones, so hard-
+    // delete is the right call. turnpoint_crossings has no soft-delete
+    // column either, so the same delete-and-reinsert applies.
     db.prepare(
       `DELETE FROM turnpoint_crossings
        WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { authPlugin, loadAuthConfig } from './auth';
 import { bootstrapWorker, rebuildTaskResults, SQLiteJobQueue } from './job-queue';
 import { dropRedundantLeagueIdColumns } from './migration-helpers';
+import { reprocessStaleSubmissions } from './reprocess';
 
 // =============================================================================
 // CONSTANTS
@@ -116,6 +117,16 @@ async function main() {
   ).run();
 
   worker.start();
+
+  // ── Boot-time IGC reprocess (only fires if scorer_version is stale) ───────
+  // No-op when every flight_attempt is at the current SCORER_VERSION; runs in
+  // ~50 ms per submission otherwise. Per-submission errors are logged and
+  // skipped so a single bad IGC can't block startup.
+  try {
+    await reprocessStaleSubmissions(db);
+  } catch (err) {
+    console.error('[boot] reprocessStaleSubmissions threw:', err);
+  }
 
   // ── Boot-time rebuild of task_results ──────────────────────────────────────
   // rebuildTaskResults now re-scores from canonical inputs (current best

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -18,7 +18,7 @@ import { createHash, randomUUID } from 'crypto';
 import type { FastifyReply, FastifyRequest as FastifyRequestBase } from 'fastify';
 import { requireAuth } from './auth';
 import { rebuildTaskResults } from './job-queue';
-import { formatPipelineError, type PipelineInput, runPipeline, type TurnpointDef } from './pipeline';
+import { formatPipelineError, type PipelineInput, runPipeline, SCORER_VERSION, type TurnpointDef } from './pipeline';
 
 // =============================================================================
 // TYPES
@@ -315,9 +315,9 @@ export async function handleIgcUpload(
           sss_crossing_time, ess_crossing_time, goal_crossing_time, task_time_s,
           reached_goal, last_turnpoint_index,
           distance_flown_km, distance_points, time_points, total_points,
-          has_flagged_crossings, attempt_index,
+          has_flagged_crossings, attempt_index, scorer_version,
           created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         attemptId,
         submissionId,
@@ -335,6 +335,7 @@ export async function handleIgcUpload(
         attempt.totalPoints,
         attempt.hasFlaggedCrossings ? 1 : 0,
         attempt.attemptIndex,
+        SCORER_VERSION,
         nowIso,
         nowIso,
       );

--- a/tests/goal-line.test.ts
+++ b/tests/goal-line.test.ts
@@ -211,33 +211,38 @@ describe('segmentNearGoalLine', () => {
   const BRG = 90;
   const TOL = 5;
 
-  it('returns the line-line intersection t when the segment actually crosses', () => {
+  it('returns the stadium entry t when the segment actually crosses the chord', () => {
+    // y goes -50 → 50; the stadium's bottom edge sits at y = -tol = -5,
+    // so the segment enters the stadium at y = -5: t = 45/100.
     const t = segmentNearGoalLine({ x: 0, y: -50 }, { x: 0, y: 50 }, ORIGIN, R, BRG, TOL);
-    expect(t).toBeCloseTo(0.5, 5);
+    expect(t).toBeCloseTo(0.45, 5);
   });
 
   it('tags a segment ending exactly at the chord (no overshoot)', () => {
+    // y goes -50 → 0; entry into the stadium at y = -5: t = 45/50.
     const t = segmentNearGoalLine({ x: 0, y: -50 }, { x: 0, y: 0 }, ORIGIN, R, BRG, TOL);
     expect(t).not.toBeNull();
-    expect(t!).toBeCloseTo(1, 5);
+    expect(t!).toBeCloseTo(0.9, 5);
   });
 
   it('tags a segment that misses the chord by less than tolerance (perpendicular short)', () => {
-    // Endpoint b sits 3 m short of the chord on the inbound side
+    // y goes -20 → -3; the segment ends 3 m short of the chord on the
+    // inbound side, but enters the stadium at y = -5: t = 15/17 ≈ 0.882.
     const t = segmentNearGoalLine({ x: 0, y: -20 }, { x: 0, y: -3 }, ORIGIN, R, BRG, TOL);
     expect(t).not.toBeNull();
+    expect(t!).toBeCloseTo(15 / 17, 4);
   });
 
   it('rejects a segment that misses the chord by more than tolerance', () => {
-    // Endpoint b sits 8 m short — outside 5 m tolerance
+    // y goes -20 → -8 — both endpoints outside the 5 m tolerance band
     const t = segmentNearGoalLine({ x: 0, y: -20 }, { x: 0, y: -8 }, ORIGIN, R, BRG, TOL);
     expect(t).toBeNull();
   });
 
-  it('tags a segment that flies parallel to the chord at < tolerance offset', () => {
-    // Track parallel to the chord at y = 4 m offset (< 5 m tolerance)
+  it('returns 0 when A starts inside the stadium (parallel < tolerance)', () => {
+    // Parallel to the chord at y = 4 (< 5 m tolerance) — A is already inside.
     const t = segmentNearGoalLine({ x: -50, y: 4 }, { x: 50, y: 4 }, ORIGIN, R, BRG, TOL);
-    expect(t).not.toBeNull();
+    expect(t).toBe(0);
   });
 
   it('rejects a segment that flies parallel to the chord at > tolerance offset', () => {
@@ -245,16 +250,27 @@ describe('segmentNearGoalLine', () => {
     expect(t).toBeNull();
   });
 
-  it('tags a segment passing within tolerance of a chord endpoint', () => {
-    // Track that ends 3 m beyond the +x chord endpoint at (100, 0). The endpoint
-    // is the closest point on the chord; track endpoint b is 3 m away.
+  it('tags a segment entering the right end-cap', () => {
+    // A at (100, -20) — at chord-x boundary, far from cap → outside.
+    // B at (103, 0) — 3 m past the +x chord endpoint → inside the cap.
+    // First-entry comes from the right-cap circle ((x−100)² + y² = 25).
     const t = segmentNearGoalLine({ x: 100, y: -20 }, { x: 103, y: 0 }, ORIGIN, R, BRG, TOL);
     expect(t).not.toBeNull();
+    expect(t!).toBeGreaterThan(0);
+    expect(t!).toBeLessThan(1);
   });
 
   it('rejects a segment > tolerance beyond the chord endpoint', () => {
     const t = segmentNearGoalLine({ x: 100, y: -20 }, { x: 110, y: 0 }, ORIGIN, R, BRG, TOL);
     expect(t).toBeNull();
+  });
+
+  it('returns the earlier of two stadium intersections when AB enters and exits', () => {
+    // A at (0, -20) outside; B at (0, 20) outside; AB punches straight
+    // through the stadium. First entry is at y = -5: t = 15/40 = 0.375.
+    // Confirms that we never accidentally return the exit t.
+    const t = segmentNearGoalLine({ x: 0, y: -20 }, { x: 0, y: 20 }, ORIGIN, R, BRG, TOL);
+    expect(t).toBeCloseTo(0.375, 5);
   });
 });
 

--- a/tests/goal-line.test.ts
+++ b/tests/goal-line.test.ts
@@ -296,9 +296,9 @@ describe('cylinder tolerance boundary (segmentIntersectsCircle + tagToleranceM)'
     expect(t).toBeNull();
   });
 
-  it('uses the 0.5% floor for large cylinders (4000 m → 20 m tolerance)', () => {
+  it('uses the 0.5% rule above the floor (4000 m → 20 m tolerance)', () => {
     const r = 4000;
-    const effectiveR = r + tagToleranceM(r); // 4020
+    const effectiveR = r + tagToleranceM(r); // 4020 — 0.5 % of 4000 = 20 m, above the 5 m floor
     // 15 m short of the strict edge — within 20 m tolerance
     const t = segmentIntersectsCircle({ x: 5000, y: 0 }, { x: 4015, y: 0 }, effectiveR);
     expect(t).not.toBeNull();

--- a/tests/goal-line.test.ts
+++ b/tests/goal-line.test.ts
@@ -205,8 +205,9 @@ describe('goal D-shape: chord + semi-circle together', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('segmentNearGoalLine', () => {
-  // East-west chord at origin, half-length 100 m, bearing 90°. Tolerance is
-  // tagToleranceM(200) === 5m for the cylinder these endpoints came from.
+  // East-west chord at origin, half-length 100 m, bearing 90°. The chord is
+  // sized off a 100 m goal cylinder, so tolerance = tagToleranceM(100) = 5 m
+  // (the 5 m floor; 0.5 % of 100 m is 0.5 m, below the floor).
   const R = 100;
   const BRG = 90;
   const TOL = 5;

--- a/tests/goal-line.test.ts
+++ b/tests/goal-line.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { segmentEntersGoalSemiCircle, segmentIntersectsGoalLine } from '../src/pipeline';
+import {
+  segmentEntersGoalSemiCircle,
+  segmentIntersectsCircle,
+  segmentIntersectsGoalLine,
+  segmentNearGoalLine,
+  tagToleranceM,
+} from '../src/pipeline';
 import { type Cylinder, optimiseRoute } from '../src/shared/task-engine';
 
 // =============================================================================
@@ -191,6 +197,94 @@ describe('goal D-shape: chord + semi-circle together', () => {
     const tArc = segmentEntersGoalSemiCircle({ x: 0, y: -200 }, { x: 0, y: -10 }, ORIGIN, R, BRG);
     expect(tChord).toBeNull();
     expect(tArc).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// segmentNearGoalLine — FAI §9.1.3 perpendicular tolerance on the chord
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('segmentNearGoalLine', () => {
+  // East-west chord at origin, half-length 100 m, bearing 90°. Tolerance is
+  // tagToleranceM(200) === 5m for the cylinder these endpoints came from.
+  const R = 100;
+  const BRG = 90;
+  const TOL = 5;
+
+  it('returns the line-line intersection t when the segment actually crosses', () => {
+    const t = segmentNearGoalLine({ x: 0, y: -50 }, { x: 0, y: 50 }, ORIGIN, R, BRG, TOL);
+    expect(t).toBeCloseTo(0.5, 5);
+  });
+
+  it('tags a segment ending exactly at the chord (no overshoot)', () => {
+    const t = segmentNearGoalLine({ x: 0, y: -50 }, { x: 0, y: 0 }, ORIGIN, R, BRG, TOL);
+    expect(t).not.toBeNull();
+    expect(t!).toBeCloseTo(1, 5);
+  });
+
+  it('tags a segment that misses the chord by less than tolerance (perpendicular short)', () => {
+    // Endpoint b sits 3 m short of the chord on the inbound side
+    const t = segmentNearGoalLine({ x: 0, y: -20 }, { x: 0, y: -3 }, ORIGIN, R, BRG, TOL);
+    expect(t).not.toBeNull();
+  });
+
+  it('rejects a segment that misses the chord by more than tolerance', () => {
+    // Endpoint b sits 8 m short — outside 5 m tolerance
+    const t = segmentNearGoalLine({ x: 0, y: -20 }, { x: 0, y: -8 }, ORIGIN, R, BRG, TOL);
+    expect(t).toBeNull();
+  });
+
+  it('tags a segment that flies parallel to the chord at < tolerance offset', () => {
+    // Track parallel to the chord at y = 4 m offset (< 5 m tolerance)
+    const t = segmentNearGoalLine({ x: -50, y: 4 }, { x: 50, y: 4 }, ORIGIN, R, BRG, TOL);
+    expect(t).not.toBeNull();
+  });
+
+  it('rejects a segment that flies parallel to the chord at > tolerance offset', () => {
+    const t = segmentNearGoalLine({ x: -50, y: 7 }, { x: 50, y: 7 }, ORIGIN, R, BRG, TOL);
+    expect(t).toBeNull();
+  });
+
+  it('tags a segment passing within tolerance of a chord endpoint', () => {
+    // Track that ends 3 m beyond the +x chord endpoint at (100, 0). The endpoint
+    // is the closest point on the chord; track endpoint b is 3 m away.
+    const t = segmentNearGoalLine({ x: 100, y: -20 }, { x: 103, y: 0 }, ORIGIN, R, BRG, TOL);
+    expect(t).not.toBeNull();
+  });
+
+  it('rejects a segment > tolerance beyond the chord endpoint', () => {
+    const t = segmentNearGoalLine({ x: 100, y: -20 }, { x: 110, y: 0 }, ORIGIN, R, BRG, TOL);
+    expect(t).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FAI §9.1.3 cylinder tolerance — boundary cases through detection helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('cylinder tolerance boundary (segmentIntersectsCircle + tagToleranceM)', () => {
+  // A 400 m cylinder gets a 5 m tolerance (the floor — 0.5% of 400 is 2 m)
+  it('tags an inbound segment ending 4 m short of a 400 m cylinder', () => {
+    const r = 400;
+    const effectiveR = r + tagToleranceM(r); // 405
+    // Track running west→east, ending 4 m short of the cylinder edge
+    const t = segmentIntersectsCircle({ x: 500, y: 0 }, { x: 404, y: 0 }, effectiveR);
+    expect(t).not.toBeNull();
+  });
+
+  it('rejects an inbound segment ending 8 m short of a 400 m cylinder', () => {
+    const r = 400;
+    const effectiveR = r + tagToleranceM(r); // 405
+    const t = segmentIntersectsCircle({ x: 500, y: 0 }, { x: 408, y: 0 }, effectiveR);
+    expect(t).toBeNull();
+  });
+
+  it('uses the 0.5% floor for large cylinders (4000 m → 20 m tolerance)', () => {
+    const r = 4000;
+    const effectiveR = r + tagToleranceM(r); // 4020
+    // 15 m short of the strict edge — within 20 m tolerance
+    const t = segmentIntersectsCircle({ x: 5000, y: 0 }, { x: 4015, y: 0 }, effectiveR);
+    expect(t).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #42.

## Summary

The cylinder crossing detection in `detectAttempts` used strict `radius_m` for the in/out check. FAI Sporting Code S7F §9.1.3 prescribes a tolerance of **`max(5 m, 0.5% × radius)`** — pilots get the benefit of the doubt for tags. A 4 km cylinder gets a 20 m tolerance.

**Concrete prod hit fixed by this PR:** Ian Heidenberger's submission to *Fly, you fools (Apr/May)* had a closest approach of **4001 m** to GRN-6K (0.8 m miss). With the new tolerance he tags TP1 cleanly and his `distance_flown_km` / `last_turnpoint_index` / score all jump up.

## What changes

- New `tagToleranceM(r) = max(5, r * 0.005)` helper applied to:
  - The SSS exit gate (in/out check + intersection radius)
  - In-cylinder check on every other turnpoint
  - `segmentIntersectsCircle` radius for graze-through detection
  - The goal-line chord and goal-arc semi-circle (per §9.1.3 separately)
  - HAF ground-state classifier's "fix inside cylinder" test
- The optimised-route geometry (`optimiseRoute`, `computePartialDistanceKm`) continues to use the strict radius — tolerance only governs *tags*.
- New `SCORER_VERSION = '1.1'` exported from `pipeline.ts`. Upload writes it into `flight_attempts.scorer_version` (column pre-existed, was unused).
- New `src/reprocess.ts`: `reprocessStaleSubmissions(db)` finds every flight_submission with attempts at an older scorer_version, re-parses the stored `igc_data` blob, replaces `flight_attempts` + `turnpoint_crossings` in a per-submission txn, then rebuilds `task_results` once per touched task. Per-submission errors are logged and skipped.
- Wired into `server.ts` boot, before the existing `rebuildTaskResults` loop. No-op when every attempt is current; ~50 ms per submission when stale.

## After deploy

Every existing IGC gets reprocessed exactly once. Pilots may see score deltas as previously-missed cylinder tags are now credited. Expected biggest mover: Ian (currently rank 7 with 1.272 km / 300.8 pts on Fly, you fools — should jump into the rank 4-6 cluster around 440-460 pts).

## Test plan

- [x] Unit tests cover the tolerance contract (5 m floor below 1000 m radius, 0.5% above).
- [x] `npm test` (194/194 pass).
- [x] `npm run typecheck`.
- [ ] After deploy: verify boot logs show `[reprocess] re-running pipeline against N submissions for SCORER_VERSION=1.1` and `[reprocess] done`.
- [ ] After deploy: confirm Ian's `last_turnpoint_index >= 1` for sub `8e5f6a22-...` on `Fly, you fools` (TP1 = GRN-6K).
- [ ] After deploy: watch the standings on `https://league.nwparagliding.com/leagues/nwpc` for new score deltas.

## Notes

- Companion to #43 (cylinder *rendering* uses a uniform-radius SVG `<circle>` — drawn ~2.7 m oversized at 47.5° lat). Filing as separate PR; tolerance is the actual scoring fix and ships first.