### PR TITLE
Lock open_date / close_date when submissions exist (#40)

### DIFF
--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1693,6 +1693,26 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         }
       }
 
+      // open_date / close_date are locked once submissions exist. Moving the
+      // window can retroactively invalidate flights — validateFlightDate
+      // rejects an IGC whose flightDate falls outside [open_date, close_date],
+      // so a future re-process would silently mark them ineligible.
+      // Admins who need to retime a task with submissions should soft-delete
+      // the offending submissions first (DELETE …/submissions/:id, #34).
+      const datesChanged =
+        (body.openDate !== undefined && body.openDate !== existingTask.open_date) ||
+        (body.closeDate !== undefined && body.closeDate !== existingTask.close_date);
+      if (datesChanged) {
+        const { c: submissionCount } = db
+          .prepare(`SELECT COUNT(*) AS c FROM flight_submissions WHERE task_id = ? AND deleted_at IS NULL`)
+          .get(taskId) as { c: number };
+        if (submissionCount > 0) {
+          return reply.status(400).send({
+            error: 'Cannot change open_date or close_date while submissions exist for this task. Delete or remove submissions first.',
+          });
+        }
+      }
+
       // Build update query dynamically
       const updates: string[] = [];
       const params: any[] = [];

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1761,16 +1761,20 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // so a future re-process would silently mark them ineligible.
       // Admins who need to retime a task with submissions should soft-delete
       // the offending submissions first (DELETE …/submissions/:id, #34).
+      // Compare as instants (getTime), not strings — "2026-01-01T00:00:00Z" and
+      // "2026-01-01T00:00:00.000Z" are the same moment but different strings, and
+      // we should treat re-submitting an equivalent value as a no-op.
+      const sameInstant = (a: string, b: string) => new Date(a).getTime() === new Date(b).getTime();
       const datesChanged =
-        (body.openDate !== undefined && body.openDate !== existingTask.open_date) ||
-        (body.closeDate !== undefined && body.closeDate !== existingTask.close_date);
+        (body.openDate !== undefined && !sameInstant(body.openDate, existingTask.open_date)) ||
+        (body.closeDate !== undefined && !sameInstant(body.closeDate, existingTask.close_date));
       if (datesChanged) {
         const { c: submissionCount } = db
           .prepare(`SELECT COUNT(*) AS c FROM flight_submissions WHERE task_id = ? AND deleted_at IS NULL`)
           .get(taskId) as { c: number };
         if (submissionCount > 0) {
           return reply.status(400).send({
-            error: 'Cannot change open_date or close_date while submissions exist for this task. Delete or remove submissions first.',
+            error: 'Cannot change openDate or closeDate while submissions exist for this task. Delete or remove submissions first.',
           });
         }
       }

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1774,7 +1774,8 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           .get(taskId) as { c: number };
         if (submissionCount > 0) {
           return reply.status(400).send({
-            error: 'Cannot change openDate or closeDate while submissions exist for this task. Delete or remove submissions first.',
+            error:
+              'Cannot change openDate or closeDate while submissions exist for this task. Delete or remove submissions first.',
           });
         }
       }

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1796,13 +1796,17 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         updates.push('task_type = ?');
         params.push(body.taskType);
       }
+      // Normalize to canonical UTC ISO before writing. validateFlightDate (and
+      // upload/reprocess) read `open_date.slice(0, 10)` to derive the YYYY-MM-DD
+      // window, so storing the raw body string would let an admin shift the
+      // window by submitting an equivalent instant with a different offset.
       if (body.openDate !== undefined) {
         updates.push('open_date = ?');
-        params.push(body.openDate);
+        params.push(new Date(body.openDate).toISOString());
       }
       if (body.closeDate !== undefined) {
         updates.push('close_date = ?');
-        params.push(body.closeDate);
+        params.push(new Date(body.closeDate).toISOString());
       }
       if (body.taskValue !== undefined) {
         updates.push('normalized_score = ?');

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1755,6 +1755,26 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         }
       }
 
+      // open_date / close_date are locked once submissions exist. Moving the
+      // window can retroactively invalidate flights — validateFlightDate
+      // rejects an IGC whose flightDate falls outside [open_date, close_date],
+      // so a future re-process would silently mark them ineligible.
+      // Admins who need to retime a task with submissions should soft-delete
+      // the offending submissions first (DELETE …/submissions/:id, #34).
+      const datesChanged =
+        (body.openDate !== undefined && body.openDate !== existingTask.open_date) ||
+        (body.closeDate !== undefined && body.closeDate !== existingTask.close_date);
+      if (datesChanged) {
+        const { c: submissionCount } = db
+          .prepare(`SELECT COUNT(*) AS c FROM flight_submissions WHERE task_id = ? AND deleted_at IS NULL`)
+          .get(taskId) as { c: number };
+        if (submissionCount > 0) {
+          return reply.status(400).send({
+            error: 'Cannot change open_date or close_date while submissions exist for this task. Delete or remove submissions first.',
+          });
+        }
+      }
+
       // Build update query dynamically
       const updates: string[] = [];
       const params: any[] = [];

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -752,16 +752,20 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
       expect(res.statusCode).toBe(200);
     });
 
-    it('treats equivalent ISO formats as a no-op (millis / offset variations)', async () => {
-      // Stored as ".000Z"; admin re-submits the same instant without millis. Or
-      // in a +HH:MM offset. Both should pass the guard even with submissions.
+    it('treats equivalent ISO formats as a no-op and normalises storage to canonical UTC', async () => {
+      // Stored as ".000Z"; admin re-submits the same instant in three other
+      // forms. Each must pass the guard *and* leave the stored value canonical,
+      // because downstream code reads open_date.slice(0, 10) for the date
+      // window — an offset that shifts the YYYY-MM-DD prefix would change
+      // validateFlightDate behavior even though the instant is unchanged.
       const stored = '2026-01-01T00:00:00.000Z';
       const noMillis = '2026-01-01T00:00:00Z';
-      const withOffset = '2026-01-01T05:00:00+05:00'; // same instant
+      const positiveOffset = '2026-01-01T05:00:00+05:00';
+      const dateBoundaryShift = '2025-12-31T22:00:00-02:00';
       const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: stored, closeDate: closeIso });
       createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
 
-      for (const equivalent of [noMillis, withOffset]) {
+      for (const equivalent of [noMillis, positiveOffset, dateBoundaryShift]) {
         const res = await app.inject({
           method: 'PUT',
           url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
@@ -769,6 +773,9 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
           payload: JSON.stringify({ openDate: equivalent }),
         });
         expect(res.statusCode).toBe(200);
+        const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+        expect(row.open_date).toBe(stored);
+        expect(row.open_date.slice(0, 10)).toBe('2026-01-01');
       }
     });
 

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -664,6 +664,119 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
     const row = db.prepare(`SELECT name FROM tasks WHERE id = ?`).get(task.id) as any;
     expect(row.name).toBe('Renamed before close');
   });
+
+  // open_date / close_date guard (#40): moving the window can retroactively
+  // invalidate flights, so it's locked when submissions exist.
+  describe('open_date / close_date guard (#40)', () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    const openIso = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(); // 6h ago
+    const closeIso = new Date(Date.now() + 7 * dayMs).toISOString();
+
+    it('allows changing open_date when no submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(200);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(newOpen);
+    });
+
+    it('rejects open_date change when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/open_date.*close_date/i);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(openIso);
+    });
+
+    it('rejects close_date change when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const newClose = new Date(Date.now() + 14 * dayMs).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ closeDate: newClose }),
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('allows non-date edits (e.g. name) even when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: 'New name with submissions' }),
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('allows submitting the same open_date value (no-op) even with submissions', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      // Send the existing value — guard should pass through since the value
+      // didn't actually change.
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: openIso }),
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('open_date becomes editable again after the submission is soft-deleted', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      const submissionId = createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      // Use the #34 admin endpoint to remove the submission.
+      const delRes = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}/submissions/${submissionId}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+      expect(delRes.statusCode).toBe(200);
+
+      // Now the lock should release.
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(200);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(newOpen);
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -702,7 +702,7 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
       });
 
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.body).error).toMatch(/open_date.*close_date/i);
+      expect(JSON.parse(res.body).error).toMatch(/openDate.*closeDate/);
       const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
       expect(row.open_date).toBe(openIso);
     });
@@ -750,6 +750,26 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
       });
 
       expect(res.statusCode).toBe(200);
+    });
+
+    it('treats equivalent ISO formats as a no-op (millis / offset variations)', async () => {
+      // Stored as ".000Z"; admin re-submits the same instant without millis. Or
+      // in a +HH:MM offset. Both should pass the guard even with submissions.
+      const stored = '2026-01-01T00:00:00.000Z';
+      const noMillis = '2026-01-01T00:00:00Z';
+      const withOffset = '2026-01-01T05:00:00+05:00'; // same instant
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: stored, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      for (const equivalent of [noMillis, withOffset]) {
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+          headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+          payload: JSON.stringify({ openDate: equivalent }),
+        });
+        expect(res.statusCode).toBe(200);
+      }
     });
 
     it('open_date becomes editable again after the submission is soft-deleted', async () => {

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -665,6 +665,119 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
     const row = db.prepare(`SELECT name FROM tasks WHERE id = ?`).get(task.id) as any;
     expect(row.name).toBe('Renamed before close');
   });
+
+  // open_date / close_date guard (#40): moving the window can retroactively
+  // invalidate flights, so it's locked when submissions exist.
+  describe('open_date / close_date guard (#40)', () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    const openIso = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(); // 6h ago
+    const closeIso = new Date(Date.now() + 7 * dayMs).toISOString();
+
+    it('allows changing open_date when no submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(200);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(newOpen);
+    });
+
+    it('rejects open_date change when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toMatch(/open_date.*close_date/i);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(openIso);
+    });
+
+    it('rejects close_date change when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const newClose = new Date(Date.now() + 14 * dayMs).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ closeDate: newClose }),
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('allows non-date edits (e.g. name) even when submissions exist', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ name: 'New name with submissions' }),
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('allows submitting the same open_date value (no-op) even with submissions', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      // Send the existing value — guard should pass through since the value
+      // didn't actually change.
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: openIso }),
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('open_date becomes editable again after the submission is soft-deleted', async () => {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      const submissionId = createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+
+      // Use the #34 admin endpoint to remove the submission.
+      const delRes = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}/submissions/${submissionId}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+      expect(delRes.statusCode).toBe(200);
+
+      // Now the lock should release.
+      const newOpen = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${task.id}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify({ openDate: newOpen }),
+      });
+
+      expect(res.statusCode).toBe(200);
+      const row = db.prepare(`SELECT open_date FROM tasks WHERE id = ?`).get(task.id) as any;
+      expect(row.open_date).toBe(newOpen);
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #40. **Stacked on top of #50** (the #34 admin-delete endpoint) — the editability-after-delete test calls that endpoint, and the guard is only useful once admins have a way to remove submissions. Merge #50 first, then rebase this onto main.

## Summary
- In the task PUT handler, if either \`openDate\` or \`closeDate\` is being changed (body value differs from the current row value) AND any non-deleted \`flight_submissions\` exist for the task → 400.
- Other edits (\`name\`, \`description\`, \`taskValue\`, \`taskType\`) are unaffected even when submissions exist.
- No-op submissions (sending the existing date value) pass through.

## Why
\`validateFlightDate\` rejects an IGC whose \`flightDate\` falls outside \`[open_date, close_date]\`. Today an admin can move \`open_date\` forward and silently invalidate every prior flight on the next re-process — there's no guard. This locks the window once submissions are at risk and forces admins to make the deletion explicit (via the new #34 endpoint) instead of accidentally orphaning data.

## Test plan
- [x] \`npx vitest run\` — 228/228 pass
- [x] \`npm run typecheck\` — clean
- [x] New \`open_date / close_date guard (#40)\` describe block in \`tests/routes/tasks.test.ts\` covers:
  - happy path: change \`open_date\` with no submissions → 200, value updated
  - rejects \`open_date\` change with submissions → 400, value unchanged
  - rejects \`close_date\` change with submissions → 400
  - allows non-date edits (name) with submissions → 200
  - allows submitting same \`open_date\` value (no-op) with submissions → 200
  - end-to-end: create submission → DELETE via #34 endpoint → \`open_date\` editable again