### PR TITLE
TaskMap: cylinder label overhaul — palette, placement, legibility, ground encoding

### DIFF
--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -547,10 +547,12 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
   // touch point.
   const markerCtxRef = useRef<Array<{ anchor: [number, number]; center: [number, number] }>>([]);
 
-  // Distance in pixels to offset the label centre from the touch point along
-  // the outward radial. 18 px gives clearance over the 3-px strict ring stroke
-  // plus the dashed ground border, with a bit of breathing room.
-  const OUTWARD_PX = 18;
+  // Clearance in pixels between the cylinder ring (and the route line passing
+  // through the touch point) and the *nearest edge* of the label. The actual
+  // outward offset is computed per-marker as labelHalfExtent + CLEARANCE so a
+  // wide name like "Tiger Launch" gets pushed further out than a short "D1"
+  // when both are placed horizontally outward of their cylinders.
+  const LABEL_CLEARANCE_PX = 16;
 
   // Label placement: apply the radial outward offset, then greedy collision
   // resolution. For each marker (in route order), if its bounding box overlaps
@@ -563,13 +565,22 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     const ctxs = markerCtxRef.current;
     if (!map || markers.length < 1) return;
 
-    // Baseline = radial outward offset, in pixels. Recomputed every pass
-    // because the projection of anchor and centre changes with zoom.
+    // Baseline = radial outward offset, in pixels. Size-aware: the offset is
+    // labelHalfExtent + LABEL_CLEARANCE_PX where labelHalfExtent is the label's
+    // half-rectangle projected onto the outward direction. That way a wide
+    // label placed horizontally outward gets enough room that its inner edge
+    // sits the desired clearance away from the ring, not its centre.
+    // Recomputed every pass — projection changes with zoom.
     const baselines: Array<[number, number]> = [];
     for (let i = 0; i < markers.length; i++) {
       const ctx = ctxs[i];
+      const el = markers[i].getElement();
+      const halfW = el.offsetWidth / 2;
+      const halfH = el.offsetHeight / 2;
+      // Fallback: place above the anchor by half-height + clearance.
+      const fallback: [number, number] = [0, -(halfH + LABEL_CLEARANCE_PX)];
       if (!ctx) {
-        baselines.push([0, -OUTWARD_PX]);
+        baselines.push(fallback);
         continue;
       }
       const aPx = map.project(ctx.anchor);
@@ -577,7 +588,19 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       const dx = aPx.x - cPx.x;
       const dy = aPx.y - cPx.y;
       const len = Math.hypot(dx, dy);
-      baselines.push(len < 0.5 ? [0, -OUTWARD_PX] : [(dx / len) * OUTWARD_PX, (dy / len) * OUTWARD_PX]);
+      if (len < 0.5) {
+        baselines.push(fallback);
+        continue;
+      }
+      const ux = dx / len;
+      const uy = dy / len;
+      // Projection of the label's half-rect onto the outward direction:
+      // halfW * |ux| + halfH * |uy| gives the distance from the centre to the
+      // edge along (ux, uy). Adding LABEL_CLEARANCE_PX is the gap from that
+      // edge to the cylinder ring (and the route line through that point).
+      const labelHalfExtent = halfW * Math.abs(ux) + halfH * Math.abs(uy);
+      const total = labelHalfExtent + LABEL_CLEARANCE_PX;
+      baselines.push([ux * total, uy * total]);
     }
     for (let i = 0; i < markers.length; i++) markers[i].setOffset(baselines[i]);
 
@@ -698,7 +721,9 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
           : ([group.lng, group.lat] as [number, number]);
       const center: [number, number] = [group.lng, group.lat];
 
-      const marker = new maplibregl.Marker({ element: el, anchor: 'center', offset: [0, -OUTWARD_PX] })
+      // Placeholder offset — dedupeLabels recomputes a size-aware outward
+      // offset on the next frame.
+      const marker = new maplibregl.Marker({ element: el, anchor: 'center', offset: [0, -LABEL_CLEARANCE_PX] })
         .setLngLat(anchor)
         .addTo(map);
       markersRef.current.push(marker);

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -41,10 +41,15 @@ function hideIrrelevantLayers(map: maplibregl.Map) {
   }
 }
 
+// Palette: blue SSS, green ESS/Goal, pink for intermediate turnpoints, and
+// vivid orange for ground-only. The ground colour used to be a muted earthy
+// brown that read too close to the intermediate amber — pilots couldn't tell
+// at a glance which cylinders required a touchdown. The pink/orange split
+// pushes those two categories far apart in hue + saturation.
 function tpColor(type: string) {
   if (type === 'SSS') return '#4a9eff';
   if (type === 'ESS' || type === 'GOAL_CYLINDER' || type === 'GOAL_LINE') return '#5db87a';
-  return '#e8a842';
+  return REGULAR_TP_COLOR;
 }
 
 function tpRole(tp: Turnpoint, cylIndex: number): string {
@@ -69,10 +74,11 @@ function toCylinder(tp: Turnpoint): Cylinder {
   };
 }
 
-const GROUND_COLOR = '#a97c50';
+const REGULAR_TP_COLOR = '#ec4899'; // pink — intermediate cylinders
+const GROUND_COLOR = '#f97316'; // vivid orange — force-ground TPs (any role)
 
 const LOCATION_TOL = 1e-4;
-const COLOR_PRI: Record<string, number> = { '#4a9eff': 3, '#5db87a': 2, '#e8a842': 1 };
+const COLOR_PRI: Record<string, number> = { '#4a9eff': 3, '#5db87a': 2, [REGULAR_TP_COLOR]: 1 };
 
 interface TpEntry {
   role: string;
@@ -443,7 +449,8 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     for (const group of groups) {
       const c = map.project([group.lng, group.lat]);
       const dotColor =
-        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ?? '#e8a842';
+        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ??
+        REGULAR_TP_COLOR;
       mk('circle', {
         cx: c.x.toFixed(1),
         cy: c.y.toFixed(1),
@@ -558,7 +565,8 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       const nameEl = document.createElement('div');
       nameEl.textContent = group.name;
       const nameColor =
-        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ?? '#e8a842';
+        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ??
+        REGULAR_TP_COLOR;
       nameEl.style.cssText = `
         color:${nameColor};font-family:"DM Mono",monospace;font-size:10px;font-weight:600;
         text-shadow:0 0 4px rgba(0,0,0,1),0 0 8px rgba(0,0,0,0.8);white-space:nowrap;
@@ -674,7 +682,7 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         {[
           { color: '#4a9eff', label: 'SSS', tooltip: 'Start of Speed Section — the clock starts on exit.' },
           {
-            color: '#e8a842',
+            color: REGULAR_TP_COLOR,
             label: 'Turnpoint',
             tooltip: 'Intermediate turnpoint — pilots must enter this cylinder.',
           },

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -80,6 +80,13 @@ const ESS_COLOR = '#a855f7'; // purple — distinct from blue start and gold goa
 const GOAL_COLOR = '#eab308'; // amber — "finish line" celebratory cue
 const REGULAR_TP_COLOR = '#ec4899'; // pink — intermediate cylinders
 
+// Clearance in pixels between the cylinder ring (and the route line passing
+// through the touch point) and the *nearest edge* of the label. The actual
+// outward offset is computed per-marker as labelHalfExtent + CLEARANCE so a
+// wide name like "Tiger Launch" gets pushed further out than a short "D1"
+// when both are placed horizontally outward of their cylinders.
+const LABEL_CLEARANCE_PX = 16;
+
 const LOCATION_TOL = 1e-4;
 // Used when two TPs sit at the same point at the same radius — render the
 // higher-priority role. SSS (start) wins over ESS/Goal (end-of-flight roles),
@@ -546,13 +553,6 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
   // strict ring stroke and the optimised route line passing through that
   // touch point.
   const markerCtxRef = useRef<Array<{ anchor: [number, number]; center: [number, number] }>>([]);
-
-  // Clearance in pixels between the cylinder ring (and the route line passing
-  // through the touch point) and the *nearest edge* of the label. The actual
-  // outward offset is computed per-marker as labelHalfExtent + CLEARANCE so a
-  // wide name like "Tiger Launch" gets pushed further out than a short "D1"
-  // when both are placed horizontally outward of their cylinders.
-  const LABEL_CLEARANCE_PX = 16;
 
   // Label placement: apply the radial outward offset, then greedy collision
   // resolution. For each marker (in route order), if its bounding box overlaps

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -97,6 +97,10 @@ interface TpEntry {
   radiusM: number;
   isGoalLine: boolean;
   forceGround: boolean;
+  /** Index back into the original turnpoints[] array. Used to look up the
+   *  optimised route's touch point so the marker label can sit on the route
+   *  line instead of in the dead centre of a giant cylinder. */
+  tpIndex: number;
 }
 interface TpGroup {
   lng: number;
@@ -108,22 +112,24 @@ interface TpGroup {
 function buildGroups(tps: Turnpoint[]): TpGroup[] {
   let cylIdx = 0;
   const groups: TpGroup[] = [];
-  for (const tp of tps) {
+  for (let i = 0; i < tps.length; i++) {
+    const tp = tps[i];
     const isPlain = tp.type !== 'SSS' && tp.type !== 'ESS' && tp.type !== 'GOAL_CYLINDER' && tp.type !== 'GOAL_LINE';
     const role = tpRole(tp, isPlain ? ++cylIdx : 0);
     const color = tpColor(tp.type);
     const isGoalLine = tp.type === 'GOAL_LINE';
     const forceGround = tp.forceGround === true;
+    const entry: TpEntry = { role, color, radiusM: tp.radiusM, isGoalLine, forceGround, tpIndex: i };
     const g = groups.find(
       (g) => Math.abs(g.lng - tp.longitude) < LOCATION_TOL && Math.abs(g.lat - tp.latitude) < LOCATION_TOL,
     );
-    if (g) g.entries.push({ role, color, radiusM: tp.radiusM, isGoalLine, forceGround });
+    if (g) g.entries.push(entry);
     else
       groups.push({
         lng: tp.longitude,
         lat: tp.latitude,
         name: tp.name,
-        entries: [{ role, color, radiusM: tp.radiusM, isGoalLine, forceGround }],
+        entries: [entry],
       });
   }
   return groups;
@@ -597,8 +603,26 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       el.appendChild(badgeRow);
       el.appendChild(nameEl);
 
+      // Anchor the label at the optimised route's touch point for this
+      // turnpoint, not the cylinder centre. Big cylinders (4 km radius) put
+      // the centre kilometres from where pilots actually fly through, so a
+      // centred label is often outside the visible viewport. The route's
+      // touch point sits right on the cylinder boundary where the optimised
+      // line enters/exits — exactly where the pilot's attention is.
+      //
+      // For groups with multiple co-located turnpoints (different radii at
+      // the same lat/lng), pick the touch point from the entry with the
+      // largest radius — its touch point sits furthest from the shared
+      // centre and is least likely to overlap with smaller cylinders below.
+      const touchPoints = cachedRoute?.touchPoints;
+      const widestEntry = [...group.entries].sort((a, b) => b.radiusM - a.radiusM)[0];
+      const anchor =
+        touchPoints && widestEntry && touchPoints[widestEntry.tpIndex]
+          ? ([touchPoints[widestEntry.tpIndex].lng, touchPoints[widestEntry.tpIndex].lat] as [number, number])
+          : ([group.lng, group.lat] as [number, number]);
+
       const marker = new maplibregl.Marker({ element: el, anchor: 'bottom', offset: [0, -10] })
-        .setLngLat([group.lng, group.lat])
+        .setLngLat(anchor)
         .addTo(map);
       markersRef.current.push(marker);
     }

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -539,33 +539,77 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     else map.once('style.load', apply);
   }, [airspace, mapReady]);
 
-  // Marker collision avoidance. After labels are placed at touch points,
-  // sweep through them in route order and push later markers down (via the
-  // marker offset, in pixel space) far enough that their bounding box clears
-  // every earlier marker. Greedy O(N²) is fine for N < 50 typical turnpoint
-  // counts. Resets each marker's offset to the baseline first so successive
-  // re-runs (e.g. on zoom) don't compound shifts from prior passes.
-  const BASELINE_OFFSET_Y = -10;
+  // Per-marker context for label placement. anchor is the touch-point lng/lat
+  // (where the marker is geo-anchored); center is the cylinder centre. The
+  // outward direction from centre → anchor in pixel space defines the preferred
+  // label offset (radially outside the cylinder), so the label clears both the
+  // strict ring stroke and the optimised route line passing through that
+  // touch point.
+  const markerCtxRef = useRef<Array<{ anchor: [number, number]; center: [number, number] }>>([]);
+
+  // Distance in pixels to offset the label centre from the touch point along
+  // the outward radial. 18 px gives clearance over the 3-px strict ring stroke
+  // plus the dashed ground border, with a bit of breathing room.
+  const OUTWARD_PX = 18;
+
+  // Label placement: apply the radial outward offset, then greedy collision
+  // resolution. For each marker (in route order), if its bounding box overlaps
+  // an earlier marker's, shift it further along its outward direction until it
+  // clears. Re-runs on zoom/resize so it stays correct as pixel distances
+  // between geo-anchored markers change.
   const dedupeLabels = useCallback(() => {
+    const map = mapRef.current;
     const markers = markersRef.current;
+    const ctxs = markerCtxRef.current;
+    if (!map || markers.length < 1) return;
+
+    // Baseline = radial outward offset, in pixels. Recomputed every pass
+    // because the projection of anchor and centre changes with zoom.
+    const baselines: Array<[number, number]> = [];
+    for (let i = 0; i < markers.length; i++) {
+      const ctx = ctxs[i];
+      if (!ctx) {
+        baselines.push([0, -OUTWARD_PX]);
+        continue;
+      }
+      const aPx = map.project(ctx.anchor);
+      const cPx = map.project(ctx.center);
+      const dx = aPx.x - cPx.x;
+      const dy = aPx.y - cPx.y;
+      const len = Math.hypot(dx, dy);
+      baselines.push(len < 0.5 ? [0, -OUTWARD_PX] : [(dx / len) * OUTWARD_PX, (dy / len) * OUTWARD_PX]);
+    }
+    for (let i = 0; i < markers.length; i++) markers[i].setOffset(baselines[i]);
+
     if (markers.length < 2) return;
 
-    for (const m of markers) m.setOffset([0, BASELINE_OFFSET_Y]);
-
+    // Greedy collision resolution. Push the colliding marker further along its
+    // outward direction; if its outward is mostly horizontal (radial ≈ ±x),
+    // there's no vertical room to push so fall back to a downward shift.
     const rects = markers.map((m) => m.getElement().getBoundingClientRect());
     for (let i = 1; i < markers.length; i++) {
-      let pushDown = 0;
+      let extra = 0;
       for (let j = 0; j < i; j++) {
         const a = rects[i];
         const b = rects[j];
         const overlap = !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
         if (overlap) {
           const need = b.bottom - a.top + 4;
-          if (need > pushDown) pushDown = need;
+          if (need > extra) extra = need;
         }
       }
-      if (pushDown > 0) {
-        markers[i].setOffset([0, BASELINE_OFFSET_Y + pushDown]);
+      if (extra > 0) {
+        const [bx, by] = baselines[i];
+        const len = Math.hypot(bx, by);
+        // Prefer pushing along the outward direction; if outward is too
+        // horizontal (|by| ≪ |bx|), the vertical room is tiny — just push
+        // straight down by `extra`.
+        if (len > 0.5 && Math.abs(by) > 4) {
+          const scale = extra / Math.abs(by);
+          markers[i].setOffset([bx + bx * scale, by + by * scale]);
+        } else {
+          markers[i].setOffset([bx, by + extra]);
+        }
         rects[i] = markers[i].getElement().getBoundingClientRect();
       }
     }
@@ -577,6 +621,7 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
 
     markersRef.current.forEach((m) => m.remove());
     markersRef.current = [];
+    markerCtxRef.current = [];
 
     const groups = buildGroups(turnpoints);
     for (const group of groups) {
@@ -658,11 +703,13 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         touchPoints && widestEntry && touchPoints[widestEntry.tpIndex]
           ? ([touchPoints[widestEntry.tpIndex].lng, touchPoints[widestEntry.tpIndex].lat] as [number, number])
           : ([group.lng, group.lat] as [number, number]);
+      const center: [number, number] = [group.lng, group.lat];
 
-      const marker = new maplibregl.Marker({ element: el, anchor: 'bottom', offset: [0, -10] })
+      const marker = new maplibregl.Marker({ element: el, anchor: 'center', offset: [0, -OUTWARD_PX] })
         .setLngLat(anchor)
         .addTo(map);
       markersRef.current.push(marker);
+      markerCtxRef.current.push({ anchor, center });
     }
 
     const fitPts = cachedRoute

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -41,14 +41,15 @@ function hideIrrelevantLayers(map: maplibregl.Map) {
   }
 }
 
-// Palette: blue SSS, green ESS/Goal, pink for intermediate turnpoints, and
-// vivid orange for ground-only. The ground colour used to be a muted earthy
-// brown that read too close to the intermediate amber — pilots couldn't tell
-// at a glance which cylinders required a touchdown. The pink/orange split
-// pushes those two categories far apart in hue + saturation.
+// Palette: four distinct fill hues, one per role. Greens are deliberately
+// out — they wash into terrain on the outdoor basemap. Force-ground state
+// (orthogonal to role) is encoded by the border, not the fill, so a ground
+// SSS reads as "blue with a dashed border" instead of losing its role to a
+// flat overlay colour.
 function tpColor(type: string) {
-  if (type === 'SSS') return '#4a9eff';
-  if (type === 'ESS' || type === 'GOAL_CYLINDER' || type === 'GOAL_LINE') return '#5db87a';
+  if (type === 'SSS') return SSS_COLOR;
+  if (type === 'ESS') return ESS_COLOR;
+  if (type === 'GOAL_CYLINDER' || type === 'GOAL_LINE') return GOAL_COLOR;
   return REGULAR_TP_COLOR;
 }
 
@@ -74,11 +75,21 @@ function toCylinder(tp: Turnpoint): Cylinder {
   };
 }
 
+const SSS_COLOR = '#4a9eff'; // blue
+const ESS_COLOR = '#a855f7'; // purple — distinct from blue start and gold goal
+const GOAL_COLOR = '#eab308'; // amber — "finish line" celebratory cue
 const REGULAR_TP_COLOR = '#ec4899'; // pink — intermediate cylinders
-const GROUND_COLOR = '#f97316'; // vivid orange — force-ground TPs (any role)
 
 const LOCATION_TOL = 1e-4;
-const COLOR_PRI: Record<string, number> = { '#4a9eff': 3, '#5db87a': 2, [REGULAR_TP_COLOR]: 1 };
+// Used when two TPs sit at the same point at the same radius — render the
+// higher-priority role. SSS (start) wins over ESS/Goal (end-of-flight roles),
+// which win over a plain intermediate cylinder.
+const COLOR_PRI: Record<string, number> = {
+  [SSS_COLOR]: 4,
+  [GOAL_COLOR]: 3,
+  [ESS_COLOR]: 2,
+  [REGULAR_TP_COLOR]: 1,
+};
 
 interface TpEntry {
   role: string;
@@ -346,7 +357,7 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       mk('path', {
         d: `${bufD} ${d}`,
         'fill-rule': 'evenodd',
-        fill: '#5db87a',
+        fill: GOAL_COLOR,
         'fill-opacity': 0.5,
         stroke: 'none',
       });
@@ -358,14 +369,17 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         'stroke-width': 8,
         'stroke-linejoin': 'round',
       });
-      mk('path', {
+      // Goal-line boundary follows the same solid/dashed rule as cylinders:
+      // dashed only when the goal is force-ground.
+      const goalLineAttrs: Record<string, string | number> = {
         d,
-        fill: 'rgba(93,184,122,0.15)',
-        stroke: '#5db87a',
+        fill: GOAL_COLOR + '28',
+        stroke: GOAL_COLOR,
         'stroke-width': 3,
-        'stroke-dasharray': '10 5',
         'stroke-linejoin': 'round',
-      });
+      };
+      if (lastTp.forceGround === true) goalLineAttrs['stroke-dasharray'] = '10 6';
+      mk('path', goalLineAttrs);
     }
 
     // ── 3. IGC track line ─────────────────────────────────────────────────────
@@ -405,13 +419,14 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       }
     }
 
-    // ── 5. Coloured dashed rings + FAI §9.1.3 tolerance buffer ───────────────
-    // Role colour shows on the fill (preserves SSS/ESS/Goal at-a-glance); the
-    // stroke switches to earthy brown with a tighter dash for force-ground TPs.
-    // Outside each strict ring we shade the annular band between r and
-    // r + tagToleranceM(r) (max(5 m, 0.5 % of r)) — that's the band the
-    // scoring pipeline actually accepts for tag detection. Drawn first so
-    // the strict ring's stroke and translucent fill sit on top.
+    // ── 5. Coloured rings + FAI §9.1.3 tolerance buffer ──────────────────────
+    // Fill colour encodes role (SSS / ESS / Goal / regular); border style
+    // encodes ground-vs-not (solid = normal, dashed = force-ground). Keeping
+    // the role colour on every channel means a ground SSS still reads as
+    // blue — you don't have to remember which earth-tone overlay belongs to
+    // which role. Outside each strict ring we shade the annular band between
+    // r and r + tagToleranceM(r) (max(5 m, 0.5 % of r)) — the band the
+    // scoring pipeline actually accepts for tag detection.
     for (const group of groups) {
       for (const { radiusM, color, forceGround } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
         const { r } = projR(group.lng, group.lat, radiusM);
@@ -423,25 +438,27 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         // shade the band rather than drawing a thin ring — much more
         // visible on big cylinders and still tolerable on small ones. No
         // `stroke` here on purpose: a stroke would paint both subpaths and
-        // the inner stroke at r would land on top of the dashed strict ring
-        // below, filling in its dash gaps.
+        // the inner stroke at r would land on top of the strict ring's
+        // stroke below, muddying it.
         const bufferRadiusM = radiusM + tagToleranceM(radiusM);
         mk('path', {
           d: `${cylinderPath(group.lng, group.lat, bufferRadiusM)} ${cylinderPath(group.lng, group.lat, radiusM)}`,
           'fill-rule': 'evenodd',
-          fill: forceGround ? GROUND_COLOR : color,
+          fill: color,
           'fill-opacity': 0.5,
           stroke: 'none',
         });
 
         // Strict cylinder boundary (the scored-distance edge).
-        mk('path', {
+        // Dashed when force-ground, solid otherwise.
+        const ringAttrs: Record<string, string | number> = {
           d: cylinderPath(group.lng, group.lat, radiusM),
           fill: color + '28',
-          stroke: forceGround ? GROUND_COLOR : color,
+          stroke: color,
           'stroke-width': 3,
-          'stroke-dasharray': forceGround ? '3 5' : '10 5',
-        });
+        };
+        if (forceGround) ringAttrs['stroke-dasharray'] = '10 6';
+        mk('path', ringAttrs);
       }
     }
 
@@ -680,27 +697,53 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         }}
       >
         {[
-          { color: '#4a9eff', label: 'SSS', tooltip: 'Start of Speed Section — the clock starts on exit.' },
           {
+            kind: 'dot' as const,
+            color: SSS_COLOR,
+            label: 'SSS',
+            tooltip: 'Start of Speed Section — the clock starts on exit.',
+          },
+          {
+            kind: 'dot' as const,
             color: REGULAR_TP_COLOR,
             label: 'Turnpoint',
             tooltip: 'Intermediate turnpoint — pilots must enter this cylinder.',
           },
           {
-            color: '#5db87a',
-            label: 'ESS / Goal',
-            tooltip: 'End of Speed Section / Goal — crossing ESS stops the clock.',
+            kind: 'dot' as const,
+            color: ESS_COLOR,
+            label: 'ESS',
+            tooltip: 'End of Speed Section — crossing this stops the clock.',
           },
           {
-            color: GROUND_COLOR,
+            kind: 'dot' as const,
+            color: GOAL_COLOR,
+            label: 'Goal',
+            tooltip: 'Goal — the finish line of the task.',
+          },
+          {
+            kind: 'dashed-ring' as const,
+            color: 'rgba(255,255,255,0.85)',
             label: 'Ground-only',
             tooltip:
-              'Hike-and-fly: pilot must arrive on foot (GPS speed must fall below the threshold during the crossing). Marked with [GND] in the task file.',
+              'Hike-and-fly: pilot must arrive on foot (GPS speed must fall below the threshold during the crossing). Marked with [GND] in the task file. Shown with a dashed border on top of the role colour.',
           },
-        ].map(({ color, label, tooltip }) => (
+        ].map(({ kind, color, label, tooltip }) => (
           <div key={label} style={{ position: 'relative' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
-              <div style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
+              {kind === 'dashed-ring' ? (
+                <div
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: '50%',
+                    border: `1.5px dashed ${color}`,
+                    flexShrink: 0,
+                  }}
+                />
+              ) : (
+                <div style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
+              )}
               <span style={{ fontSize: 10, fontFamily: '"DM Mono", monospace', color: 'rgba(255,255,255,0.75)' }}>
                 {label}
               </span>

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -583,33 +583,26 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
 
     if (markers.length < 2) return;
 
-    // Greedy collision resolution. Push the colliding marker further along its
-    // outward direction; if its outward is mostly horizontal (radial ≈ ±x),
-    // there's no vertical room to push so fall back to a downward shift.
+    // Greedy collision resolution: keep the marker's outward X offset (so the
+    // label still leans toward whichever side of the cylinder the route exits)
+    // and shift it purely downward by the smallest amount that clears every
+    // earlier marker. Push-down is the simplest predictable axis and matches
+    // how the dedupe worked before the radial offset landed.
     const rects = markers.map((m) => m.getElement().getBoundingClientRect());
     for (let i = 1; i < markers.length; i++) {
-      let extra = 0;
+      let pushDown = 0;
       for (let j = 0; j < i; j++) {
         const a = rects[i];
         const b = rects[j];
         const overlap = !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
         if (overlap) {
           const need = b.bottom - a.top + 4;
-          if (need > extra) extra = need;
+          if (need > pushDown) pushDown = need;
         }
       }
-      if (extra > 0) {
+      if (pushDown > 0) {
         const [bx, by] = baselines[i];
-        const len = Math.hypot(bx, by);
-        // Prefer pushing along the outward direction; if outward is too
-        // horizontal (|by| ≪ |bx|), the vertical room is tiny — just push
-        // straight down by `extra`.
-        if (len > 0.5 && Math.abs(by) > 4) {
-          const scale = extra / Math.abs(by);
-          markers[i].setOffset([bx + bx * scale, by + by * scale]);
-        } else {
-          markers[i].setOffset([bx, by + extra]);
-        }
+        markers[i].setOffset([bx, by + pushDown]);
         rects[i] = markers[i].getElement().getBoundingClientRect();
       }
     }

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -468,21 +468,6 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       }
     }
 
-    // ── 6. Center dots ────────────────────────────────────────────────────────
-    for (const group of groups) {
-      const c = map.project([group.lng, group.lat]);
-      const dotColor =
-        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ??
-        REGULAR_TP_COLOR;
-      mk('circle', {
-        cx: c.x.toFixed(1),
-        cy: c.y.toFixed(1),
-        r: 5,
-        fill: dotColor,
-        stroke: 'rgba(0,0,0,0.7)',
-        'stroke-width': 2,
-      });
-    }
   }, []);
 
   useEffect(() => {
@@ -554,6 +539,38 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     if (map.isStyleLoaded()) apply();
     else map.once('style.load', apply);
   }, [airspace, mapReady]);
+
+  // Marker collision avoidance. After labels are placed at touch points,
+  // sweep through them in route order and push later markers down (via the
+  // marker offset, in pixel space) far enough that their bounding box clears
+  // every earlier marker. Greedy O(N²) is fine for N < 50 typical turnpoint
+  // counts. Resets each marker's offset to the baseline first so successive
+  // re-runs (e.g. on zoom) don't compound shifts from prior passes.
+  const BASELINE_OFFSET_Y = -10;
+  const dedupeLabels = useCallback(() => {
+    const markers = markersRef.current;
+    if (markers.length < 2) return;
+
+    for (const m of markers) m.setOffset([0, BASELINE_OFFSET_Y]);
+
+    const rects = markers.map((m) => m.getElement().getBoundingClientRect());
+    for (let i = 1; i < markers.length; i++) {
+      let pushDown = 0;
+      for (let j = 0; j < i; j++) {
+        const a = rects[i];
+        const b = rects[j];
+        const overlap = !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
+        if (overlap) {
+          const need = b.bottom - a.top + 4;
+          if (need > pushDown) pushDown = need;
+        }
+      }
+      if (pushDown > 0) {
+        markers[i].setOffset([0, BASELINE_OFFSET_Y + pushDown]);
+        rects[i] = markers[i].getElement().getBoundingClientRect();
+      }
+    }
+  }, []);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -644,8 +661,36 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
 
     drawSvg();
     const tid = setTimeout(drawSvg, 700);
-    return () => clearTimeout(tid);
-  }, [turnpoints, mapReady, drawSvg]);
+    // Wait one frame for markers to paint before we measure for collisions.
+    const rafId = requestAnimationFrame(dedupeLabels);
+    return () => {
+      clearTimeout(tid);
+      cancelAnimationFrame(rafId);
+    };
+  }, [turnpoints, mapReady, drawSvg, dedupeLabels]);
+
+  // Re-run collision avoidance on zoom + resize. Pan doesn't change pixel
+  // distances between geo-anchored markers, so it's not hooked. rAF-coalesced
+  // so a continuous zoom interaction does at most one dedupe per frame.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+    let pending = false;
+    const onChange = () => {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(() => {
+        pending = false;
+        dedupeLabels();
+      });
+    };
+    map.on('zoom', onChange);
+    map.on('resize', onChange);
+    return () => {
+      map.off('zoom', onChange);
+      map.off('resize', onChange);
+    };
+  }, [mapReady, dedupeLabels]);
 
   // Redraw when track changes (no map move needed)
   useEffect(() => {

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -559,7 +559,12 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     const groups = buildGroups(turnpoints);
     for (const group of groups) {
       const el = document.createElement('div');
-      el.style.cssText = 'pointer-events:none;text-align:center;';
+      // z-index 10 lifts the label above the SVG overlay (which is a sibling
+      // of the MapLibre container in the wrapper div with no explicit z).
+      // Without it, the cylinder fill + tolerance band paint over the role
+      // badge and place name, making them unreadable when the cylinder is
+      // small relative to the label.
+      el.style.cssText = 'pointer-events:none;text-align:center;z-index:10;';
 
       const badgeRow = document.createElement('div');
       badgeRow.style.cssText = 'display:flex;gap:3px;justify-content:center;margin-bottom:2px;flex-wrap:wrap;';
@@ -628,7 +633,14 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
       <svg
         ref={svgRef}
-        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
       />
 
       {/* Basemap + airspace toggle */}
@@ -726,7 +738,7 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
             color: 'rgba(255,255,255,0.85)',
             label: 'Ground-only',
             tooltip:
-              'Hike-and-fly: pilot must arrive on foot (GPS speed must fall below the threshold during the crossing). Marked with [GND] in the task file. Shown with a dashed border on top of the role colour.',
+              'Hike-and-fly: pilot must touch down somewhere inside the cylinder — a sustained 20 s window of low ground speed counts, so flying in, landing on a hillside, and relaunching is valid. Marked with [GND] in the task file. Shown with a dashed border on top of the role colour.',
           },
         ].map(({ kind, color, label, tooltip }) => (
           <div key={label} style={{ position: 'relative' }}>

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -589,31 +589,53 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       el.style.cssText = 'pointer-events:none;text-align:center;z-index:10;';
 
       const badgeRow = document.createElement('div');
-      badgeRow.style.cssText = 'display:flex;gap:3px;justify-content:center;margin-bottom:2px;flex-wrap:wrap;';
+      badgeRow.style.cssText = 'display:flex;gap:3px;justify-content:center;margin-bottom:3px;flex-wrap:wrap;';
       const seenRoles = new Set<string>();
       for (const { role, color } of group.entries) {
         if (seenRoles.has(role)) continue;
         seenRoles.add(role);
         const badge = document.createElement('div');
         badge.textContent = role;
+        // Dark pill + role-coloured text + matching outline. The dark fill
+        // takes the role colour off the basemap entirely so it reads on
+        // satellite, terrain, and OSM alike. Drop shadow gives a hint of
+        // separation from the cylinder fill beneath.
         badge.style.cssText = `
           display:inline-block;
-          background:${color}22;color:${color};
-          border:1px solid ${color}99;
-          font-family:"DM Mono",monospace;font-size:10px;font-weight:800;letter-spacing:0.05em;
-          padding:1px 5px;border-radius:3px;
+          background:rgba(0,0,0,0.82);
+          color:${color};
+          border:1px solid ${color}cc;
+          font-family:"DM Mono",monospace;
+          font-size:11px;
+          font-weight:700;
+          letter-spacing:0.06em;
+          padding:2px 7px;
+          border-radius:3px;
+          box-shadow:0 1px 2px rgba(0,0,0,0.4);
         `;
         badgeRow.appendChild(badge);
       }
 
+      // Place name in white with a hard dark halo — the standard cartographic
+      // label treatment (Google/OSM/Apple all variations of this). Four offset
+      // shadows form a sharp 1.2 px stroke that survives any basemap; the
+      // soft 4 px glow adds a faint backdrop where the basemap is light. Way
+      // more legible at small sizes than coloured text + soft shadow was.
       const nameEl = document.createElement('div');
       nameEl.textContent = group.name;
-      const nameColor =
-        [...group.entries].sort((a, b) => (COLOR_PRI[b.color] ?? 0) - (COLOR_PRI[a.color] ?? 0))[0]?.color ??
-        REGULAR_TP_COLOR;
       nameEl.style.cssText = `
-        color:${nameColor};font-family:"DM Mono",monospace;font-size:10px;font-weight:600;
-        text-shadow:0 0 4px rgba(0,0,0,1),0 0 8px rgba(0,0,0,0.8);white-space:nowrap;
+        color:#fff;
+        font-family:"DM Mono",monospace;
+        font-size:13px;
+        font-weight:700;
+        letter-spacing:0.02em;
+        white-space:nowrap;
+        text-shadow:
+          -1.2px -1.2px 0 rgba(0,0,0,0.95),
+          1.2px -1.2px 0 rgba(0,0,0,0.95),
+          -1.2px 1.2px 0 rgba(0,0,0,0.95),
+          1.2px 1.2px 0 rgba(0,0,0,0.95),
+          0 0 4px rgba(0,0,0,0.7);
       `;
 
       el.appendChild(badgeRow);

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -467,7 +467,6 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         mk('path', ringAttrs);
       }
     }
-
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Pilots reported the cylinder labels were hard to read and the ground-vs-normal encoding was conflated with role. This PR is the result of iterating with that feedback live — it ended up touching most of `TaskMap.tsx`. All in one file, all related, but worth listing the moving parts.

## What changed

### 1. Role + ground encoding split into two channels

Old: a single colour channel tried to encode both role (SSS / ESS / Goal / regular) and ground-state. Brown overrode the role colour for ground TPs, so a ground SSS lost its blue.

New: **fill colour = role**, **border style = ground**. A ground SSS now reads as a *blue cylinder with a dashed border*.

| Role        | Colour             | Hex       |
|-------------|--------------------|-----------|
| SSS         | blue               | `#4a9eff` |
| Turnpoint   | pink               | `#ec4899` |
| ESS         | purple             | `#a855f7` |
| Goal        | amber              | `#eab308` |

Greens are deliberately out — they wash into terrain on the outdoor MapTiler basemap.

| Border state | Stroke style    |
|--------------|-----------------|
| Non-ground   | solid           |
| Ground       | dashed (10 / 6) |

### 2. Labels anchored at the optimised route's touch point

Previously labels sat at the cylinder centre. For big cylinders (the NWPC tasks routinely use a 4 km GRN-6K cylinder) the centre is kilometres away from where pilots actually fly through, so the label was often well outside the visible viewport. Each marker now anchors at `routeResult.touchPoints[tpIndex]` — the point on the boundary where the optimised line enters/exits. Falls back to the centre when the optimiser hasn't produced a route.

### 3. Size-aware radial outward placement

Anchoring at the touch point put the label *on* the strict ring stroke and *on* the route line. Now each label is offset radially outward from the cylinder centre by

```
labelHalfExtent + LABEL_CLEARANCE_PX
```

where `labelHalfExtent = halfW × |ux| + halfH × |uy|` is the rect's half-extent projected onto the outward direction. Wide labels ("Tiger Launch") placed east/west get the same visual gap from the ring as short labels ("D1") placed north/south. `LABEL_CLEARANCE_PX = 16` is the tuning knob.

### 4. Collision dedupe

Adjacent turnpoints in screen space were producing overlapping labels. Added a greedy O(N²) pass that walks markers in route order and, for each one overlapping an earlier marker's bounding box, shifts it purely downward by enough to clear. Keeps the outward X intact so the label still leans toward the side of the cylinder the route exits. rAF-coalesced on the `zoom` listener; not hooked to `pan` (geo-anchored markers preserve relative pixel distances on pan). Re-runs on `resize` too.

### 5. Legibility pass on label content

- **Place name** (e.g. "Tiger Launch") was 10 px coloured text + soft shadow — washed out against the role-coloured tolerance band. Now 13 px white text with a sharp 1.2 px dark halo (four offset shadows) plus a soft glow. Standard cartographic treatment, reads on satellite / terrain / OSM the same.
- **Role badges** (e.g. "SSS", "D1") were faintly-tinted pills letting the basemap bleed through. Now near-opaque dark pills with role-coloured text + matching outline. Bumped 10 → 11 px / 700 weight, tiny drop shadow lifts them off the cylinder fill.

### 6. Tooltip fidelity

The Ground-only tooltip said the pilot must arrive on foot. That's wrong — `classifyGroundState` only requires a sustained 20 s window of low ground speed somewhere inside the cylinder. Fly-in / land on a hillside / relaunch is the canonical HAF move and counts fine. Reworded to match.

### 7. Smaller things

- **Centre dots removed** — didn't carry information pilots act on. The ring is the scored edge; the label says what's there.
- **Goal-line D-shape now amber** (was hard-coded green). Dashes only when the goal is force-ground.
- **`COLOR_PRI` reordered**: SSS > Goal > ESS > Regular — picks the right colour when two TPs share a centre + radius.
- **Legend gains a 4th row** so ESS and Goal aren't lumped together. The Ground-only swatch is now a dashed ring (no fill) to demonstrate the actual visual encoding.
- **z-index on labels**: SVG overlay (cylinder rings, tolerance band) was painting over the badges and place names. Explicit `zIndex: 1` on the SVG, `z-index: 10` on each marker DOM. Labels stay on top now.
- **`LABEL_CLEARANCE_PX`** lives at module scope alongside the colour constants.

## Test plan

- [x] `npm run typecheck` clean
- [x] `vite build` clean
- [x] `biome check` clean on `TaskMap.tsx`
- [x] `npx vitest run` — 220/220 pass
- [x] Visual smoke-tested locally against a NWPC task with the 4 km GRN-6K cylinder and a `[GND]`-prefixed task. Labels stay on top, sit just outside the cylinder rings, and stack vertically on zoom-out when consecutive TPs get close.