### PR TITLE
Drop dead /tasks/:taskId endpoint + public track replay

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -89,13 +89,9 @@ export interface LeaderboardResponse {
 // =============================================================================
 
 export const tasksApi = {
-  /** List all tasks for a season */
+  /** List all tasks for a season — returns each task with turnpoints nested. */
   list: (leagueSlug: string, seasonId: string) =>
     api.get<{ tasks: Task[] }>(`/leagues/${leagueSlug}/seasons/${seasonId}/tasks`),
-
-  /** Get a single task */
-  get: (leagueSlug: string, seasonId: string, taskId: string) =>
-    api.get<{ task: Task }>(`/leagues/${leagueSlug}/seasons/${seasonId}/tasks/${taskId}`),
 
   /** Get task leaderboard */
   leaderboard: (leagueSlug: string, seasonId: string, taskId: string) =>

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -349,40 +349,6 @@
  */
 
 /**
- * GET /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId
- * Auth: not required
- *
- * Response 200:
- *   {
- *     task: TaskDetail,
- *     turnpoints: Array<{
- *       id: string,
- *       sequenceIndex: number,
- *       name: string,
- *       lat: number,
- *       lng: number,
- *       radiusM: number,
- *       type: string,
- *       goalLineBearingDeg: number | null,
- *     }>,
- *     results: Array<TaskResultSummary>,   // public results — best attempt per pilot
- *   }
- *
- * TaskResultSummary:
- *   {
- *     rank: number,
- *     userId: string,
- *     displayName: string,
- *     distanceFlownKm: number,
- *     reachedGoal: boolean,
- *     taskTimeS: number | null,
- *     totalPoints: number,
- *     hasFlaggedCrossings: boolean,
- *   }
- *   Note: distancePoints and timePoints breakdown NOT included here (private to pilot).
- */
-
-/**
  * PATCH /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId
  * Auth: league admin or super-admin
  *
@@ -541,8 +507,8 @@
 
 /**
  * GET /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId/track
- * Auth: authenticated, league member (any pilot in the league can replay
- *   another pilot's track — same gate as the /submissions listing).
+ * Auth: not required — tracks are part of the public competition record
+ *   alongside the public leaderboard.
  *
  * Returns the parsed track for the leaderboard map view: every IGC fix
  * (down-sampled by the client), the scored attempt's turnpoint crossings,
@@ -790,14 +756,13 @@
  *
  * public      GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks               List tasks
  * admin       POST     /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks               Create task
- * public      GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId       Task + results
  * admin       PATCH    /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId       Update task
  * member      GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/download  .xctsk file
  *
  * member      POST     /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions          Upload IGC
  * self/admin  GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions          Own submissions
  * self/admin  GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:id      Submission detail
- * self/admin  GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:id/track Track replay
+ * public      GET      /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:id/track Track replay
  *
  * required    GET      /api/v1/notifications                                             Own notifications
  * required    POST     /api/v1/notifications/read                                        Mark read

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -228,79 +228,6 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       return reply.send({ tasks });
     });
 
-    // ── Get task details with results ──────────────────────────────────────
-    leagueScope.get('/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId', async (request, reply) => {
-      const { seasonId, taskId } = request.params as { seasonId: string; taskId: string };
-      const league = (request as any).league;
-
-      // Verify task belongs to this season/league
-      const task = db
-        .prepare(
-          `SELECT
-           t.id,
-           t.name,
-           t.description,
-           t.task_type as taskType,
-           t.open_date as openDate,
-           t.close_date as closeDate
-         FROM tasks t
-         JOIN seasons s ON s.id = t.season_id
-         WHERE t.id = ? AND t.season_id = ? AND s.league_id = ? AND t.deleted_at IS NULL`,
-        )
-        .get(taskId, seasonId, league.id);
-
-      if (!task) {
-        return reply.status(404).send({ error: 'Task not found' });
-      }
-
-      // Get turnpoints
-      // SQLite stores force_ground as 0/1 INTEGER; coerce to real boolean
-      // so the JSON payload matches the TS `Turnpoint` contract on the client.
-      const turnpoints = (
-        db
-          .prepare(
-            `SELECT
-           id,
-           sequence_index as sequenceIndex,
-           name,
-           lat,
-           lng,
-           radius_m as radiusM,
-           type,
-           force_ground as forceGround,
-           goal_line_bearing_deg as goalLineBearingDeg
-         FROM turnpoints
-         WHERE task_id = ?
-         ORDER BY sequence_index`,
-          )
-          .all(taskId) as Array<{ forceGround: number }>
-      ).map((tp) => ({ ...tp, forceGround: Boolean(tp.forceGround) }));
-
-      // Get results (best attempt per pilot)
-      const results = db
-        .prepare(
-          `SELECT 
-           tr.rank,
-           tr.user_id as userId,
-           u.display_name as pilotName,
-           tr.distance_points as distancePoints,
-           tr.time_points as timePoints,
-           tr.total_points as totalPoints,
-           tr.distance_flown_km as distanceFlownKm,
-           tr.task_time_s as taskTimeS,
-           tr.reached_goal as reachedGoal,
-           tr.has_flagged_crossings as hasFlaggedCrossings,
-           tr.submitted_at as submittedAt
-         FROM task_results tr
-         JOIN users u ON u.id = tr.user_id
-         WHERE tr.task_id = ?
-         ORDER BY tr.rank`,
-        )
-        .all(taskId);
-
-      return reply.send({ task, turnpoints, results });
-    });
-
     // ── Task leaderboard ───────────────────────────────────────────────────
     leagueScope.get('/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/leaderboard', async (request, reply) => {
       const { seasonId, taskId } = request.params as { seasonId: string; taskId: string };
@@ -438,12 +365,10 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
     leagueScope.get(
       '/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId/track',
       async (request, reply) => {
-        // The track payload contains every IGC fix. The submissionId is
-        // exposed via the public leaderboard, so without auth anyone could
-        // pull any pilot's track at any time. Gate on league membership to
-        // match the /submissions listing.
-        requireAuth(request, reply);
-        requireLeagueMember(request, reply);
+        // Public — tracks are part of the visible competition record alongside
+        // the public leaderboard. URL params are validated against the row's
+        // own task/season/league below so a track ID can't be paired with the
+        // wrong context.
 
         const { seasonId, taskId, submissionId } = request.params as {
           submissionId: string;

--- a/tests/routes/track.test.ts
+++ b/tests/routes/track.test.ts
@@ -1,0 +1,84 @@
+// =============================================================================
+// GET /tasks/:taskId/submissions/:submissionId/track — public access
+//
+// Locks down the auth contract that #49 establishes: the track replay
+// endpoint must serve unauthenticated requests, and must still 404 when the
+// submissionId in the URL doesn't belong to the URL's task/season.
+// =============================================================================
+
+import { randomUUID } from 'crypto';
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { authPlugin, loadAuthConfig } from '../../src/auth';
+import { registerLeagueRoutes } from '../../src/routes/leagues';
+import {
+  createTestLeague,
+  createTestSeason,
+  createTestSubmission,
+  createTestTask,
+  createTestUser,
+  setupTestDatabase,
+} from '../helpers';
+import { getTestDb, resetTestDb } from '../setup';
+
+async function buildTestApp(db: ReturnType<typeof getTestDb>) {
+  const app = Fastify();
+  // Cookie plugin first — auth's preHandler reads request.cookies for the
+  // non-test-bypass JWT path. Without it an anonymous request crashes with
+  // "Cannot read properties of undefined (reading 'xcleague_jwt')".
+  await app.register(import('@fastify/cookie'));
+  await app.register(authPlugin, { config: loadAuthConfig(), db });
+  await registerLeagueRoutes(app, { db });
+  await app.ready();
+  return app;
+}
+
+describe('GET .../track — public access', () => {
+  let app: Awaited<ReturnType<typeof buildTestApp>>;
+  let db: ReturnType<typeof getTestDb>;
+  let user: ReturnType<typeof createTestUser>;
+  let league: ReturnType<typeof createTestLeague>;
+  let season: ReturnType<typeof createTestSeason>;
+  let task: ReturnType<typeof createTestTask>;
+  let submissionId: string;
+
+  beforeEach(async () => {
+    resetTestDb();
+    db = getTestDb();
+    setupTestDatabase(db);
+    user = createTestUser(db, { email: 'pilot@test.com', displayName: 'Pilot' });
+    league = createTestLeague(db, { slug: 'test-league' });
+    season = createTestSeason(db, league.id);
+    task = createTestTask(db, season.id, league.id);
+    submissionId = createTestSubmission(db, task.id, user.id, league.id);
+    app = await buildTestApp(db);
+  });
+
+  const trackUrl = (overrides: { taskId?: string; seasonId?: string; submissionId?: string } = {}) =>
+    `/leagues/${league.slug}/seasons/${overrides.seasonId ?? season.id}/tasks/${overrides.taskId ?? task.id}/submissions/${overrides.submissionId ?? submissionId}/track`;
+
+  it('does not require auth — anonymous request reaches the handler (no 401)', async () => {
+    // No `x-test-user-id` header → request.user is null.
+    const res = await app.inject({ method: 'GET', url: trackUrl() });
+    // Empty igc_data fails parsing, so this returns 422 INVALID_IGC.
+    // The point is just that we got *past* the auth gate (was 401 before #49).
+    expect(res.statusCode).not.toBe(401);
+    expect(res.statusCode).toBe(422);
+    expect(JSON.parse(res.body).error.code).toBe('INVALID_IGC');
+  });
+
+  it('404s when submissionId does not belong to the URL task', async () => {
+    // Sibling task in the same season; ask for our submission via that task's URL.
+    const otherTask = createTestTask(db, season.id, league.id, { id: randomUUID(), name: 'Other Task' });
+    const res = await app.inject({ method: 'GET', url: trackUrl({ taskId: otherTask.id }) });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error.code).toBe('SUBMISSION_NOT_FOUND');
+  });
+
+  it('404s when submissionId does not belong to the URL season', async () => {
+    const otherSeason = createTestSeason(db, league.id);
+    const res = await app.inject({ method: 'GET', url: trackUrl({ seasonId: otherSeason.id }) });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error.code).toBe('SUBMISSION_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #37 by deletion rather than fix.

The `GET /api/v1/leagues/:slug/seasons/:sid/tasks/:tid` endpoint had two SQL bugs (selected nonexistent `lat` / `lng` and `tr.submitted_at`) and was 500-ing in prod, but `grep -rn 'tasksApi.get'` shows nothing in the frontend actually calls it — the homepage map gets turnpoints from the LIST endpoint's nested response. So drop the route, its spec block, the route-summary entry, and the unused `tasksApi.get()` shim.

## Driveby — public track replay

Drop the `requireAuth + requireLeagueMember` gate I added to the `/track` endpoint back in #32. Tracks are part of the public competition record alongside the public leaderboard, and gating them made the dev-site map unusable for unauthenticated visitors. The URL params (taskId, seasonId, league.id) are still cross-validated against the row's own values inside the SELECT, so a track id can't be paired with the wrong context.

Spec entry updated: `Auth: not required` and the route-summary table flips it from `self/admin` to `public`.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run` — 213 pass
- [x] `npx biome check src/ frontend/src/ tests/ --diagnostic-level=error` — clean
- [x] Local: `curl .../track` (no auth) returns the structured 404 / payload, not 401
- [ ] Smoke prod after deploy: `https://league.nwparagliding.com/api/v1/leagues/nwpc/seasons/.../tasks/22108448-.../submissions/<sid>/track` should return JSON without a session cookie
- [ ] Verify the frontend map still works when logged out (no regression)