### PR TITLE
Per-submission breakdown on the task panel (#41)

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -41,6 +41,21 @@ export interface AttemptResult {
   turnpointsCrossed: number;
 }
 
+/**
+ * Per-submission attempt facts. Same shape as AttemptResult minus the score
+ * fields — those would mix submission-time numbers with the live per-pilot
+ * scoring and could read as stale or impossible. The leaderboard's
+ * `bestAttempt` is the source of truth for points.
+ */
+export interface SubmissionAttemptFacts {
+  attemptIndex: number;
+  reachedGoal: boolean;
+  distanceFlownKm: number;
+  lastTurnpointIndex: number;
+  taskTimeS: number | null;
+  hasFlaggedCrossings: boolean;
+}
+
 export interface Submission {
   id: string;
   status: 'PROCESSED' | 'INVALID' | 'PENDING' | 'PROCESSING' | 'ERROR';
@@ -50,6 +65,10 @@ export interface Submission {
   igcDate: string | null;
   bestAttempt: AttemptResult;
   allAttempts: AttemptResult[];
+  /** Facts about *this* submission's own best attempt (not the leaderboard's). */
+  thisSubmission: SubmissionAttemptFacts | null;
+  /** True iff this submission's best attempt is the one currently on the leaderboard. */
+  isCurrentBest: boolean;
   timePointsProvisional: boolean;
 }
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -65,10 +65,19 @@ export interface Submission {
   igcDate: string | null;
   bestAttempt: AttemptResult;
   allAttempts: AttemptResult[];
-  /** Facts about *this* submission's own best attempt (not the leaderboard's). */
-  thisSubmission: SubmissionAttemptFacts | null;
-  /** True iff this submission's best attempt is the one currently on the leaderboard. */
-  isCurrentBest: boolean;
+  /**
+   * Facts about *this* submission's own best attempt (not the leaderboard's).
+   * Optional because the POST upload response doesn't populate it (only the
+   * GET list does), and even on GET it's null when fs.best_attempt_id hasn't
+   * been set yet (mid-processing).
+   */
+  thisSubmission?: SubmissionAttemptFacts | null;
+  /**
+   * True iff this submission's best attempt is the one currently on the
+   * leaderboard. Optional for the same reason as thisSubmission — only the
+   * GET list response populates it.
+   */
+  isCurrentBest?: boolean;
   timePointsProvisional: boolean;
 }
 

--- a/frontend/src/components/MySubmissions.tsx
+++ b/frontend/src/components/MySubmissions.tsx
@@ -92,10 +92,7 @@ export default function MySubmissions({ taskId, totalTurnpoints }: Props) {
             {data.map((sub) => {
               const f = sub.thisSubmission;
               return (
-                <tr
-                  key={sub.id}
-                  style={{ background: sub.isCurrentBest ? 'rgba(59,130,246,0.07)' : undefined }}
-                >
+                <tr key={sub.id} style={{ background: sub.isCurrentBest ? 'rgba(59,130,246,0.07)' : undefined }}>
                   <td style={{ ...TD, fontFamily: 'var(--font-mono)', color: 'var(--text2)' }}>
                     {fmtDateTime(sub.submittedAt)}
                   </td>

--- a/frontend/src/components/MySubmissions.tsx
+++ b/frontend/src/components/MySubmissions.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from '@tanstack/react-query';
+import { type Submission, submissionsApi } from '../api/tasks';
+import { useLeague } from '../hooks/useLeague';
+
+const TH: React.CSSProperties = {
+  padding: '4px 8px',
+  textAlign: 'left',
+  fontWeight: 600,
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: 'var(--text3)',
+  borderBottom: '1px solid var(--border)',
+  whiteSpace: 'nowrap',
+};
+
+const TD: React.CSSProperties = {
+  padding: '5px 8px',
+  borderBottom: '1px solid var(--border)',
+  fontSize: 12,
+  whiteSpace: 'nowrap',
+  verticalAlign: 'top',
+};
+
+function fmtDateTime(iso: string) {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+/**
+ * Plain-English label for what the pilot reached on this attempt.
+ * `lastTurnpointIndex` is 0 for SSS-only, then 1..N for each turnpoint reached.
+ * Goal trumps everything else.
+ */
+function reachedLabel(s: NonNullable<Submission['thisSubmission']>, totalTurnpoints: number) {
+  if (s.reachedGoal) return 'Reached goal';
+  if (s.lastTurnpointIndex === 0) return 'Reached SSS';
+  // turnpoints array indexes 0=SSS, 1..N-1=intermediates+ESS+GOAL.
+  // Pilot-facing TP numbering treats SSS as "the start" and counts from TP1.
+  return `Reached TP${s.lastTurnpointIndex} of ${Math.max(0, totalTurnpoints - 2)}`;
+}
+
+interface Props {
+  taskId: string;
+  /** Total turnpoints in the task (used to format "TP X of N"). */
+  totalTurnpoints: number;
+}
+
+export default function MySubmissions({ taskId, totalTurnpoints }: Props) {
+  const { leagueSlug, seasonId } = useLeague();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['submissions', leagueSlug, seasonId, taskId],
+    queryFn: () => submissionsApi.list(leagueSlug, seasonId, taskId),
+    select: (res) => res.submissions,
+    staleTime: 60 * 1000,
+  });
+
+  if (isLoading || isError || !data || data.length === 0) {
+    // Empty / loading / error states are silent — the upload zone above this
+    // already handles "no submissions yet" and the leaderboard itself surfaces
+    // any score. There's nothing useful to show here in those cases.
+    return null;
+  }
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+          color: 'var(--text3)',
+          fontFamily: 'var(--font-mono)',
+          marginBottom: 8,
+        }}
+      >
+        Your Submissions
+      </div>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr>
+              <th style={TH}>Submitted</th>
+              <th style={TH}>File</th>
+              <th style={TH}>Result</th>
+              <th style={{ ...TH, textAlign: 'right' }}>Dist</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((sub) => {
+              const f = sub.thisSubmission;
+              return (
+                <tr
+                  key={sub.id}
+                  style={{ background: sub.isCurrentBest ? 'rgba(59,130,246,0.07)' : undefined }}
+                >
+                  <td style={{ ...TD, fontFamily: 'var(--font-mono)', color: 'var(--text2)' }}>
+                    {fmtDateTime(sub.submittedAt)}
+                  </td>
+                  <td style={{ ...TD, color: 'var(--text2)' }}>
+                    <span style={{ fontFamily: 'var(--font-mono)' }}>{sub.igcFilename}</span>
+                    {sub.isCurrentBest && (
+                      <span
+                        style={{
+                          marginLeft: 6,
+                          fontSize: 10,
+                          color: 'var(--accent)',
+                          fontFamily: 'var(--font-mono)',
+                          fontWeight: 700,
+                        }}
+                      >
+                        ← scored as best
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ ...TD, color: 'var(--text)' }}>
+                    {f ? (
+                      <>
+                        {reachedLabel(f, totalTurnpoints)}
+                        {f.hasFlaggedCrossings && (
+                          <span style={{ marginLeft: 6, color: 'var(--warning)' }} title="Unconfirmed crossing">
+                            ⚑
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span style={{ color: 'var(--text3)' }}>{sub.status.toLowerCase()}</span>
+                    )}
+                  </td>
+                  <td style={{ ...TD, textAlign: 'right', fontFamily: 'var(--font-mono)', color: 'var(--text2)' }}>
+                    {f ? `${f.distanceFlownKm.toFixed(2)} km` : '—'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MySubmissions.tsx
+++ b/frontend/src/components/MySubmissions.tsx
@@ -120,7 +120,12 @@ export default function MySubmissions({ taskId, totalTurnpoints }: Props) {
                       <>
                         {reachedLabel(f, totalTurnpoints)}
                         {f.hasFlaggedCrossings && (
-                          <span style={{ marginLeft: 6, color: 'var(--warning)' }} title="Unconfirmed crossing">
+                          <span
+                            role="img"
+                            aria-label="Unconfirmed turnpoint crossing"
+                            title="Unconfirmed crossing"
+                            style={{ marginLeft: 6, color: 'var(--warning)' }}
+                          >
                             ⚑
                           </span>
                         )}

--- a/frontend/src/components/MySubmissions.tsx
+++ b/frontend/src/components/MySubmissions.tsx
@@ -44,9 +44,17 @@ interface Props {
   taskId: string;
   /** Total turnpoints in the task (used to format "TP X of N"). */
   totalTurnpoints: number;
+  /**
+   * Currently-selected submission for track display (controlled by the parent
+   * which shares one "show track for X" slot with the leaderboard). Rows match
+   * this id get the selected styling.
+   */
+  selectedSubmissionId?: string | null;
+  /** Click handler — fired with a row's submissionId. Parent decides what to do (e.g. fetch and render its track). */
+  onSelectSubmission?: (submissionId: string) => void;
 }
 
-export default function MySubmissions({ taskId, totalTurnpoints }: Props) {
+export default function MySubmissions({ taskId, totalTurnpoints, selectedSubmissionId, onSelectSubmission }: Props) {
   const { leagueSlug, seasonId } = useLeague();
 
   const { data, isLoading, isError } = useQuery({
@@ -91,8 +99,27 @@ export default function MySubmissions({ taskId, totalTurnpoints }: Props) {
           <tbody>
             {data.map((sub) => {
               const f = sub.thisSubmission;
+              // A row is clickable when it has a parseable attempt (so the
+              // track endpoint can return something) AND the parent wired up
+              // a handler. Selected row gets the leaderboard's purple tint;
+              // current-best row (when not selected) keeps the blue tint.
+              const isSelected = !!selectedSubmissionId && sub.id === selectedSubmissionId;
+              const clickable = !!onSelectSubmission && !!f;
+              const bg = isSelected
+                ? 'rgba(167,139,250,0.12)'
+                : sub.isCurrentBest
+                  ? 'rgba(59,130,246,0.07)'
+                  : undefined;
               return (
-                <tr key={sub.id} style={{ background: sub.isCurrentBest ? 'rgba(59,130,246,0.07)' : undefined }}>
+                <tr
+                  key={sub.id}
+                  onClick={clickable ? () => onSelectSubmission!(sub.id) : undefined}
+                  style={{
+                    background: bg,
+                    cursor: clickable ? 'pointer' : undefined,
+                    outline: isSelected ? '1px solid rgba(167,139,250,0.4)' : undefined,
+                  }}
+                >
                   <td style={{ ...TD, fontFamily: 'var(--font-mono)', color: 'var(--text2)' }}>
                     {fmtDateTime(sub.submittedAt)}
                   </td>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -180,8 +180,12 @@ function TaskLeftPanel({
       {/* Upload zone */}
       <UploadZone taskId={task.id} taskStatus={taskStatus} task={task} />
 
-      {/* Pilot's per-submission breakdown — only renders if the viewer is a
-          logged-in league member with at least one submission on this task. */}
+      {/* Pilot's per-submission breakdown — only mounts for logged-in viewers.
+          GET /submissions returns 403 for logged-in non-members of the league;
+          MySubmissions handles that by silently rendering null. We don't gate on
+          membership here because the User type doesn't carry memberships, and a
+          one-off 403'd request per task-panel view by a non-member is cheaper
+          than fetching the member list just to suppress it. */}
       {myId && <MySubmissions taskId={task.id} totalTurnpoints={task.turnpoints.length} />}
     </>
   );

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import { tasksApi } from '../api/tasks';
 import type { ReplayFix } from '../api/track';
 import { trackApi } from '../api/track';
 import LeagueSwitcher from '../components/LeagueSwitcher';
+import MySubmissions from '../components/MySubmissions';
 import ScoringExplainer from '../components/ScoringExplainer';
 import StandingsMatrix from '../components/StandingsMatrix';
 import TaskLeaderboard from '../components/TaskLeaderboard';
@@ -178,6 +179,10 @@ function TaskLeftPanel({
 
       {/* Upload zone */}
       <UploadZone taskId={task.id} taskStatus={taskStatus} task={task} />
+
+      {/* Pilot's per-submission breakdown — only renders if the viewer is a
+          logged-in league member with at least one submission on this task. */}
+      {myId && <MySubmissions taskId={task.id} totalTurnpoints={task.turnpoints.length} />}
     </>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -109,16 +109,20 @@ function TaskLeftPanel({
   leaderboardLoading,
   myId,
   selectedPilotId,
+  selectedSubmissionId,
   trackLoading,
   onSelectPilot,
+  onSelectMySubmission,
 }: {
   task: Task;
   leaderboardEntries: LeaderboardEntry[];
   leaderboardLoading: boolean;
   myId: string | undefined;
   selectedPilotId: string | undefined;
+  selectedSubmissionId: string | null;
   trackLoading: boolean;
   onSelectPilot: (entry: LeaderboardEntry) => void;
+  onSelectMySubmission: (submissionId: string) => void;
 }) {
   const taskStatus = getTaskStatus(task);
   const ss = STATUS_STYLE[taskStatus];
@@ -186,7 +190,14 @@ function TaskLeftPanel({
           membership here because the User type doesn't carry memberships, and a
           one-off 403'd request per task-panel view by a non-member is cheaper
           than fetching the member list just to suppress it. */}
-      {myId && <MySubmissions taskId={task.id} totalTurnpoints={task.turnpoints.length} />}
+      {myId && (
+        <MySubmissions
+          taskId={task.id}
+          totalTurnpoints={task.turnpoints.length}
+          selectedSubmissionId={selectedSubmissionId}
+          onSelectSubmission={onSelectMySubmission}
+        />
+      )}
     </>
   );
 }
@@ -268,8 +279,41 @@ export default function HomePage() {
   const activeEntry = selectedEntry;
 
   const handleSelectPilot = (entry: LeaderboardEntry) => {
-    setSelectedEntry((prev) => (prev?.pilotId === entry.pilotId ? null : entry));
+    setSelectedEntry((prev) => (prev?.submissionId === entry.submissionId ? null : entry));
   };
+
+  // Click on a row in MySubmissions — fabricate a LeaderboardEntry-shaped row
+  // whose submissionId points at the chosen submission (which may not be the
+  // pilot's leaderboard best). The track-fetch query keys off submissionId, so
+  // this drives the same map slot the leaderboard does.
+  const handleSelectMySubmission = (submissionId: string) => {
+    if (!user) return;
+    setSelectedEntry((prev) => {
+      if (prev?.submissionId === submissionId) return null;
+      const myLeaderboardEntry = activeEntries.find((e) => e.pilotId === user.id);
+      if (myLeaderboardEntry) return { ...myLeaderboardEntry, submissionId };
+      return {
+        rank: 0,
+        pilotId: user.id,
+        pilotName: user.displayName,
+        submissionId,
+        distanceFlownKm: 0,
+        reachedGoal: false,
+        taskTimeS: null,
+        distancePoints: 0,
+        timePoints: 0,
+        totalPoints: 0,
+        hasFlaggedCrossings: false,
+      };
+    });
+  };
+
+  // The leaderboard's row should highlight only when the *selected*
+  // submission is the one the leaderboard is currently scoring — otherwise
+  // the user picked a non-best from MySubmissions and the leaderboard row
+  // doesn't correspond to the track being shown.
+  const selectedSubmissionId = activeEntry?.submissionId ?? null;
+  const leaderboardSelectedPilotId = activeEntries.find((e) => e.submissionId === selectedSubmissionId)?.pilotId;
 
   // Fetch track for selected pilot
   const { data: trackData, isFetching: trackLoading } = useQuery({
@@ -445,9 +489,11 @@ export default function HomePage() {
               leaderboardEntries={activeEntries}
               leaderboardLoading={activeQuery?.isLoading ?? false}
               myId={user?.id}
-              selectedPilotId={activeEntry?.pilotId}
+              selectedPilotId={leaderboardSelectedPilotId}
+              selectedSubmissionId={selectedSubmissionId}
               trackLoading={trackLoading}
               onSelectPilot={handleSelectPilot}
+              onSelectMySubmission={handleSelectMySubmission}
             />
           ) : null)}
 

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -485,8 +485,21 @@
  *       id: string,
  *       status: string,
  *       submittedAt: string,
- *       bestAttempt: AttemptResult | null,
+ *       igcFilename: string,
+ *       igcSizeBytes: number,
+ *       igcDate: string | null,
+ *       bestAttempt: AttemptResult | null,        // pilot's overall best (matches the leaderboard); same on every row
  *       allAttempts: Array<AttemptResult>,
+ *       thisSubmission: {                          // facts about this specific submission's own best attempt
+ *         attemptIndex: number,
+ *         reachedGoal: boolean,
+ *         distanceFlownKm: number,
+ *         lastTurnpointIndex: number,
+ *         taskTimeS: number | null,
+ *         hasFlaggedCrossings: boolean,
+ *       } | null,                                  // null when fs.best_attempt_id hasn't been set (mid-processing)
+ *       isCurrentBest: boolean,                    // true iff this submission produced the attempt the leaderboard is using
+ *       timePointsProvisional: boolean,            // scores can shift while the task is open
  *     }>
  *   }
  */

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -489,7 +489,9 @@
  *       igcSizeBytes: number,
  *       igcDate: string | null,
  *       bestAttempt: AttemptResult | null,        // pilot's overall best (matches the leaderboard); same on every row
- *       allAttempts: Array<AttemptResult>,
+ *       allAttempts: Array<AttemptResult>,         // currently always [bestAttempt] or [] — single-element compatibility shim,
+ *                                                  //   not the full per-submission attempt list. Use thisSubmission for
+ *                                                  //   per-submission facts; the multi-attempt array is reserved for future use.
  *       thisSubmission: {                          // facts about this specific submission's own best attempt
  *         attemptIndex: number,
  *         reachedGoal: boolean,

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -297,27 +297,38 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       const userId = (request as any).user!.userId;
       const league = (request as any).league;
 
-      // Each row shows the pilot's *current* task state (their best attempt
-      // across all submissions for this task, scored against the live
-      // best-distance + goal-times set). Both the score columns and the
-      // attempt metadata are sourced via tr.best_attempt_id so attempt_index
-      // and turnpointsCrossed always describe the same attempt that produced
-      // the score — no risk of mixing metadata from one submission with
-      // scores from another. Every submission row therefore carries the
-      // same bestAttempt; that's correct because scoring is per-pilot
-      // per-task, not per-submission.
+      // Two attempt views per row:
+      //   bestAttempt   — the pilot's current overall best for the task,
+      //                   sourced via tr.best_attempt_id. Same on every row
+      //                   because scoring is per-pilot, not per-submission;
+      //                   matches the leaderboard.
+      //   thisSubmission — facts about *this specific* submission's own best
+      //                   detected attempt (joined via fs.best_attempt_id).
+      //                   No score fields — those would re-derive stale numbers
+      //                   (live scoring depends on every other pilot's flights).
+      //   isCurrentBest  — true iff this submission produced the attempt the
+      //                   leaderboard is currently using.
       const rows = db
         .prepare(
           `SELECT fs.id, fs.status, fs.igc_filename, fs.igc_size_bytes, fs.submitted_at, fs.igc_date,
+                fs.best_attempt_id          AS submission_best_attempt_id,
                 tr.reached_goal, tr.distance_flown_km, tr.task_time_s,
                 tr.distance_points, tr.time_points, tr.total_points,
                 tr.has_flagged_crossings,
+                tr.best_attempt_id          AS pilot_best_attempt_id,
                 fa.attempt_index, fa.last_turnpoint_index,
+                fas.attempt_index           AS sub_attempt_index,
+                fas.reached_goal            AS sub_reached_goal,
+                fas.distance_flown_km       AS sub_distance_flown_km,
+                fas.task_time_s             AS sub_task_time_s,
+                fas.last_turnpoint_index    AS sub_last_turnpoint_index,
+                fas.has_flagged_crossings   AS sub_has_flagged_crossings,
                 t.close_date AS task_close_date
          FROM flight_submissions fs
-         LEFT JOIN task_results tr ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
-         LEFT JOIN flight_attempts fa ON fa.id = tr.best_attempt_id
-         JOIN tasks t ON t.id = fs.task_id
+         LEFT JOIN task_results tr     ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
+         LEFT JOIN flight_attempts fa  ON fa.id  = tr.best_attempt_id
+         LEFT JOIN flight_attempts fas ON fas.id = fs.best_attempt_id AND fas.deleted_at IS NULL
+         JOIN tasks t   ON t.id = fs.task_id
          JOIN seasons s ON s.id = t.season_id
          WHERE fs.task_id = ? AND s.id = ? AND s.league_id = ?
            AND fs.user_id = ? AND fs.deleted_at IS NULL
@@ -342,6 +353,23 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
               }
             : null;
 
+        const thisSubmission =
+          row.sub_attempt_index != null
+            ? {
+                attemptIndex: row.sub_attempt_index,
+                reachedGoal: Boolean(row.sub_reached_goal),
+                distanceFlownKm: row.sub_distance_flown_km ?? 0,
+                lastTurnpointIndex: row.sub_last_turnpoint_index ?? 0,
+                taskTimeS: row.sub_task_time_s ?? null,
+                hasFlaggedCrossings: Boolean(row.sub_has_flagged_crossings),
+              }
+            : null;
+
+        const isCurrentBest =
+          row.submission_best_attempt_id != null &&
+          row.pilot_best_attempt_id != null &&
+          row.submission_best_attempt_id === row.pilot_best_attempt_id;
+
         const taskOpen = now <= new Date(row.task_close_date);
         return {
           id: row.id,
@@ -352,6 +380,8 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           igcDate: row.igc_date ?? null,
           bestAttempt,
           allAttempts: bestAttempt ? [bestAttempt] : [],
+          thisSubmission,
+          isCurrentBest,
           // Scores can change while the task is open (any new upload may shift
           // the best distance or goal-times set and rescore everyone).
           timePointsProvisional: taskOpen,

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -327,7 +327,11 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
          FROM flight_submissions fs
          LEFT JOIN task_results tr     ON tr.task_id = fs.task_id AND tr.user_id = fs.user_id
          LEFT JOIN flight_attempts fa  ON fa.id  = tr.best_attempt_id
-         LEFT JOIN flight_attempts fas ON fas.id = fs.best_attempt_id AND fas.deleted_at IS NULL
+         LEFT JOIN flight_attempts fas ON fas.id = fs.best_attempt_id
+                                       AND fas.submission_id = fs.id
+                                       AND fas.task_id       = fs.task_id
+                                       AND fas.user_id       = fs.user_id
+                                       AND fas.deleted_at IS NULL
          JOIN tasks t   ON t.id = fs.task_id
          JOIN seasons s ON s.id = t.season_id
          WHERE fs.task_id = ? AND s.id = ? AND s.league_id = ?

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { dropRedundantLeagueIdColumns } from '../src/migration-helpers';
@@ -183,9 +183,10 @@ export function createTestSubmission(
   overrides: Partial<{ id: string; igcSha256: string; igcFilename: string }> = {},
 ) {
   const id = overrides.id || randomUUID();
-  // Randomise sha by default so the same pilot can have multiple submissions
-  // on a task without tripping the (task_id, user_id, igc_sha256) unique idx.
-  const sha = overrides.igcSha256 || randomUUID();
+  // Random 64-char hex by default — matches the production sha256 format
+  // and lets the same pilot have multiple submissions on a task without
+  // tripping the (task_id, user_id, igc_sha256) unique index.
+  const sha = overrides.igcSha256 || randomBytes(32).toString('hex');
   const filename = overrides.igcFilename || 'test.igc';
   db.prepare(
     `INSERT INTO flight_submissions (

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -180,17 +180,21 @@ export function createTestSubmission(
   taskId: string,
   userId: string,
   leagueId: string,
-  overrides: Partial<{ id: string }> = {},
+  overrides: Partial<{ id: string; igcSha256: string; igcFilename: string }> = {},
 ) {
   const id = overrides.id || randomUUID();
+  // Randomise sha by default so the same pilot can have multiple submissions
+  // on a task without tripping the (task_id, user_id, igc_sha256) unique idx.
+  const sha = overrides.igcSha256 || randomUUID();
+  const filename = overrides.igcFilename || 'test.igc';
   db.prepare(
     `INSERT INTO flight_submissions (
        id, task_id, user_id, league_id,
        igc_data, igc_filename, igc_size_bytes, igc_sha256,
        status, submitted_at, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, '', 'test.igc', 0, 'abc', 'PROCESSED',
+     ) VALUES (?, ?, ?, ?, '', ?, 0, ?, 'PROCESSED',
                datetime('now'), datetime('now'), datetime('now'))`,
-  ).run(id, taskId, userId, leagueId);
+  ).run(id, taskId, userId, leagueId, filename, sha);
   return id;
 }
 

--- a/tests/routes/submissions.test.ts
+++ b/tests/routes/submissions.test.ts
@@ -127,7 +127,10 @@ describe('GET /tasks/:taskId/submissions — per-submission breakdown (#41)', ()
   });
 
   it('thisSubmission is null when fs.best_attempt_id has not been set yet', async () => {
-    // Brand-new submission, processing not yet wired up its best_attempt_id.
+    // Submission row exists without a best_attempt_id link — the test is
+    // exercising the join, not the status field, so it doesn't matter that
+    // the helper marks the row PROCESSED. Production hits this state mid-
+    // processing or when scoring fails before best_attempt_id is set.
     createTestSubmission(db, testTask.id, pilot.id, testLeague.id);
 
     const res = await app.inject({

--- a/tests/routes/submissions.test.ts
+++ b/tests/routes/submissions.test.ts
@@ -1,0 +1,165 @@
+// =============================================================================
+// Submissions API — GET /tasks/:taskId/submissions
+//
+// Covers the per-submission breakdown extension (#41): each row carries
+// `thisSubmission` (facts about the submission's own best attempt) and
+// `isCurrentBest` (whether this submission's best attempt is the one the
+// leaderboard is currently using). The pre-existing `bestAttempt` payload
+// (the pilot's overall best, matching the leaderboard) is unchanged.
+// =============================================================================
+
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { authPlugin, loadAuthConfig } from '../../src/auth';
+import { rebuildTaskResults } from '../../src/job-queue';
+import { registerLeagueRoutes } from '../../src/routes/leagues';
+import {
+  addLeagueMember,
+  createTestAttempt,
+  createTestLeague,
+  createTestSeason,
+  createTestSubmission,
+  createTestTask,
+  createTestUser,
+  setupTestDatabase,
+} from '../helpers';
+import { getTestDb, resetTestDb } from '../setup';
+
+async function buildTestApp(db: ReturnType<typeof getTestDb>) {
+  const app = Fastify();
+  await app.register(authPlugin, { config: loadAuthConfig(), db });
+  await registerLeagueRoutes(app, { db });
+  await app.ready();
+  return app;
+}
+
+/** Wire submission → attempt by setting flight_submissions.best_attempt_id. */
+function linkSubmissionBestAttempt(db: ReturnType<typeof getTestDb>, submissionId: string, attemptId: string) {
+  db.prepare(`UPDATE flight_submissions SET best_attempt_id = ? WHERE id = ?`).run(attemptId, submissionId);
+}
+
+describe('GET /tasks/:taskId/submissions — per-submission breakdown (#41)', () => {
+  let app: ReturnType<typeof Fastify>;
+  let db: ReturnType<typeof getTestDb>;
+  let pilot: ReturnType<typeof createTestUser>;
+  let testLeague: ReturnType<typeof createTestLeague>;
+  let testSeason: ReturnType<typeof createTestSeason>;
+  let testTask: ReturnType<typeof createTestTask>;
+
+  beforeEach(async () => {
+    resetTestDb();
+    db = getTestDb();
+    setupTestDatabase(db);
+
+    pilot = createTestUser(db, { email: 'pilot@test.com' });
+    testLeague = createTestLeague(db, { slug: 'test-league' });
+    testSeason = createTestSeason(db, testLeague.id);
+    testTask = createTestTask(db, testSeason.id, testLeague.id);
+    addLeagueMember(db, testLeague.id, pilot.id, 'pilot');
+
+    app = await buildTestApp(db);
+  });
+
+  const listUrl = () => `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${testTask.id}/submissions`;
+
+  it('populates thisSubmission for each row from fs.best_attempt_id', async () => {
+    const subA = createTestSubmission(db, testTask.id, pilot.id, testLeague.id, { igcFilename: 'a.igc' });
+    const attA = createTestAttempt(db, subA, testTask.id, pilot.id, testLeague.id, {
+      distanceFlownKm: 2.795,
+    });
+    linkSubmissionBestAttempt(db, subA, attA);
+
+    const subB = createTestSubmission(db, testTask.id, pilot.id, testLeague.id, { igcFilename: 'b.igc' });
+    const attB = createTestAttempt(db, subB, testTask.id, pilot.id, testLeague.id, {
+      distanceFlownKm: 1.178,
+      attemptIndex: 0,
+    });
+    linkSubmissionBestAttempt(db, subB, attB);
+
+    rebuildTaskResults(db, testTask.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: listUrl(),
+      headers: { 'x-test-user-id': pilot.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { submissions } = JSON.parse(res.body) as { submissions: any[] };
+    expect(submissions).toHaveLength(2);
+
+    // Each row's thisSubmission reflects its own attempt.
+    const byFile = new Map(submissions.map((s) => [s.igcFilename, s]));
+    expect(byFile.get('a.igc').thisSubmission.distanceFlownKm).toBeCloseTo(2.795);
+    expect(byFile.get('b.igc').thisSubmission.distanceFlownKm).toBeCloseTo(1.178);
+
+    // bestAttempt is the per-pilot overall best — same on both rows.
+    expect(byFile.get('a.igc').bestAttempt.distanceFlownKm).toBeCloseTo(2.795);
+    expect(byFile.get('b.igc').bestAttempt.distanceFlownKm).toBeCloseTo(2.795);
+  });
+
+  it('isCurrentBest is true only for the submission whose attempt the leaderboard uses', async () => {
+    const subBest = createTestSubmission(db, testTask.id, pilot.id, testLeague.id, { igcFilename: 'best.igc' });
+    const attBest = createTestAttempt(db, subBest, testTask.id, pilot.id, testLeague.id, {
+      distanceFlownKm: 20,
+    });
+    linkSubmissionBestAttempt(db, subBest, attBest);
+
+    const subWorse = createTestSubmission(db, testTask.id, pilot.id, testLeague.id, { igcFilename: 'worse.igc' });
+    const attWorse = createTestAttempt(db, subWorse, testTask.id, pilot.id, testLeague.id, {
+      distanceFlownKm: 5,
+    });
+    linkSubmissionBestAttempt(db, subWorse, attWorse);
+
+    rebuildTaskResults(db, testTask.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: listUrl(),
+      headers: { 'x-test-user-id': pilot.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { submissions } = JSON.parse(res.body) as { submissions: any[] };
+    const byFile = new Map(submissions.map((s) => [s.igcFilename, s]));
+    expect(byFile.get('best.igc').isCurrentBest).toBe(true);
+    expect(byFile.get('worse.igc').isCurrentBest).toBe(false);
+  });
+
+  it('thisSubmission is null when fs.best_attempt_id has not been set yet', async () => {
+    // Brand-new submission, processing not yet wired up its best_attempt_id.
+    createTestSubmission(db, testTask.id, pilot.id, testLeague.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: listUrl(),
+      headers: { 'x-test-user-id': pilot.id },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { submissions } = JSON.parse(res.body) as { submissions: any[] };
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].thisSubmission).toBeNull();
+    expect(submissions[0].isCurrentBest).toBe(false);
+  });
+
+  it('preserves the pre-existing bestAttempt + timePointsProvisional fields', async () => {
+    const sub = createTestSubmission(db, testTask.id, pilot.id, testLeague.id);
+    const att = createTestAttempt(db, sub, testTask.id, pilot.id, testLeague.id, { distanceFlownKm: 8 });
+    linkSubmissionBestAttempt(db, sub, att);
+    rebuildTaskResults(db, testTask.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: listUrl(),
+      headers: { 'x-test-user-id': pilot.id },
+    });
+
+    const { submissions } = JSON.parse(res.body) as { submissions: any[] };
+    const row = submissions[0];
+    expect(row.bestAttempt).toBeTruthy();
+    expect(row.bestAttempt.distanceFlownKm).toBeCloseTo(8);
+    expect(row.allAttempts).toHaveLength(1);
+    expect(typeof row.timePointsProvisional).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Closes #41.

## Summary
- Backend: \`GET /tasks/:id/submissions\` now returns two extra fields per row.
  - \`thisSubmission\` — facts about *this* submission's own best detected attempt (joined via \`fs.best_attempt_id\`). Distance, lastTurnpointIndex, reachedGoal, taskTimeS, hasFlaggedCrossings — but **no scores**, since per-submission scoring would re-derive numbers that depend on every other pilot's flights.
  - \`isCurrentBest\` — true iff this submission's best attempt is the one the leaderboard is using right now (\`fs.best_attempt_id == tr.best_attempt_id\`).
  - \`bestAttempt\` and the rest of the payload are unchanged.
- Frontend: new \`<MySubmissions />\` on the per-task left panel under the upload zone. Renders one row per upload (newest first) with submitted-at, IGC filename, what was reached on that attempt (\`Reached SSS\` / \`Reached TP1 of 3\` / \`Reached goal\`), and the distance flown. The currently-scoring submission gets a \`← scored as best\` badge.

## Why
Concrete case from this week: Fannyu uploaded a flight on Apr 30 that she felt was better than her Apr 27 flight. The new upload only crossed SSS (1.18 km along route); the older one reached TP1 (2.80 km). Scoring correctly kept the older flight, but she had no way to verify that without help. With this PR she'd see both rows side-by-side with the per-upload distance and last-TP, so the answer is self-serve.

## UI testing
\`tsc --noEmit\` and \`vite build\` both clean. I didn't spin up the dev server with seeded submission data — the visual should be straightforward but worth eyeballing on staging before merge. The component is hidden for logged-out viewers and renders nothing when there are no submissions, so the blast radius for non-pilots is zero.

## Test plan
- [x] \`npx vitest run\` — 220/220 pass
- [x] \`npm run typecheck\` — clean (server + frontend)
- [x] \`npm run build\` (frontend) — clean
- [x] New \`tests/routes/submissions.test.ts\` covers:
  - \`thisSubmission\` populated per-row from \`fs.best_attempt_id\` (each row reflects its own attempt; \`bestAttempt\` is the same on every row — pilot's overall best)
  - \`isCurrentBest\` is true only on the submission the leaderboard is using
  - \`thisSubmission\` is null when \`fs.best_attempt_id\` hasn't been set yet (mid-processing)
  - existing \`bestAttempt\` + \`timePointsProvisional\` unchanged

## Note on the helper change
\`createTestSubmission\` previously hardcoded \`igc_sha256 = 'abc'\`, which made it impossible to give the same pilot two submissions on one task (unique-index violation). Same one-line fix as in #50 (the #34 PR) — these will rebase cleanly against each other since both apply the same edit.