### PR TITLE
Render FAI §9.1.3 tolerance buffer on map cylinders

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -317,6 +317,33 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         'Z',
       ].join(' ');
 
+      // Buffered D — Minkowski-sum approximation. Both chord half-length
+      // and arc radius extended by tagToleranceM(halfM); we don't draw the
+      // thin inbound band that the full Minkowski sum would add (sub-pixel
+      // at typical zoom for the 5 m floor on small goal lines, and the
+      // outbound expansion + chord-end caps already convey "tolerance scope
+      // here"). Drawn first so the strict dashed boundary stays the focal cue.
+      const tolM = tagToleranceM(halfM);
+      const bufHalfM = halfM + tolM;
+      const buf_dlatDeg = ((Math.cos(brgRad) * bufHalfM) / 6371000) * (180 / Math.PI);
+      const buf_dlngDeg = ((Math.sin(brgRad) * bufHalfM) / (6371000 * Math.cos((lat * Math.PI) / 180))) * (180 / Math.PI);
+      const bufEp1 = map.project([lng + buf_dlngDeg, lat + buf_dlatDeg]);
+      const bufEp2 = map.project([lng - buf_dlngDeg, lat - buf_dlatDeg]);
+      const bufArcR = Math.hypot(bufEp1.x - goalPx.x, bufEp1.y - goalPx.y).toFixed(1);
+      const bufD = [
+        `M${bufEp1.x.toFixed(1)},${bufEp1.y.toFixed(1)}`,
+        `L${bufEp2.x.toFixed(1)},${bufEp2.y.toFixed(1)}`,
+        `A${bufArcR},${bufArcR},0,0,${sweep},${bufEp1.x.toFixed(1)},${bufEp1.y.toFixed(1)}`,
+        'Z',
+      ].join(' ');
+      mk('path', {
+        d: `${bufD} ${d}`,
+        'fill-rule': 'evenodd',
+        fill: '#5db87a',
+        'fill-opacity': 0.5,
+        stroke: 'none',
+      });
+
       mk('path', {
         d,
         fill: 'rgba(0,0,0,0.2)',
@@ -387,17 +414,17 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         // a single path with two subpaths and evenodd fill-rule. The buffer
         // is small in absolute terms (5 m floor, then 0.5 % of r), so we
         // shade the band rather than drawing a thin ring — much more
-        // visible on big cylinders and still tolerable on small ones.
+        // visible on big cylinders and still tolerable on small ones. No
+        // `stroke` here on purpose: a stroke would paint both subpaths and
+        // the inner stroke at r would land on top of the dashed strict ring
+        // below, filling in its dash gaps.
         const bufferRadiusM = radiusM + tagToleranceM(radiusM);
-        const bandStroke = forceGround ? GROUND_COLOR : color;
         mk('path', {
           d: `${cylinderPath(group.lng, group.lat, bufferRadiusM)} ${cylinderPath(group.lng, group.lat, radiusM)}`,
           'fill-rule': 'evenodd',
-          fill: bandStroke,
+          fill: forceGround ? GROUND_COLOR : color,
           'fill-opacity': 0.5,
-          stroke: bandStroke,
-          'stroke-width': 1,
-          'stroke-opacity': 0.6,
+          stroke: 'none',
         });
 
         // Strict cylinder boundary (the scored-distance edge).

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -326,7 +326,8 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       const tolM = tagToleranceM(halfM);
       const bufHalfM = halfM + tolM;
       const buf_dlatDeg = ((Math.cos(brgRad) * bufHalfM) / 6371000) * (180 / Math.PI);
-      const buf_dlngDeg = ((Math.sin(brgRad) * bufHalfM) / (6371000 * Math.cos((lat * Math.PI) / 180))) * (180 / Math.PI);
+      const buf_dlngDeg =
+        ((Math.sin(brgRad) * bufHalfM) / (6371000 * Math.cos((lat * Math.PI) / 180))) * (180 / Math.PI);
       const bufEp1 = map.project([lng + buf_dlngDeg, lat + buf_dlatDeg]);
       const bufEp2 = map.project([lng - buf_dlngDeg, lat - buf_dlatDeg]);
       const bufArcR = Math.hypot(bufEp1.x - goalPx.x, bufEp1.y - goalPx.y).toFixed(1);

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -1,7 +1,7 @@
 import maplibregl from 'maplibre-gl';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { type Cylinder, computeDistanceKm, optimiseRoute } from '../../../src/shared/task-engine';
+import { type Cylinder, computeDistanceKm, optimiseRoute, tagToleranceM } from '../../../src/shared/task-engine';
 import type { Turnpoint } from '../api/tasks';
 import type { ReplayFix } from '../api/track';
 
@@ -371,13 +371,30 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       }
     }
 
-    // ── 5. Coloured dashed rings ──────────────────────────────────────────────
+    // ── 5. Coloured dashed rings + FAI §9.1.3 tolerance buffer ───────────────
     // Role colour shows on the fill (preserves SSS/ESS/Goal at-a-glance); the
     // stroke switches to earthy brown with a tighter dash for force-ground TPs.
+    // Outside each strict ring we draw a faint buffer at r + tagToleranceM(r)
+    // — that's the boundary the scoring pipeline actually uses for tag
+    // detection (max(5 m, 0.5 % of r)). Visible as a thin halo on small
+    // cylinders, more apparent on large ones.
     for (const group of groups) {
       for (const { radiusM, color, forceGround } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
         const { r } = projR(group.lng, group.lat, radiusM);
         if (r < 1) continue;
+
+        // Tolerance buffer (drawn first so it sits behind the strict ring).
+        const bufferRadiusM = radiusM + tagToleranceM(radiusM);
+        mk('path', {
+          d: cylinderPath(group.lng, group.lat, bufferRadiusM),
+          fill: 'none',
+          stroke: forceGround ? GROUND_COLOR : color,
+          'stroke-width': 1,
+          'stroke-opacity': 0.45,
+          'stroke-dasharray': '2 4',
+        });
+
+        // Strict cylinder boundary (the scored-distance edge).
         mk('path', {
           d: cylinderPath(group.lng, group.lat, radiusM),
           fill: color + '28',

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -374,24 +374,30 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     // ── 5. Coloured dashed rings + FAI §9.1.3 tolerance buffer ───────────────
     // Role colour shows on the fill (preserves SSS/ESS/Goal at-a-glance); the
     // stroke switches to earthy brown with a tighter dash for force-ground TPs.
-    // Outside each strict ring we draw a faint buffer at r + tagToleranceM(r)
-    // — that's the boundary the scoring pipeline actually uses for tag
-    // detection (max(5 m, 0.5 % of r)). Visible as a thin halo on small
-    // cylinders, more apparent on large ones.
+    // Outside each strict ring we shade the annular band between r and
+    // r + tagToleranceM(r) (max(5 m, 0.5 % of r)) — that's the band the
+    // scoring pipeline actually accepts for tag detection. Drawn first so
+    // the strict ring's stroke and translucent fill sit on top.
     for (const group of groups) {
       for (const { radiusM, color, forceGround } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
         const { r } = projR(group.lng, group.lat, radiusM);
         if (r < 1) continue;
 
-        // Tolerance buffer (drawn first so it sits behind the strict ring).
+        // Annular tolerance band (donut between r and r + tolerance) drawn as
+        // a single path with two subpaths and evenodd fill-rule. The buffer
+        // is small in absolute terms (5 m floor, then 0.5 % of r), so we
+        // shade the band rather than drawing a thin ring — much more
+        // visible on big cylinders and still tolerable on small ones.
         const bufferRadiusM = radiusM + tagToleranceM(radiusM);
+        const bandStroke = forceGround ? GROUND_COLOR : color;
         mk('path', {
-          d: cylinderPath(group.lng, group.lat, bufferRadiusM),
-          fill: 'none',
-          stroke: forceGround ? GROUND_COLOR : color,
+          d: `${cylinderPath(group.lng, group.lat, bufferRadiusM)} ${cylinderPath(group.lng, group.lat, radiusM)}`,
+          'fill-rule': 'evenodd',
+          fill: bandStroke,
+          'fill-opacity': 0.5,
+          stroke: bandStroke,
           'stroke-width': 1,
-          'stroke-opacity': 0.45,
-          'stroke-dasharray': '2 4',
+          'stroke-opacity': 0.6,
         });
 
         // Strict cylinder boundary (the scored-distance edge).

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -14,6 +14,7 @@ import {
   MAX_POINTS,
   type OptimisedRoute,
   optimiseRoute,
+  tagToleranceM,
 } from './shared/task-engine';
 
 // =============================================================================
@@ -26,20 +27,9 @@ import {
 
 export const SCORER_VERSION = '1.1';
 
-// =============================================================================
-// FAI §9.1.3 cylinder tolerance
-//
-// "Tolerance is applied separately to the straight portion and to the
-// semi-circle." Standard practice across FAI scoring tools is 0.5% of the
-// radius with a minimum of 5 m. The boundary effectively shifts outward by
-// `tagToleranceM(r)` — a fix at distance ≤ r + tolerance is considered
-// inside. The optimised-route geometry continues to use the strict radius;
-// tolerance only governs whether a track tags the cylinder.
-// =============================================================================
-
-export function tagToleranceM(radiusM: number): number {
-  return Math.max(5, radiusM * 0.005);
-}
+// Re-export so existing `import { tagToleranceM } from './pipeline'` paths
+// keep working. The canonical helper lives in `./shared/task-engine`.
+export { tagToleranceM };
 
 // =============================================================================
 // SHARED TYPES

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -7,6 +7,21 @@
 // =============================================================================
 
 // =============================================================================
+// FAI §9.1.3 cylinder tolerance
+//
+// "Tolerance is applied separately to the straight portion and to the
+// semi-circle." Standard practice across FAI scoring tools is 0.5 % of the
+// radius with a minimum of 5 m. The boundary effectively shifts outward by
+// `tagToleranceM(r)` — a fix at distance ≤ r + tolerance is considered
+// inside. The optimised-route geometry continues to use the strict radius;
+// tolerance only governs whether a track tags the cylinder.
+// =============================================================================
+
+export function tagToleranceM(radiusM: number): number {
+  return Math.max(5, radiusM * 0.005);
+}
+
+// =============================================================================
 // TYPES
 // =============================================================================
 


### PR DESCRIPTION
## Summary

The scoring pipeline considers a fix "inside" a control zone up to `r + tagToleranceM(r)` (max(5 m, 0.5 % × r) per FAI §9.1.3), but the map only drew the strict boundary. Pilots couldn't see the band their track had to cross to tag. This PR shades the tolerance band on each cylinder and on goal-line tasks.

## Changes

- **`src/shared/task-engine.ts`**: lift `tagToleranceM` here so it's the single source of truth for both backend and frontend.
- **`src/pipeline.ts`**: import + re-export `tagToleranceM` from the shared module so existing pipeline-side imports keep working.
- **`frontend/src/components/TaskMap.tsx`**: import `tagToleranceM`. Inside the cylinder render loop, draw an `evenodd`-filled annular band between `r` and `r + tagToleranceM(r)` (50 % fill, no stroke — see review comment for why) *before* the strict dashed ring. On `GOAL_LINE` tasks, do the same with a buffered D-shape (chord half-length + arc radius extended by `tagToleranceM(halfM)`); this is the Minkowski-sum approximation, missing the thin inbound band that's sub-pixel at typical zoom.

Buffer sizes for typical tasks:
- 200 m cyl → 5 m band (2.5 % of radius — most visible proportionally)
- 1 000 m cyl → 5 m band (0.5 %)
- 6 000 m cyl → 30 m band (very obvious at any reasonable zoom)

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run` — all pass
- [x] `npx biome check src/ frontend/src/ tests/ --diagnostic-level=error` — clean
- [x] Visual check on dev against the seeded "Wing Goes South" demo (cylinders 200/500/1000/3000 m) — band is clearly visible on the 3 km TG1-6K and the 200 m goal cyl, more subtle on 500/1000 m
- [ ] Visual check on a GOAL_LINE task once one exists in dev — should show the same band around the chord ends + outbound arc