### PR TITLE
Admin endpoint: selective flight_submission soft-delete (#34)

### DIFF
--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -521,6 +521,28 @@
  */
 
 /**
+ * DELETE /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId
+ * Auth: league admin
+ *
+ * Soft-deletes a single pilot submission (admin moderation). Useful for
+ * removing a cheating or invalid upload without nuking the entire task.
+ *
+ * Cascade (in one txn):
+ *   1. flight_submissions.deleted_at = now
+ *   2. flight_attempts.deleted_at = now (all attempts in this submission)
+ *   3. rebuildTaskResults — pilot's task_results row is recomputed from
+ *      their remaining attempts, or dropped if this was their only one.
+ *
+ * Response 200:
+ *   { message: 'Submission deleted' }
+ *
+ * Response 403: caller is not a league admin
+ * Response 404: submission not found, already deleted, or doesn't belong
+ *   to the URL's task/season/league (also returned when a concurrent
+ *   delete wins the race for the same submission).
+ */
+
+/**
  * GET /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId/track
  * Auth: not required — tracks are part of the public competition record
  *   alongside the public leaderboard.

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -506,6 +506,28 @@
  */
 
 /**
+ * DELETE /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId
+ * Auth: league admin
+ *
+ * Soft-deletes a single pilot submission (admin moderation). Useful for
+ * removing a cheating or invalid upload without nuking the entire task.
+ *
+ * Cascade (in one txn):
+ *   1. flight_submissions.deleted_at = now
+ *   2. flight_attempts.deleted_at = now (all attempts in this submission)
+ *   3. rebuildTaskResults — pilot's task_results row is recomputed from
+ *      their remaining attempts, or dropped if this was their only one.
+ *
+ * Response 200:
+ *   { message: 'Submission deleted' }
+ *
+ * Response 403: caller is not a league admin
+ * Response 404: submission not found, already deleted, or doesn't belong
+ *   to the URL's task/season/league (also returned when a concurrent
+ *   delete wins the race for the same submission).
+ */
+
+/**
  * GET /api/v1/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId/track
  * Auth: not required — tracks are part of the public competition record
  *   alongside the public leaderboard.

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -530,16 +530,20 @@
  * Cascade (in one txn):
  *   1. flight_submissions.deleted_at = now
  *   2. flight_attempts.deleted_at = now (all attempts in this submission)
- *   3. rebuildTaskResults — pilot's task_results row is recomputed from
+ *   3. admin_audit_log row with action 'DELETE_SUBMISSION', actor = admin,
+ *      target = pilot whose submission was removed, details = JSON of the
+ *      league/season/task/submission identifiers.
+ *   4. rebuildTaskResults — pilot's task_results row is recomputed from
  *      their remaining attempts, or dropped if this was their only one.
  *
  * Response 200:
  *   { message: 'Submission deleted' }
  *
  * Response 403: caller is not a league admin
- * Response 404: submission not found, already deleted, or doesn't belong
- *   to the URL's task/season/league (also returned when a concurrent
- *   delete wins the race for the same submission).
+ * Response 404: submission not found, already deleted, parent task or
+ *   season is soft-deleted, or doesn't belong to the URL's task/season/
+ *   league (also returned when a concurrent delete wins the race for the
+ *   same submission).
  */
 
 /**

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto';
 import type { FastifyInstance } from 'fastify';
 import QRCode from 'qrcode';
 import { makeResolveLeagueHook, requireAuth, requireLeagueAdmin, requireLeagueMember } from '../auth';
+import { rebuildTaskResults } from '../job-queue';
 import { parseAndValidate } from '../pipeline';
 import { type Cylinder, optimiseRoute } from '../shared/task-engine';
 import {
@@ -360,6 +361,59 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
 
       return reply.send({ submissions });
     });
+
+    // ── Soft-delete a single submission (admin moderation) ─────────────────
+    // Per-submission cousin of the task soft-delete cascade above. Removes one
+    // pilot's upload without nuking the whole task; the pilot's task_results
+    // row is recomputed from their remaining attempts (or dropped if this was
+    // their only submission).
+    leagueScope.delete(
+      '/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId',
+      async (request, reply) => {
+        requireLeagueAdmin(request, reply);
+
+        const { seasonId, taskId, submissionId } = request.params as {
+          seasonId: string;
+          taskId: string;
+          submissionId: string;
+        };
+        const league = (request as any).league;
+
+        const submission = db
+          .prepare(
+            `SELECT fs.id, fs.user_id
+               FROM flight_submissions fs
+               JOIN tasks t ON t.id = fs.task_id
+               JOIN seasons s ON s.id = t.season_id
+              WHERE fs.id = ? AND fs.task_id = ? AND t.season_id = ? AND s.league_id = ?
+                AND fs.deleted_at IS NULL AND t.deleted_at IS NULL`,
+          )
+          .get(submissionId, taskId, seasonId, league.id) as { id: string; user_id: string } | undefined;
+
+        if (!submission) {
+          return reply.status(404).send({ error: 'Submission not found' });
+        }
+
+        // rebuildTaskResults wipes task_results for the task and recomputes
+        // from the live (non-deleted) flight_attempts, so soft-deleting the
+        // attempts in the same txn is enough — the pilot's row is re-derived
+        // from their remaining best attempt or dropped if this was their only
+        // submission.
+        db.transaction(() => {
+          db.prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ?`).run(submissionId);
+          db.prepare(
+            `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE submission_id = ? AND deleted_at IS NULL`,
+          ).run(submissionId);
+          rebuildTaskResults(db, taskId);
+        })();
+
+        request.log.info(
+          { leagueId: league.id, seasonId, taskId, submissionId, pilotId: submission.user_id },
+          'Submission soft-deleted by admin',
+        );
+        return reply.send({ message: 'Submission deleted' });
+      },
+    );
 
     // ── Get submission track data ──────────────────────────────────────────
     leagueScope.get(

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -420,13 +420,15 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
                JOIN tasks t ON t.id = fs.task_id
                JOIN seasons s ON s.id = t.season_id
               WHERE fs.id = ? AND fs.task_id = ? AND t.season_id = ? AND s.league_id = ?
-                AND fs.deleted_at IS NULL AND t.deleted_at IS NULL`,
+                AND fs.deleted_at IS NULL AND t.deleted_at IS NULL AND s.deleted_at IS NULL`,
           )
           .get(submissionId, taskId, seasonId, league.id) as { id: string; user_id: string } | undefined;
 
         if (!submission) {
           return reply.status(404).send({ error: 'Submission not found' });
         }
+
+        const actorUserId = (request as any).user!.userId;
 
         // rebuildTaskResults wipes task_results for the task and recomputes
         // from the live (non-deleted) flight_attempts, so soft-deleting the
@@ -451,6 +453,15 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           db.prepare(
             `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE submission_id = ? AND deleted_at IS NULL`,
           ).run(submissionId);
+          db.prepare(
+            `INSERT INTO admin_audit_log (id, actor_user_id, target_user_id, action, details, created_at)
+             VALUES (?, ?, ?, 'DELETE_SUBMISSION', ?, datetime('now'))`,
+          ).run(
+            randomUUID(),
+            actorUserId,
+            submission.user_id,
+            JSON.stringify({ leagueId: league.id, seasonId, taskId, submissionId }),
+          );
           rebuildTaskResults(db, taskId);
         })();
 

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto';
 import type { FastifyInstance } from 'fastify';
 import QRCode from 'qrcode';
 import { makeResolveLeagueHook, requireAuth, requireLeagueAdmin, requireLeagueMember } from '../auth';
+import { rebuildTaskResults } from '../job-queue';
 import { parseAndValidate } from '../pipeline';
 import { type Cylinder, optimiseRoute } from '../shared/task-engine';
 import {
@@ -394,6 +395,59 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
 
       return reply.send({ submissions });
     });
+
+    // ── Soft-delete a single submission (admin moderation) ─────────────────
+    // Per-submission cousin of the task soft-delete cascade above. Removes one
+    // pilot's upload without nuking the whole task; the pilot's task_results
+    // row is recomputed from their remaining attempts (or dropped if this was
+    // their only submission).
+    leagueScope.delete(
+      '/leagues/:leagueSlug/seasons/:seasonId/tasks/:taskId/submissions/:submissionId',
+      async (request, reply) => {
+        requireLeagueAdmin(request, reply);
+
+        const { seasonId, taskId, submissionId } = request.params as {
+          seasonId: string;
+          taskId: string;
+          submissionId: string;
+        };
+        const league = (request as any).league;
+
+        const submission = db
+          .prepare(
+            `SELECT fs.id, fs.user_id
+               FROM flight_submissions fs
+               JOIN tasks t ON t.id = fs.task_id
+               JOIN seasons s ON s.id = t.season_id
+              WHERE fs.id = ? AND fs.task_id = ? AND t.season_id = ? AND s.league_id = ?
+                AND fs.deleted_at IS NULL AND t.deleted_at IS NULL`,
+          )
+          .get(submissionId, taskId, seasonId, league.id) as { id: string; user_id: string } | undefined;
+
+        if (!submission) {
+          return reply.status(404).send({ error: 'Submission not found' });
+        }
+
+        // rebuildTaskResults wipes task_results for the task and recomputes
+        // from the live (non-deleted) flight_attempts, so soft-deleting the
+        // attempts in the same txn is enough — the pilot's row is re-derived
+        // from their remaining best attempt or dropped if this was their only
+        // submission.
+        db.transaction(() => {
+          db.prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ?`).run(submissionId);
+          db.prepare(
+            `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE submission_id = ? AND deleted_at IS NULL`,
+          ).run(submissionId);
+          rebuildTaskResults(db, taskId);
+        })();
+
+        request.log.info(
+          { leagueId: league.id, seasonId, taskId, submissionId, pilotId: submission.user_id },
+          'Submission soft-deleted by admin',
+        );
+        return reply.send({ message: 'Submission deleted' });
+      },
+    );
 
     // ── Get submission track data ──────────────────────────────────────────
     leagueScope.get(

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -399,13 +399,30 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         // attempts in the same txn is enough — the pilot's row is re-derived
         // from their remaining best attempt or dropped if this was their only
         // submission.
+        //
+        // The `AND deleted_at IS NULL` on the submission UPDATE closes a
+        // TOCTOU window: between the pre-read above and this UPDATE another
+        // concurrent admin could have already soft-deleted the row. If the
+        // UPDATE finds no live row (changes === 0) we bail with 404 so the
+        // second concurrent caller doesn't see a misleading 200.
+        let deleted = true;
         db.transaction(() => {
-          db.prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ?`).run(submissionId);
+          const result = db
+            .prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ? AND deleted_at IS NULL`)
+            .run(submissionId);
+          if (result.changes === 0) {
+            deleted = false;
+            return;
+          }
           db.prepare(
             `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE submission_id = ? AND deleted_at IS NULL`,
           ).run(submissionId);
           rebuildTaskResults(db, taskId);
         })();
+
+        if (!deleted) {
+          return reply.status(404).send({ error: 'Submission not found' });
+        }
 
         request.log.info(
           { leagueId: league.id, seasonId, taskId, submissionId, pilotId: submission.user_id },

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -433,13 +433,30 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         // attempts in the same txn is enough — the pilot's row is re-derived
         // from their remaining best attempt or dropped if this was their only
         // submission.
+        //
+        // The `AND deleted_at IS NULL` on the submission UPDATE closes a
+        // TOCTOU window: between the pre-read above and this UPDATE another
+        // concurrent admin could have already soft-deleted the row. If the
+        // UPDATE finds no live row (changes === 0) we bail with 404 so the
+        // second concurrent caller doesn't see a misleading 200.
+        let deleted = true;
         db.transaction(() => {
-          db.prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ?`).run(submissionId);
+          const result = db
+            .prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ? AND deleted_at IS NULL`)
+            .run(submissionId);
+          if (result.changes === 0) {
+            deleted = false;
+            return;
+          }
           db.prepare(
             `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE submission_id = ? AND deleted_at IS NULL`,
           ).run(submissionId);
           rebuildTaskResults(db, taskId);
         })();
+
+        if (!deleted) {
+          return reply.status(404).send({ error: 'Submission not found' });
+        }
 
         request.log.info(
           { leagueId: league.id, seasonId, taskId, submissionId, pilotId: submission.user_id },

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { dropRedundantLeagueIdColumns } from '../src/migration-helpers';
@@ -183,9 +183,10 @@ export function createTestSubmission(
   overrides: Partial<{ id: string; igcSha256: string }> = {},
 ) {
   const id = overrides.id || randomUUID();
-  // Randomise sha by default so the same pilot can have multiple submissions
-  // on a task without tripping the (task_id, user_id, igc_sha256) unique idx.
-  const sha = overrides.igcSha256 || randomUUID();
+  // Random 64-char hex by default — matches the production sha256 format
+  // and lets the same pilot have multiple submissions on a task without
+  // tripping the (task_id, user_id, igc_sha256) unique index.
+  const sha = overrides.igcSha256 || randomBytes(32).toString('hex');
   db.prepare(
     `INSERT INTO flight_submissions (
        id, task_id, user_id, league_id,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -180,17 +180,20 @@ export function createTestSubmission(
   taskId: string,
   userId: string,
   leagueId: string,
-  overrides: Partial<{ id: string }> = {},
+  overrides: Partial<{ id: string; igcSha256: string }> = {},
 ) {
   const id = overrides.id || randomUUID();
+  // Randomise sha by default so the same pilot can have multiple submissions
+  // on a task without tripping the (task_id, user_id, igc_sha256) unique idx.
+  const sha = overrides.igcSha256 || randomUUID();
   db.prepare(
     `INSERT INTO flight_submissions (
        id, task_id, user_id, league_id,
        igc_data, igc_filename, igc_size_bytes, igc_sha256,
        status, submitted_at, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, '', 'test.igc', 0, 'abc', 'PROCESSED',
+     ) VALUES (?, ?, ?, ?, '', 'test.igc', 0, ?, 'PROCESSED',
                datetime('now'), datetime('now'), datetime('now'))`,
-  ).run(id, taskId, userId, leagueId);
+  ).run(id, taskId, userId, leagueId, sha);
   return id;
 }
 

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -5,16 +5,20 @@
 // Auth is bypassed in test mode via x-test-user-id header.
 // =============================================================================
 
+import { randomUUID } from 'crypto';
 import Fastify from 'fastify';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { authPlugin, loadAuthConfig } from '../../src/auth';
+import { rebuildTaskResults } from '../../src/job-queue';
 import { registerLeagueRoutes } from '../../src/routes/leagues';
 import { buildXctrackDeepLink, type ExportTask, encodeXctskZ } from '../../src/task-exporters';
 import { parseCup, parseXctsk } from '../../src/task-parsers';
 import {
   addLeagueMember,
+  createTestAttempt,
   createTestLeague,
   createTestSeason,
+  createTestSubmission,
   createTestTask,
   createTestUser,
   setupTestDatabase,
@@ -1311,5 +1315,156 @@ describe('GOAL_LINE import — goal_line_bearing_deg persistence', () => {
     expect(goalTp).toBeTruthy();
     expect(goalTp.goalLineBearingDeg).not.toBeNull();
     expect(typeof goalTp.goalLineBearingDeg).toBe('number');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin submission moderation — DELETE /tasks/:taskId/submissions/:submissionId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Submission moderation — DELETE /submissions/:submissionId', () => {
+  let app: ReturnType<typeof Fastify>;
+  let db: ReturnType<typeof getTestDb>;
+  let adminUser: ReturnType<typeof createTestUser>;
+  let pilotUser: ReturnType<typeof createTestUser>;
+  let otherPilot: ReturnType<typeof createTestUser>;
+  let testLeague: ReturnType<typeof createTestLeague>;
+  let testSeason: ReturnType<typeof createTestSeason>;
+  let testTask: ReturnType<typeof createTestTask>;
+
+  beforeEach(async () => {
+    resetTestDb();
+    db = getTestDb();
+    setupTestDatabase(db);
+
+    adminUser = createTestUser(db, { email: 'admin@test.com' });
+    pilotUser = createTestUser(db, { email: 'pilot@test.com' });
+    otherPilot = createTestUser(db, { email: 'other@test.com' });
+    testLeague = createTestLeague(db, { slug: 'test-league' });
+    testSeason = createTestSeason(db, testLeague.id);
+    testTask = createTestTask(db, testSeason.id, testLeague.id);
+
+    addLeagueMember(db, testLeague.id, adminUser.id, 'admin');
+    addLeagueMember(db, testLeague.id, pilotUser.id, 'pilot');
+    addLeagueMember(db, testLeague.id, otherPilot.id, 'pilot');
+
+    app = await buildTestApp(db);
+  });
+
+  const deleteUrl = (submissionId: string) =>
+    `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${testTask.id}/submissions/${submissionId}`;
+
+  it('soft-deletes the submission + linked attempts and rebuilds task_results', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    const attemptId = createTestAttempt(db, submissionId, testTask.id, pilotUser.id, testLeague.id, {
+      distanceFlownKm: 12.3,
+    });
+    // Seed the cache so we can verify rebuildTaskResults actually fired.
+    db.prepare(
+      `INSERT INTO task_results (id, task_id, user_id, best_attempt_id, distance_flown_km,
+         reached_goal, distance_points, time_points, total_points, has_flagged_crossings, rank,
+         last_computed_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 12.3, 0, 100, 0, 100, 0, 1, datetime('now'), datetime('now'), datetime('now'))`,
+    ).run(randomUUID(), testTask.id, pilotUser.id, attemptId);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).message).toMatch(/deleted/i);
+
+    const sub = db.prepare(`SELECT deleted_at FROM flight_submissions WHERE id = ?`).get(submissionId) as any;
+    expect(sub.deleted_at).not.toBeNull();
+
+    const att = db.prepare(`SELECT deleted_at FROM flight_attempts WHERE id = ?`).get(attemptId) as any;
+    expect(att.deleted_at).not.toBeNull();
+
+    // Pilot was the only entrant — rebuildTaskResults drops the row.
+    const trCount = db
+      .prepare(`SELECT COUNT(*) AS c FROM task_results WHERE task_id = ? AND user_id = ?`)
+      .get(testTask.id, pilotUser.id) as any;
+    expect(trCount.c).toBe(0);
+  });
+
+  it('promotes the next-best attempt when the deleted submission held the lead', async () => {
+    // Same pilot, two submissions: 20 km (best) and 5 km. Delete the 20 km one
+    // and the pilot's task_results row should now reflect the 5 km attempt.
+    const subBest = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    createTestAttempt(db, subBest, testTask.id, pilotUser.id, testLeague.id, { distanceFlownKm: 20 });
+
+    const subWorse = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    const worseAttempt = createTestAttempt(db, subWorse, testTask.id, pilotUser.id, testLeague.id, {
+      distanceFlownKm: 5,
+    });
+
+    // Prime task_results with the current best so we can confirm the rebuild
+    // moved the pointer.
+    rebuildTaskResults(db, testTask.id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(subBest),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const tr = db
+      .prepare(`SELECT best_attempt_id, distance_flown_km FROM task_results WHERE task_id = ? AND user_id = ?`)
+      .get(testTask.id, pilotUser.id) as any;
+    expect(tr.best_attempt_id).toBe(worseAttempt);
+    expect(tr.distance_flown_km).toBe(5);
+  });
+
+  it('leaves other pilots untouched', async () => {
+    const subPilot = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    createTestAttempt(db, subPilot, testTask.id, pilotUser.id, testLeague.id, { distanceFlownKm: 10 });
+    const subOther = createTestSubmission(db, testTask.id, otherPilot.id, testLeague.id);
+    createTestAttempt(db, subOther, testTask.id, otherPilot.id, testLeague.id, { distanceFlownKm: 8 });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(subPilot),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const otherSub = db.prepare(`SELECT deleted_at FROM flight_submissions WHERE id = ?`).get(subOther) as any;
+    expect(otherSub.deleted_at).toBeNull();
+  });
+
+  it('returns 403 when a pilot tries to delete', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': pilotUser.id },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 404 when the submission does not belong to the URL task', async () => {
+    const otherTask = createTestTask(db, testSeason.id, testLeague.id, { id: randomUUID() });
+    const submissionId = createTestSubmission(db, otherTask.id, pilotUser.id, testLeague.id);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the submission is already soft-deleted (idempotency guard)', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    db.prepare(`UPDATE flight_submissions SET deleted_at = datetime('now') WHERE id = ?`).run(submissionId);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -20,6 +20,7 @@ import {
   createTestSeason,
   createTestSubmission,
   createTestTask,
+  createTestTaskResult,
   createTestUser,
   setupTestDatabase,
 } from '../helpers';
@@ -1322,7 +1323,7 @@ describe('GOAL_LINE import — goal_line_bearing_deg persistence', () => {
 // Admin submission moderation — DELETE /tasks/:taskId/submissions/:submissionId
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Submission moderation — DELETE /submissions/:submissionId', () => {
+describe('Submission moderation — DELETE /tasks/:taskId/submissions/:submissionId', () => {
   let app: ReturnType<typeof Fastify>;
   let db: ReturnType<typeof getTestDb>;
   let adminUser: ReturnType<typeof createTestUser>;
@@ -1360,12 +1361,11 @@ describe('Submission moderation — DELETE /submissions/:submissionId', () => {
       distanceFlownKm: 12.3,
     });
     // Seed the cache so we can verify rebuildTaskResults actually fired.
-    db.prepare(
-      `INSERT INTO task_results (id, task_id, user_id, best_attempt_id, distance_flown_km,
-         reached_goal, distance_points, time_points, total_points, has_flagged_crossings, rank,
-         last_computed_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 12.3, 0, 100, 0, 100, 0, 1, datetime('now'), datetime('now'), datetime('now'))`,
-    ).run(randomUUID(), testTask.id, pilotUser.id, attemptId);
+    createTestTaskResult(db, testTask.id, pilotUser.id, testLeague.id, attemptId, {
+      distanceFlownKm: 12.3,
+      distancePoints: 100,
+      totalPoints: 100,
+    });
 
     const res = await app.inject({
       method: 'DELETE',

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -1466,5 +1466,144 @@ describe('Submission moderation — DELETE /tasks/:taskId/submissions/:submissio
       headers: { 'x-test-user-id': adminUser.id },
     });
     expect(res.statusCode).toBe(404);
+
+    // 404 from the pre-read short-circuits before the txn opens, so no audit
+    // row should leak.
+    const auditCount = db
+      .prepare(`SELECT COUNT(*) AS c FROM admin_audit_log WHERE action = 'DELETE_SUBMISSION'`)
+      .get() as { c: number };
+    expect(auditCount.c).toBe(0);
   });
+
+  it('returns 404 when the parent task is soft-deleted', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    db.prepare(`UPDATE tasks SET deleted_at = datetime('now') WHERE id = ?`).run(testTask.id);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the parent season is soft-deleted', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    db.prepare(`UPDATE seasons SET deleted_at = datetime('now') WHERE id = ?`).run(testSeason.id);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the submission belongs to a different league than the URL', async () => {
+    // Admin of testLeague tries to delete a submission in otherLeague by
+    // pasting otherLeague's submissionId into testLeague's URL path. The
+    // pre-read JOIN chain (s.league_id = league.id) refuses it.
+    const otherLeague = createTestLeague(db, { slug: 'other-league' });
+    const otherSeason = createTestSeason(db, otherLeague.id);
+    const otherTask = createTestTask(db, otherSeason.id, otherLeague.id);
+    const otherSubmission = createTestSubmission(db, otherTask.id, pilotUser.id, otherLeague.id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(otherSubmission),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(404);
+
+    // Submission in the other league is untouched.
+    const stillLive = db
+      .prepare(`SELECT deleted_at FROM flight_submissions WHERE id = ?`)
+      .get(otherSubmission) as any;
+    expect(stillLive.deleted_at).toBeNull();
+  });
+
+  it('soft-deletes every attempt when the submission has multiple attempts', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    const a0 = createTestAttempt(db, submissionId, testTask.id, pilotUser.id, testLeague.id, {
+      distanceFlownKm: 8,
+      attemptIndex: 0,
+    });
+    const a1 = createTestAttempt(db, submissionId, testTask.id, pilotUser.id, testLeague.id, {
+      distanceFlownKm: 12,
+      attemptIndex: 1,
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const rows = db
+      .prepare(`SELECT id, deleted_at FROM flight_attempts WHERE id IN (?, ?)`)
+      .all(a0, a1) as Array<{ id: string; deleted_at: string | null }>;
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.deleted_at).not.toBeNull();
+    }
+  });
+
+  it('recomputes ranks of surviving pilots after the leader is removed', async () => {
+    // Pilot is leader at 20 km; otherPilot trails at 10 km.
+    const leaderSub = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    createTestAttempt(db, leaderSub, testTask.id, pilotUser.id, testLeague.id, { distanceFlownKm: 20 });
+
+    const survivorSub = createTestSubmission(db, testTask.id, otherPilot.id, testLeague.id);
+    createTestAttempt(db, survivorSub, testTask.id, otherPilot.id, testLeague.id, { distanceFlownKm: 10 });
+
+    rebuildTaskResults(db, testTask.id);
+
+    const before = db
+      .prepare(`SELECT rank FROM task_results WHERE task_id = ? AND user_id = ?`)
+      .get(testTask.id, otherPilot.id) as { rank: number };
+    expect(before.rank).toBe(2);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(leaderSub),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const after = db
+      .prepare(`SELECT rank, distance_flown_km FROM task_results WHERE task_id = ? AND user_id = ?`)
+      .get(testTask.id, otherPilot.id) as { rank: number; distance_flown_km: number };
+    expect(after.rank).toBe(1);
+    expect(after.distance_flown_km).toBe(10);
+  });
+
+  it('writes an admin_audit_log row recording the moderation', async () => {
+    const submissionId = createTestSubmission(db, testTask.id, pilotUser.id, testLeague.id);
+    createTestAttempt(db, submissionId, testTask.id, pilotUser.id, testLeague.id, { distanceFlownKm: 7 });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: deleteUrl(submissionId),
+      headers: { 'x-test-user-id': adminUser.id },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const audit = db
+      .prepare(
+        `SELECT actor_user_id, target_user_id, action, details
+           FROM admin_audit_log
+          WHERE action = 'DELETE_SUBMISSION' AND target_user_id = ?`,
+      )
+      .get(pilotUser.id) as { actor_user_id: string; target_user_id: string; action: string; details: string };
+    expect(audit).toBeDefined();
+    expect(audit.actor_user_id).toBe(adminUser.id);
+    expect(audit.target_user_id).toBe(pilotUser.id);
+    expect(audit.action).toBe('DELETE_SUBMISSION');
+    expect(JSON.parse(audit.details)).toEqual({
+      leagueId: testLeague.id,
+      seasonId: testSeason.id,
+      taskId: testTask.id,
+      submissionId,
+    });
+  });
+
 });

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -1498,25 +1498,29 @@ describe('Submission moderation — DELETE /tasks/:taskId/submissions/:submissio
   });
 
   it('returns 404 when the submission belongs to a different league than the URL', async () => {
-    // Admin of testLeague tries to delete a submission in otherLeague by
-    // pasting otherLeague's submissionId into testLeague's URL path. The
-    // pre-read JOIN chain (s.league_id = league.id) refuses it.
+    // Admin of testLeague is also admin of otherLeague (so requireLeagueAdmin
+    // would pass for either) — they craft a URL with testLeague's slug but
+    // otherLeague's season/task/submission ids. The path makes it past the
+    // task and season filters in the pre-read; only the `s.league_id =
+    // league.id` clause stops it (request.league resolves to testLeague via
+    // the slug, but the season chain leads to otherLeague). This is what
+    // exercises the league guard specifically.
     const otherLeague = createTestLeague(db, { slug: 'other-league' });
+    addLeagueMember(db, otherLeague.id, adminUser.id, 'admin');
     const otherSeason = createTestSeason(db, otherLeague.id);
     const otherTask = createTestTask(db, otherSeason.id, otherLeague.id);
     const otherSubmission = createTestSubmission(db, otherTask.id, pilotUser.id, otherLeague.id);
 
+    const url = `/leagues/${testLeague.slug}/seasons/${otherSeason.id}/tasks/${otherTask.id}/submissions/${otherSubmission}`;
     const res = await app.inject({
       method: 'DELETE',
-      url: deleteUrl(otherSubmission),
+      url,
       headers: { 'x-test-user-id': adminUser.id },
     });
     expect(res.statusCode).toBe(404);
 
     // Submission in the other league is untouched.
-    const stillLive = db
-      .prepare(`SELECT deleted_at FROM flight_submissions WHERE id = ?`)
-      .get(otherSubmission) as any;
+    const stillLive = db.prepare(`SELECT deleted_at FROM flight_submissions WHERE id = ?`).get(otherSubmission) as any;
     expect(stillLive.deleted_at).toBeNull();
   });
 
@@ -1538,9 +1542,10 @@ describe('Submission moderation — DELETE /tasks/:taskId/submissions/:submissio
     });
     expect(res.statusCode).toBe(200);
 
-    const rows = db
-      .prepare(`SELECT id, deleted_at FROM flight_attempts WHERE id IN (?, ?)`)
-      .all(a0, a1) as Array<{ id: string; deleted_at: string | null }>;
+    const rows = db.prepare(`SELECT id, deleted_at FROM flight_attempts WHERE id IN (?, ?)`).all(a0, a1) as Array<{
+      id: string;
+      deleted_at: string | null;
+    }>;
     expect(rows).toHaveLength(2);
     for (const row of rows) {
       expect(row.deleted_at).not.toBeNull();
@@ -1605,5 +1610,4 @@ describe('Submission moderation — DELETE /tasks/:taskId/submissions/:submissio
       submissionId,
     });
   });
-
 });


### PR DESCRIPTION
Closes #34.

## Summary
- New `DELETE /api/v1/leagues/:slug/seasons/:id/tasks/:id/submissions/:id` (admin-only).
- Soft-deletes the `flight_submissions` row + linked `flight_attempts`, emits an `admin_audit_log` row (action `DELETE_SUBMISSION`, target = pilot, details = JSON of the URL identifiers), then calls `rebuildTaskResults` synchronously in the same txn. The pilot's `task_results` row recomputes from their remaining best attempt — or drops entirely if that was their only submission.
- Per-submission cousin of the existing task soft-delete cascade at `src/routes/leagues.ts:1722`. Same audit-friendly pattern (soft-delete on tables that have `deleted_at`; rely on the rebuild to refresh the computed cache).
- Unblocks #40 (open_date guard becomes useful only once admins can remove the submissions that would lock it).

## Implementation notes
- `rebuildTaskResults` already wipes `task_results` for the task and recomputes from the live (non-deleted) `flight_attempts`, so explicit pilot-row deletion is unnecessary — the rebuild is the single source of truth.
- The pre-read gates on `fs.deleted_at`, `t.deleted_at`, and `s.deleted_at IS NULL` — soft-deleted parents short-circuit before the txn opens.
- The UPDATE on `flight_submissions` re-checks `AND deleted_at IS NULL` and bails with 404 if `changes === 0`, closing the TOCTOU window between the pre-read and the write.

## Test plan
- [x] `npx vitest run` — 232/232 pass
- [x] `npm run typecheck` — clean
- [x] Manual run against a copy of the production DB: happy path, idempotency 404, pilot 403, cross-task 404, and full row-drop after deleting every submission a pilot had.
- [x] `Submission moderation` block in `tests/routes/tasks.test.ts` covers:
  - happy path: row + attempts marked deleted, pilot's `task_results` dropped
  - promotes the next-best attempt when the deleted submission held the lead
  - leaves other pilots' submissions untouched
  - 403 for pilots, 404 for cross-task submissionId
  - idempotency (re-delete returns 404 AND no audit-log row leaks)
  - 404 when the parent task or season is soft-deleted
  - 404 when the submission belongs to a different league than the URL
  - soft-deletes every attempt when the submission has multiple attempts
  - recomputes ranks of surviving pilots after the leader is removed
  - writes an `admin_audit_log` row with the correct actor / target / action / details JSON