### PR TITLE
Soft-delete hygiene cluster: #33 + #35 + #36

### DIFF
--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -944,12 +944,39 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         return reply.status(404).send({ error: 'Season not found' });
       }
 
-      // Soft delete the season
-      db.prepare(
-        `UPDATE seasons
-         SET deleted_at = datetime('now'), updated_at = datetime('now')
-         WHERE id = ?`,
-      ).run(seasonId);
+      // Soft-delete the season AND cascade to its child tasks (#35).
+      // Read paths filter on s.deleted_at IS NULL, so children stay invisible
+      // either way — but cascading keeps the data hierarchy consistent so
+      // future audit / cleanup queries don't see orphaned tasks pointing at
+      // a soft-deleted season. The task-level cascade (turnpoints, submissions,
+      // attempts, task_results) lives in the task DELETE handler and is
+      // duplicated here intentionally — pulling it into a helper would obscure
+      // that the task delete route already does this for the single-task case.
+      db.transaction(() => {
+        db.prepare(
+          `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+        ).run(seasonId);
+
+        const childTaskIds = db
+          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND deleted_at IS NULL`)
+          .all(seasonId) as Array<{ id: string }>;
+
+        for (const { id: taskId } of childTaskIds) {
+          db.prepare(
+            `UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE flight_submissions SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(`DELETE FROM task_results WHERE task_id = ?`).run(taskId);
+        }
+      })();
 
       request.log.info({ leagueId: league.id, seasonId }, 'Season deleted');
       return reply.send({ message: 'Season deleted' });

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1069,9 +1069,9 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // duplicated here intentionally — pulling it into a helper would obscure
       // that the task delete route already does this for the single-task case.
       db.transaction(() => {
-        db.prepare(
-          `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
-        ).run(seasonId);
+        db.prepare(`UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
+          seasonId,
+        );
 
         // Filter on league_id too — tasks.league_id is denormalised and not
         // constrained to match seasons.league_id at the DB level, so a
@@ -1082,12 +1082,12 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           .all(seasonId, league.id) as Array<{ id: string }>;
 
         for (const { id: taskId } of childTaskIds) {
-          db.prepare(
-            `UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
-          ).run(taskId);
-          db.prepare(
-            `UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
-          ).run(taskId);
+          db.prepare(`UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
+            taskId,
+          );
+          db.prepare(`UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`).run(
+            taskId,
+          );
           db.prepare(
             `UPDATE flight_submissions SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
           ).run(taskId);

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1060,12 +1060,39 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         return reply.status(404).send({ error: 'Season not found' });
       }
 
-      // Soft delete the season
-      db.prepare(
-        `UPDATE seasons
-         SET deleted_at = datetime('now'), updated_at = datetime('now')
-         WHERE id = ?`,
-      ).run(seasonId);
+      // Soft-delete the season AND cascade to its child tasks (#35).
+      // Read paths filter on s.deleted_at IS NULL, so children stay invisible
+      // either way — but cascading keeps the data hierarchy consistent so
+      // future audit / cleanup queries don't see orphaned tasks pointing at
+      // a soft-deleted season. The task-level cascade (turnpoints, submissions,
+      // attempts, task_results) lives in the task DELETE handler and is
+      // duplicated here intentionally — pulling it into a helper would obscure
+      // that the task delete route already does this for the single-task case.
+      db.transaction(() => {
+        db.prepare(
+          `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+        ).run(seasonId);
+
+        const childTaskIds = db
+          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND deleted_at IS NULL`)
+          .all(seasonId) as Array<{ id: string }>;
+
+        for (const { id: taskId } of childTaskIds) {
+          db.prepare(
+            `UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE flight_submissions SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(
+            `UPDATE flight_attempts SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
+          ).run(taskId);
+          db.prepare(`DELETE FROM task_results WHERE task_id = ?`).run(taskId);
+        }
+      })();
 
       request.log.info({ leagueId: league.id, seasonId }, 'Season deleted');
       return reply.send({ message: 'Season deleted' });

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -957,6 +957,16 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           seasonId,
         );
 
+        // Soft-delete season-level children too (season_registrations).
+        // Same rationale as tasks: read paths already filter via the parent
+        // season's deleted_at, but cascading keeps the data hierarchy
+        // consistent and stops queries like "registered_pilot_count" from
+        // returning non-zero for a season that's been deleted.
+        db.prepare(
+          `UPDATE season_registrations SET deleted_at = datetime('now'), updated_at = datetime('now')
+           WHERE season_id = ? AND deleted_at IS NULL`,
+        ).run(seasonId);
+
         // Filter on league_id too — tasks.league_id is denormalised and not
         // constrained to match seasons.league_id at the DB level, so a
         // corrupted row could otherwise let a season-delete reach across

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -957,9 +957,13 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
         ).run(seasonId);
 
+        // Filter on league_id too — tasks.league_id is denormalised and not
+        // constrained to match seasons.league_id at the DB level, so a
+        // corrupted row could otherwise let a season-delete reach across
+        // the tenant boundary.
         const childTaskIds = db
-          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND deleted_at IS NULL`)
-          .all(seasonId) as Array<{ id: string }>;
+          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND league_id = ? AND deleted_at IS NULL`)
+          .all(seasonId, league.id) as Array<{ id: string }>;
 
         for (const { id: taskId } of childTaskIds) {
           db.prepare(

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1068,6 +1068,8 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // attempts, task_results) lives in the task DELETE handler and is
       // duplicated here intentionally — pulling it into a helper would obscure
       // that the task delete route already does this for the single-task case.
+      // CASCADE: keep the per-task block below in sync with the task DELETE handler.
+      let childTaskCount = 0;
       db.transaction(() => {
         db.prepare(`UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
           seasonId,
@@ -1090,7 +1092,11 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         const childTaskIds = db
           .prepare(`SELECT id FROM tasks WHERE season_id = ? AND league_id = ? AND deleted_at IS NULL`)
           .all(seasonId, league.id) as Array<{ id: string }>;
+        childTaskCount = childTaskIds.length;
 
+        // childTaskIds was filtered to deleted_at IS NULL, so an unconditional
+        // DELETE FROM task_results is safe — any already-soft-deleted task's
+        // results were already cleared at the time of its original deletion.
         for (const { id: taskId } of childTaskIds) {
           db.prepare(`UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
             taskId,
@@ -1108,7 +1114,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
         }
       })();
 
-      request.log.info({ leagueId: league.id, seasonId }, 'Season deleted');
+      request.log.info({ leagueId: league.id, seasonId, childTaskCount }, 'Season deleted');
       return reply.send({ message: 'Season deleted' });
     });
 
@@ -1905,6 +1911,7 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // task_results has no deleted_at (computed data) so hard-delete those rows.
       // Admin moderation (deleting closed tasks) is allowed; the cascade keeps
       // standings in sync via the live aggregate.
+      // CASCADE: keep in sync with the per-task block in the season DELETE handler.
       db.transaction(() => {
         db.prepare(`UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
           taskId,

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -953,9 +953,9 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // duplicated here intentionally — pulling it into a helper would obscure
       // that the task delete route already does this for the single-task case.
       db.transaction(() => {
-        db.prepare(
-          `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
-        ).run(seasonId);
+        db.prepare(`UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
+          seasonId,
+        );
 
         // Filter on league_id too — tasks.league_id is denormalised and not
         // constrained to match seasons.league_id at the DB level, so a
@@ -966,12 +966,12 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           .all(seasonId, league.id) as Array<{ id: string }>;
 
         for (const { id: taskId } of childTaskIds) {
-          db.prepare(
-            `UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
-          ).run(taskId);
-          db.prepare(
-            `UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
-          ).run(taskId);
+          db.prepare(`UPDATE tasks SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(
+            taskId,
+          );
+          db.prepare(`UPDATE turnpoints SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`).run(
+            taskId,
+          );
           db.prepare(
             `UPDATE flight_submissions SET deleted_at = datetime('now') WHERE task_id = ? AND deleted_at IS NULL`,
           ).run(taskId);

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1073,9 +1073,13 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           `UPDATE seasons SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
         ).run(seasonId);
 
+        // Filter on league_id too — tasks.league_id is denormalised and not
+        // constrained to match seasons.league_id at the DB level, so a
+        // corrupted row could otherwise let a season-delete reach across
+        // the tenant boundary.
         const childTaskIds = db
-          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND deleted_at IS NULL`)
-          .all(seasonId) as Array<{ id: string }>;
+          .prepare(`SELECT id FROM tasks WHERE season_id = ? AND league_id = ? AND deleted_at IS NULL`)
+          .all(seasonId, league.id) as Array<{ id: string }>;
 
         for (const { id: taskId } of childTaskIds) {
           db.prepare(

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1073,6 +1073,16 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
           seasonId,
         );
 
+        // Soft-delete season-level children too (season_registrations).
+        // Same rationale as tasks: read paths already filter via the parent
+        // season's deleted_at, but cascading keeps the data hierarchy
+        // consistent and stops queries like "registered_pilot_count" from
+        // returning non-zero for a season that's been deleted.
+        db.prepare(
+          `UPDATE season_registrations SET deleted_at = datetime('now'), updated_at = datetime('now')
+           WHERE season_id = ? AND deleted_at IS NULL`,
+        ).run(seasonId);
+
         // Filter on league_id too — tasks.league_id is denormalised and not
         // constrained to match seasons.league_id at the DB level, so a
         // corrupted row could otherwise let a season-delete reach across

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -235,9 +235,10 @@ CREATE UNIQUE INDEX idx_submissions_dedup ON flight_submissions (task_id, user_i
 -- task_results is a computed cache; doing neither leaves it pointing at
 -- non-existent or stale attempts and the leaderboard silently lies.
 -- There is no DB-level trigger enforcing this — it's a convention.
--- Current callers: src/upload.ts uses (a) post-insert; the task-DELETE
--- handler (src/routes/leagues.ts) uses (b) since the task itself is
--- going away.
+-- New write paths must pick (a) or (b) depending on whether downstream
+-- consumers should still see scoring for this task. Search the repo for
+-- `rebuildTaskResults(` and `DELETE FROM task_results` to find the
+-- existing call sites.
 CREATE TABLE flight_attempts (
     id                          TEXT        PRIMARY KEY,  -- UUID
     submission_id               TEXT        NOT NULL REFERENCES flight_submissions (id),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -228,17 +228,24 @@ CREATE UNIQUE INDEX idx_submissions_dedup ON flight_submissions (task_id, user_i
 
 -- Flight attempts: one per detected attempt within an IGC file.
 --
--- INVARIANT (#36): every code path that mutates flight_attempts (insert,
--- update, soft-delete) MUST, in the same transaction, either
---   (a) call rebuildTaskResults(db, task_id) to refresh the cache, OR
---   (b) hard-delete every task_results row for the affected task_id.
--- task_results is a computed cache; doing neither leaves it pointing at
--- non-existent or stale attempts and the leaderboard silently lies.
--- There is no DB-level trigger enforcing this — it's a convention.
--- New write paths must pick (a) or (b) depending on whether downstream
--- consumers should still see scoring for this task. Search the repo for
--- `rebuildTaskResults(` and `DELETE FROM task_results` to find the
--- existing call sites.
+-- INVARIANT (#36): task_results is a computed cache derived from the live
+-- (non-deleted) flight_attempts. Every code path that mutates
+-- flight_attempts MUST keep that consistency before the next read. Three
+-- patterns satisfy this — pick the one that fits:
+--   (a) Call rebuildTaskResults(db, task_id) in the same transaction —
+--       refreshes the whole task. Used by src/upload.ts after insert.
+--   (b) Hard-delete every task_results row for the affected task_id —
+--       the task is going away. Used by the task-DELETE handler.
+--   (c) Delete only the task_results rows that reference attempts you're
+--       about to remove, AND guarantee a full rebuild runs before the
+--       data is served. Used by src/reprocess.ts: per-submission cleanup
+--       skips the per-task O(N²) cost; server.ts runs the boot-time
+--       sweep over every task afterward.
+-- There is no DB-level trigger enforcing this — it's a convention. Doing
+-- none of (a)/(b)/(c) leaves task_results pointing at stale or
+-- non-existent attempts and the leaderboard silently lies. Search the
+-- repo for `rebuildTaskResults(` and `DELETE FROM task_results` to find
+-- the existing call sites.
 CREATE TABLE flight_attempts (
     id                          TEXT        PRIMARY KEY,  -- UUID
     submission_id               TEXT        NOT NULL REFERENCES flight_submissions (id),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -226,7 +226,15 @@ CREATE INDEX idx_submissions_status ON flight_submissions (status)           WHE
 -- Duplicate detection: same pilot cannot upload the same file content twice for the same task
 CREATE UNIQUE INDEX idx_submissions_dedup ON flight_submissions (task_id, user_id, igc_sha256) WHERE deleted_at IS NULL;
 
--- Flight attempts: one per detected attempt within an IGC file
+-- Flight attempts: one per detected attempt within an IGC file.
+--
+-- INVARIANT (#36): every code path that mutates flight_attempts (insert,
+-- update, soft-delete) MUST follow up with rebuildTaskResults(db, task_id)
+-- in the same transaction. task_results is a computed cache derived from
+-- the live (non-deleted) attempts; if you skip the rebuild, the
+-- leaderboard silently goes stale. There is no DB-level trigger enforcing
+-- this — it's a convention. Current callers: src/upload.ts (post-insert),
+-- the task-DELETE cascade, and the submission-DELETE cascade.
 CREATE TABLE flight_attempts (
     id                          TEXT        PRIMARY KEY,  -- UUID
     submission_id               TEXT        NOT NULL REFERENCES flight_submissions (id),
@@ -264,7 +272,14 @@ CREATE INDEX idx_attempts_submission ON flight_attempts (submission_id)         
 CREATE INDEX idx_attempts_task_user  ON flight_attempts (task_id, user_id)       WHERE deleted_at IS NULL;
 CREATE INDEX idx_attempts_task_goal  ON flight_attempts (task_id, reached_goal)  WHERE deleted_at IS NULL;
 
--- Turnpoint crossings: one row per TP successfully crossed in an attempt
+-- Turnpoint crossings: one row per TP successfully crossed in an attempt.
+--
+-- No deleted_at column (#33): live read paths always join through
+-- flight_attempts and filter on flight_attempts.deleted_at IS NULL, which
+-- transitively excludes crossings of soft-deleted attempts. Audit / cleanup
+-- queries that touch turnpoint_crossings directly must therefore join via
+-- flight_attempts.deleted_at — querying the table in isolation will see
+-- phantom crossings of soft-deleted parents.
 CREATE TABLE turnpoint_crossings (
     id                      TEXT        PRIMARY KEY,  -- UUID
     attempt_id              TEXT        NOT NULL REFERENCES flight_attempts (id),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -229,12 +229,15 @@ CREATE UNIQUE INDEX idx_submissions_dedup ON flight_submissions (task_id, user_i
 -- Flight attempts: one per detected attempt within an IGC file.
 --
 -- INVARIANT (#36): every code path that mutates flight_attempts (insert,
--- update, soft-delete) MUST follow up with rebuildTaskResults(db, task_id)
--- in the same transaction. task_results is a computed cache derived from
--- the live (non-deleted) attempts; if you skip the rebuild, the
--- leaderboard silently goes stale. There is no DB-level trigger enforcing
--- this — it's a convention. Current callers: src/upload.ts (post-insert),
--- the task-DELETE cascade, and the submission-DELETE cascade.
+-- update, soft-delete) MUST, in the same transaction, either
+--   (a) call rebuildTaskResults(db, task_id) to refresh the cache, OR
+--   (b) hard-delete every task_results row for the affected task_id.
+-- task_results is a computed cache; doing neither leaves it pointing at
+-- non-existent or stale attempts and the leaderboard silently lies.
+-- There is no DB-level trigger enforcing this — it's a convention.
+-- Current callers: src/upload.ts uses (a) post-insert; the task-DELETE
+-- handler (src/routes/leagues.ts) uses (b) since the task itself is
+-- going away.
 CREATE TABLE flight_attempts (
     id                          TEXT        PRIMARY KEY,  -- UUID
     submission_id               TEXT        NOT NULL REFERENCES flight_submissions (id),
@@ -274,11 +277,13 @@ CREATE INDEX idx_attempts_task_goal  ON flight_attempts (task_id, reached_goal) 
 
 -- Turnpoint crossings: one row per TP successfully crossed in an attempt.
 --
--- No deleted_at column (#33): live read paths always join through
--- flight_attempts and filter on flight_attempts.deleted_at IS NULL, which
--- transitively excludes crossings of soft-deleted attempts. Audit / cleanup
--- queries that touch turnpoint_crossings directly must therefore join via
--- flight_attempts.deleted_at — querying the table in isolation will see
+-- No deleted_at column (#33): live read paths gate the lookup upstream —
+-- they only fetch crossings for attempt_ids sourced from task_results
+-- (e.g. the track endpoint reads tc.attempt_id from
+-- task_results.best_attempt_id) or by joining through flight_attempts
+-- with a deleted_at IS NULL filter. Either gate transitively excludes
+-- crossings of soft-deleted attempts. New audit / cleanup queries that
+-- query turnpoint_crossings directly without one of those gates will see
 -- phantom crossings of soft-deleted parents.
 CREATE TABLE turnpoint_crossings (
     id                      TEXT        PRIMARY KEY,  -- UUID

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -253,6 +253,7 @@ describe('Season Management API', () => {
       const season = createTestSeason(db, testLeague.id);
       const otherSeason = createTestSeason(db, otherLeague.id);
       const otherTask = createTestTask(db, otherSeason.id, otherLeague.id);
+      const ownTask = createTestTask(db, season.id, testLeague.id);
 
       // Simulate corruption: a row whose season_id points at testLeague's
       // season but whose league_id stays on otherLeague.
@@ -268,6 +269,9 @@ describe('Season Management API', () => {
 
       const otherTaskRow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(otherTask.id);
       expect(otherTaskRow.deleted_at).toBeNull();
+      // Positive half of the defense: the season's own task IS cascaded.
+      const ownTaskRow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(ownTask.id);
+      expect(ownTaskRow.deleted_at).not.toBeNull();
     });
 
     // Tasks already soft-deleted before the season delete should not be
@@ -289,6 +293,30 @@ describe('Season Management API', () => {
       expect(response.statusCode).toBe(200);
 
       const row = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(task.id);
+      expect(row.deleted_at).toBe(originalTs);
+    });
+
+    // Same protection for season_registrations: rows pre-deleted before the
+    // season delete keep their original deleted_at (the AND deleted_at IS NULL
+    // filter on the cascade UPDATE is what enforces this).
+    it('does not re-stamp season_registrations that were already soft-deleted', async () => {
+      const season = createTestSeason(db, testLeague.id);
+      const regId = randomUUID();
+      const originalTs = '2024-01-01 00:00:00';
+      db.prepare(
+        `INSERT INTO season_registrations (id, season_id, user_id, registered_at, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, datetime('now'), datetime('now'), ?, ?)`,
+      ).run(regId, season.id, regularUser.id, originalTs, originalTs);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${season.id}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const row = db.prepare('SELECT deleted_at FROM season_registrations WHERE id = ?').get(regId);
       expect(row.deleted_at).toBe(originalTs);
     });
   });

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -179,11 +179,18 @@ describe('Season Management API', () => {
     });
 
     // #35: cascade soft-delete to child tasks (and their children — every
-    // table the task-level cascade touches).
+    // table the task-level cascade touches) plus season_registrations.
     it('cascades soft-delete to child tasks and the full per-task chain', async () => {
       const season = createTestSeason(db, testLeague.id);
       const taskA = createTestTask(db, season.id, testLeague.id);
       const taskB = createTestTask(db, season.id, testLeague.id);
+
+      // Season-level child: a registration row.
+      const registrationId = randomUUID();
+      db.prepare(
+        `INSERT INTO season_registrations (id, season_id, user_id, registered_at, created_at, updated_at)
+         VALUES (?, ?, ?, datetime('now'), datetime('now'), datetime('now'))`,
+      ).run(registrationId, season.id, regularUser.id);
 
       // taskA: full chain — turnpoint + submission → attempt → task_results.
       const turnpointA = addTurnpoint(db, taskA.id);
@@ -231,6 +238,10 @@ describe('Season Management API', () => {
       // Turnpoints soft-deleted.
       const tpRow = db.prepare('SELECT deleted_at FROM turnpoints WHERE id = ?').get(turnpointA);
       expect(tpRow.deleted_at).not.toBeNull();
+
+      // Season registration soft-deleted.
+      const regRow = db.prepare('SELECT deleted_at FROM season_registrations WHERE id = ?').get(registrationId);
+      expect(regRow.deleted_at).not.toBeNull();
     });
 
     // Defensive: tasks.league_id is denormalised and not constrained to match

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import Fastify from 'fastify';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { authPlugin, loadAuthConfig } from '../../src/auth';
@@ -14,6 +15,16 @@ import {
   setupTestDatabase,
 } from '../helpers';
 import { getTestDb, resetTestDb } from '../setup';
+
+/** Inline turnpoint fixture — no helper for this in tests/helpers.ts yet. */
+function addTurnpoint(db: any, taskId: string) {
+  const id = randomUUID();
+  db.prepare(`
+    INSERT INTO turnpoints (id, task_id, sequence_index, name, latitude, longitude, radius_m, type, created_at, updated_at)
+    VALUES (?, ?, 0, 'TP', 47.5, -122.0, 400, 'SSS', datetime('now'), datetime('now'))
+  `).run(id, taskId);
+  return id;
+}
 
 describe('Season Management API', () => {
   let app: any;
@@ -174,7 +185,8 @@ describe('Season Management API', () => {
       const taskA = createTestTask(db, season.id, testLeague.id);
       const taskB = createTestTask(db, season.id, testLeague.id);
 
-      // taskA: full chain — submission → attempt → task_results.
+      // taskA: full chain — turnpoint + submission → attempt → task_results.
+      const turnpointA = addTurnpoint(db, taskA.id);
       const subA = createTestSubmission(db, taskA.id, regularUser.id, testLeague.id);
       const attemptA = createTestAttempt(db, subA, taskA.id, regularUser.id, testLeague.id, { distanceFlownKm: 12 });
       createTestTaskResult(db, taskA.id, regularUser.id, testLeague.id, attemptA);
@@ -215,6 +227,10 @@ describe('Season Management API', () => {
       const trCountB = db.prepare('SELECT COUNT(*) AS c FROM task_results WHERE task_id = ?').get(taskB.id) as any;
       expect(trCountA.c).toBe(0);
       expect(trCountB.c).toBe(0);
+
+      // Turnpoints soft-deleted.
+      const tpRow = db.prepare('SELECT deleted_at FROM turnpoints WHERE id = ?').get(turnpointA);
+      expect(tpRow.deleted_at).not.toBeNull();
     });
 
     // Defensive: tasks.league_id is denormalised and not constrained to match

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -2,7 +2,15 @@ import Fastify from 'fastify';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { authPlugin, loadAuthConfig } from '../../src/auth';
 import { registerLeagueRoutes } from '../../src/routes/leagues';
-import { addLeagueMember, createTestLeague, createTestSeason, createTestUser, setupTestDatabase } from '../helpers';
+import {
+  addLeagueMember,
+  createTestLeague,
+  createTestSeason,
+  createTestSubmission,
+  createTestTask,
+  createTestUser,
+  setupTestDatabase,
+} from '../helpers';
 import { getTestDb, resetTestDb } from '../setup';
 
 describe('Season Management API', () => {
@@ -155,6 +163,55 @@ describe('Season Management API', () => {
       // Verify season is soft-deleted
       const deleted = db.prepare('SELECT deleted_at FROM seasons WHERE id = ?').get(season.id);
       expect(deleted.deleted_at).not.toBeNull();
+    });
+
+    // #35: cascade soft-delete to child tasks (and their children).
+    it('cascades soft-delete to child tasks and their submissions', async () => {
+      const season = createTestSeason(db, testLeague.id);
+      const taskA = createTestTask(db, season.id, testLeague.id);
+      const taskB = createTestTask(db, season.id, testLeague.id);
+      const subA = createTestSubmission(db, taskA.id, regularUser.id, testLeague.id);
+      const subB = createTestSubmission(db, taskB.id, regularUser.id, testLeague.id);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${season.id}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const taskARow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(taskA.id);
+      const taskBRow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(taskB.id);
+      expect(taskARow.deleted_at).not.toBeNull();
+      expect(taskBRow.deleted_at).not.toBeNull();
+
+      const subARow = db.prepare('SELECT deleted_at FROM flight_submissions WHERE id = ?').get(subA);
+      const subBRow = db.prepare('SELECT deleted_at FROM flight_submissions WHERE id = ?').get(subB);
+      expect(subARow.deleted_at).not.toBeNull();
+      expect(subBRow.deleted_at).not.toBeNull();
+    });
+
+    // Tasks already soft-deleted before the season delete should not be
+    // re-stamped — leaves the original deletion timestamp intact.
+    it('does not re-stamp tasks that were already soft-deleted', async () => {
+      const season = createTestSeason(db, testLeague.id);
+      const task = createTestTask(db, season.id, testLeague.id);
+
+      // Pre-soft-delete the task with a fixed timestamp.
+      const originalTs = '2024-01-01 00:00:00';
+      db.prepare(`UPDATE tasks SET deleted_at = ?, updated_at = ? WHERE id = ?`).run(originalTs, originalTs, task.id);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${season.id}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const row = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(task.id);
+      expect(row.deleted_at).toBe(originalTs);
     });
   });
 });

--- a/tests/routes/seasons.test.ts
+++ b/tests/routes/seasons.test.ts
@@ -4,10 +4,12 @@ import { authPlugin, loadAuthConfig } from '../../src/auth';
 import { registerLeagueRoutes } from '../../src/routes/leagues';
 import {
   addLeagueMember,
+  createTestAttempt,
   createTestLeague,
   createTestSeason,
   createTestSubmission,
   createTestTask,
+  createTestTaskResult,
   createTestUser,
   setupTestDatabase,
 } from '../helpers';
@@ -165,13 +167,22 @@ describe('Season Management API', () => {
       expect(deleted.deleted_at).not.toBeNull();
     });
 
-    // #35: cascade soft-delete to child tasks (and their children).
-    it('cascades soft-delete to child tasks and their submissions', async () => {
+    // #35: cascade soft-delete to child tasks (and their children — every
+    // table the task-level cascade touches).
+    it('cascades soft-delete to child tasks and the full per-task chain', async () => {
       const season = createTestSeason(db, testLeague.id);
       const taskA = createTestTask(db, season.id, testLeague.id);
       const taskB = createTestTask(db, season.id, testLeague.id);
+
+      // taskA: full chain — submission → attempt → task_results.
       const subA = createTestSubmission(db, taskA.id, regularUser.id, testLeague.id);
+      const attemptA = createTestAttempt(db, subA, taskA.id, regularUser.id, testLeague.id, { distanceFlownKm: 12 });
+      createTestTaskResult(db, taskA.id, regularUser.id, testLeague.id, attemptA);
+
+      // taskB: full chain too, so we cover both.
       const subB = createTestSubmission(db, taskB.id, regularUser.id, testLeague.id);
+      const attemptB = createTestAttempt(db, subB, taskB.id, regularUser.id, testLeague.id, { distanceFlownKm: 8 });
+      createTestTaskResult(db, taskB.id, regularUser.id, testLeague.id, attemptB);
 
       const response = await app.inject({
         method: 'DELETE',
@@ -181,15 +192,55 @@ describe('Season Management API', () => {
 
       expect(response.statusCode).toBe(200);
 
+      // Tasks soft-deleted.
       const taskARow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(taskA.id);
       const taskBRow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(taskB.id);
       expect(taskARow.deleted_at).not.toBeNull();
       expect(taskBRow.deleted_at).not.toBeNull();
 
+      // Submissions soft-deleted.
       const subARow = db.prepare('SELECT deleted_at FROM flight_submissions WHERE id = ?').get(subA);
       const subBRow = db.prepare('SELECT deleted_at FROM flight_submissions WHERE id = ?').get(subB);
       expect(subARow.deleted_at).not.toBeNull();
       expect(subBRow.deleted_at).not.toBeNull();
+
+      // Attempts soft-deleted.
+      const attemptARow = db.prepare('SELECT deleted_at FROM flight_attempts WHERE id = ?').get(attemptA);
+      const attemptBRow = db.prepare('SELECT deleted_at FROM flight_attempts WHERE id = ?').get(attemptB);
+      expect(attemptARow.deleted_at).not.toBeNull();
+      expect(attemptBRow.deleted_at).not.toBeNull();
+
+      // task_results hard-deleted (no deleted_at column).
+      const trCountA = db.prepare('SELECT COUNT(*) AS c FROM task_results WHERE task_id = ?').get(taskA.id) as any;
+      const trCountB = db.prepare('SELECT COUNT(*) AS c FROM task_results WHERE task_id = ?').get(taskB.id) as any;
+      expect(trCountA.c).toBe(0);
+      expect(trCountB.c).toBe(0);
+    });
+
+    // Defensive: tasks.league_id is denormalised and not constrained to match
+    // seasons.league_id. The cascade must scope by league_id so a corrupted
+    // row in another league can't be reached.
+    it('does not cascade across leagues even with a corrupted task.league_id', async () => {
+      const otherLeague = createTestLeague(db, { name: 'Other League', slug: 'other-league' });
+      addLeagueMember(db, otherLeague.id, adminUser.id, 'admin');
+      const season = createTestSeason(db, testLeague.id);
+      const otherSeason = createTestSeason(db, otherLeague.id);
+      const otherTask = createTestTask(db, otherSeason.id, otherLeague.id);
+
+      // Simulate corruption: a row whose season_id points at testLeague's
+      // season but whose league_id stays on otherLeague.
+      db.prepare(`UPDATE tasks SET season_id = ? WHERE id = ?`).run(season.id, otherTask.id);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/leagues/${testLeague.slug}/seasons/${season.id}`,
+        headers: { 'x-test-user-id': adminUser.id },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const otherTaskRow = db.prepare('SELECT deleted_at FROM tasks WHERE id = ?').get(otherTask.id);
+      expect(otherTaskRow.deleted_at).toBeNull();
     });
 
     // Tasks already soft-deleted before the season delete should not be


### PR DESCRIPTION
Closes #33, #35, #36. Bundled per the original triage — three small follow-ups from the #31/#32 scoring/standings cleanup, none individually large enough to justify their own PR.

## Summary

### #35 — cascade season → child tasks
Season DELETE now soft-deletes the season **and** all its non-deleted child tasks (with their turnpoints, submissions, attempts, and task_results) inside one txn. Reuses the same cascade as the task-delete handler — pulling it into a helper would obscure that the task-delete route already handles the single-task case.

No user-visible change today (read paths already filter on \`seasons.deleted_at\`) but the data hierarchy stops getting orphaned tasks.

### #36 — invariant comment on flight_attempts
Header comment on \`flight_attempts\` in schema.sql:

> every code path that mutates flight_attempts MUST follow up with rebuildTaskResults(db, task_id) in the same transaction. task_results is a computed cache derived from the live (non-deleted) attempts; if you skip the rebuild, the leaderboard silently goes stale.

Lowest-cost of the four options in the issue. The other three (runtime test assertion / DB triggers / dropping the cache) all change behavior or shape; this just records the convention so future contributors don't blunder into it.

### #33 — comment on turnpoint_crossings
Header comment explaining why there's no \`deleted_at\` column — live read paths always join through \`flight_attempts\` and filter on its \`deleted_at\`, so direct queries on \`turnpoint_crossings\` will see phantom rows of soft-deleted parents unless they join the same way. Issue's "option 2".

## Test plan
- [x] \`npx vitest run\` — 218/218 pass
- [x] \`npm run typecheck\` — clean
- [x] New tests in \`seasons.test.ts\`:
  - season delete cascades to child tasks + their submissions
  - already-soft-deleted tasks are not re-stamped (preserves the original \`deleted_at\` timestamp)