### PR TITLE
Render cylinder boundary as 96-segment polygon, not uniform-radius circle

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -198,19 +198,36 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     // arcs at mid-latitudes (Mercator's secant changes across a 4 km radius),
     // making tracks appear inside the cylinder while actually outside. 96
     // segments gives sub-pixel accuracy at any reasonable zoom for our radii.
+    //
+    // Cached per (group, radiusM) so the shadow ring and coloured ring share
+    // one set of ~97 map.project calls instead of doubling the work each
+    // pan/zoom.
+    const cylinderPathCache = new Map<string, string>();
     const cylinderPath = (lng: number, lat: number, radiusM: number, segments = 96): string => {
+      const key = `${lng},${lat},${radiusM},${segments}`;
+      const cached = cylinderPathCache.get(key);
+      if (cached !== undefined) return cached;
       const R = 6371000;
       const DEG = Math.PI / 180;
-      const cosLat = Math.cos(lat * DEG);
-      let d = '';
+      // cos(lat) approaches 0 near the poles and would blow dLng up to ±∞,
+      // producing NaN coordinates downstream. Clamp to a tiny epsilon so the
+      // polygon stays bounded — purely defensive; our actual TPs are at
+      // mid-latitudes where this guard never fires.
+      const COS_LAT_EPSILON = 1e-12;
+      const cosLatRaw = Math.cos(lat * DEG);
+      const cosLat = Math.abs(cosLatRaw) < COS_LAT_EPSILON ? Math.sign(cosLatRaw || 1) * COS_LAT_EPSILON : cosLatRaw;
+      const cmds: string[] = [];
       for (let i = 0; i <= segments; i++) {
         const theta = (i / segments) * 2 * Math.PI;
         const dLat = ((radiusM * Math.sin(theta)) / R) * (180 / Math.PI);
         const dLng = ((radiusM * Math.cos(theta)) / (R * cosLat)) * (180 / Math.PI);
         const p = map.project([lng + dLng, lat + dLat]);
-        d += `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+        cmds.push(`${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`);
       }
-      return d + 'Z';
+      cmds.push('Z');
+      const d = cmds.join('');
+      cylinderPathCache.set(key, d);
+      return d;
     };
 
     // ── 1. Optimized route line ───────────────────────────────────────────────

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -192,6 +192,27 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       return { cx: c.x, cy: c.y, r: Math.hypot(c.x - e.x, c.y - e.y) };
     };
 
+    // Render the cylinder boundary as a polygon, with each vertex projected
+    // through map.project individually. A uniform-radius SVG <circle> based on
+    // projR's N-direction value over-renders the boundary on the south/east
+    // arcs at mid-latitudes (Mercator's secant changes across a 4 km radius),
+    // making tracks appear inside the cylinder while actually outside. 96
+    // segments gives sub-pixel accuracy at any reasonable zoom for our radii.
+    const cylinderPath = (lng: number, lat: number, radiusM: number, segments = 96): string => {
+      const R = 6371000;
+      const DEG = Math.PI / 180;
+      const cosLat = Math.cos(lat * DEG);
+      let d = '';
+      for (let i = 0; i <= segments; i++) {
+        const theta = (i / segments) * 2 * Math.PI;
+        const dLat = ((radiusM * Math.sin(theta)) / R) * (180 / Math.PI);
+        const dLng = ((radiusM * Math.cos(theta)) / (R * cosLat)) * (180 / Math.PI);
+        const p = map.project([lng + dLng, lat + dLat]);
+        d += `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+      }
+      return d + 'Z';
+    };
+
     // ── 1. Optimized route line ───────────────────────────────────────────────
     const routeResult = routeRef.current;
     const linePts = routeResult
@@ -322,12 +343,10 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     // ── 4. Cylinder shadow rings ──────────────────────────────────────────────
     for (const group of groups) {
       for (const { radiusM } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
-        const { cx, cy, r } = projR(group.lng, group.lat, radiusM);
+        const { r } = projR(group.lng, group.lat, radiusM);
         if (r < 1) continue;
-        mk('circle', {
-          cx: cx.toFixed(1),
-          cy: cy.toFixed(1),
-          r: r.toFixed(1),
+        mk('path', {
+          d: cylinderPath(group.lng, group.lat, radiusM),
           fill: 'none',
           stroke: 'rgba(0,0,0,0.55)',
           'stroke-width': 8,
@@ -340,12 +359,10 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     // stroke switches to earthy brown with a tighter dash for force-ground TPs.
     for (const group of groups) {
       for (const { radiusM, color, forceGround } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
-        const { cx, cy, r } = projR(group.lng, group.lat, radiusM);
+        const { r } = projR(group.lng, group.lat, radiusM);
         if (r < 1) continue;
-        mk('circle', {
-          cx: cx.toFixed(1),
-          cy: cy.toFixed(1),
-          r: r.toFixed(1),
+        mk('path', {
+          d: cylinderPath(group.lng, group.lat, radiusM),
           fill: color + '28',
           stroke: forceGround ? GROUND_COLOR : color,
           'stroke-width': 3,


### PR DESCRIPTION
Closes #43.

## Why

`projR` in `frontend/src/components/TaskMap.tsx` computes the screen radius using only the N-direction (`map.project(lat + radiusM/R)`). At 47.5°N, Mercator's secant of latitude changes measurably across a 4 km radius, so the true projected cylinder is slightly smaller in the south/east arcs than in the north. The previous SVG `<circle>` used the larger N-value uniformly, drawing the boundary **~2.7 m too far out** in non-N directions at this latitude.

The miscalibration was visible on real flights: Ian Heidenberger's track on *Fly, you fools (Apr/May)* appeared **inside** GRN-6K while in reality his closest approach was **0.8 m outside** the true boundary. Confusing for pilots and triage.

## Fix

Replace the SVG `<circle>` with an SVG `<path>` polygon. Each of 96 vertices is computed in geographic space (radians at the cylinder's latitude for the N-S step, `radians / cos(lat)` for E-W) and then projected through `map.project`. The rendered shape always matches whatever projection the map uses, regardless of latitude or future projection changes.

96 segments at 4 km is sub-pixel accurate at any reasonable zoom. Verified live in the browser via Chrome MCP — the rendered polygon now matches the true projected boundary at all bearings (vs +6 px / -2.7 m on the south/east arcs of the old `<circle>`).

Both the shadow ring and the coloured dashed ring switch from `<circle>` to the new `<path>`. Center dot and the goal-line D-shape are unchanged.

## Test plan

- [x] `npm test` (unchanged: 191 server tests pass — frontend has no test suite for this component yet).
- [x] `npm run typecheck`.
- [x] Manual: live verified in Chrome that the polygon matches the true Mercator projection of the cylinder at multiple bearings, while the previous `<circle>` was off by ~6 px at zoom 17.
- [ ] After deploy: Ian's closest-approach screenshot should now show his track *outside* the GRN-6K boundary.

## Related

- Companion to #44 — the actual scoring fix (FAI §9.1.3 tolerance). With both merged, Ian's track will appear visually outside the cylinder *and* score correctly because the tolerance covers his 0.8 m miss.