### PR TITLE
QR: emit 09:00Z start gate for XCTrack race-to-goal mode

### DIFF
--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -199,17 +199,27 @@ export function buildXctrackDeepLink(task: ExportTask): string {
     return obj;
   });
 
+  // For RACE_TO_GOAL, emit a single 09:00Z gate so XCTrack treats the task
+  // as a real race (start countdown + audio cues at SSS). 09:00 UTC is
+  // 02:00 PDT / 01:00 PST — effectively always-open for any real flight
+  // in this league, so the gate doesn't constrain when pilots can start.
+  //
+  // For OPEN_DISTANCE, omit `g` so XCTrack treats the task as a free
+  // task. Emitting `g:[]` doesn't work either — XCTrack rejects empty
+  // arrays with an "sss.timeGates is empty" parse error.
+  //
+  // `s.t = 1` is RACE (vs 2 = elapsed-time). `s.d` is documented as
+  // obsolete but is kept for backward compatibility with older readers.
+  const s: Record<string, unknown> = { d: 1, t: 1 };
+  if (task.taskType === 'RACE_TO_GOAL') {
+    s.g = ['09:00:00Z'];
+  }
+
   const qrTask: Record<string, unknown> = {
     taskType: 'CLASSIC',
     version: 2,
     t: turnpoints,
-    // Race-to-goal with a single 09:00Z gate. 09:00 UTC = ~01:00–02:00 PDT,
-    // so the gate is effectively always-open for real flights in this league
-    // while still giving XCTrack a valid race task (audio cues, countdown).
-    // `g` must be non-empty — `g:[]` triggers an "sss.timeGates is empty"
-    // parse error in XCTrack. `t:1` = RACE, `d` is documented as obsolete
-    // but kept for backward compatibility with older readers.
-    s: { g: ['09:00:00Z'], d: 1, t: 1 },
+    s,
     o: { v: 2 },
     e: 0, // WGS84
   };

--- a/src/task-exporters.ts
+++ b/src/task-exporters.ts
@@ -203,7 +203,13 @@ export function buildXctrackDeepLink(task: ExportTask): string {
     taskType: 'CLASSIC',
     version: 2,
     t: turnpoints,
-    s: { d: 1, t: 1 }, // no time gates (omitting g avoids XCTrack "timeGates is empty" parse error)
+    // Race-to-goal with a single 09:00Z gate. 09:00 UTC = ~01:00–02:00 PDT,
+    // so the gate is effectively always-open for real flights in this league
+    // while still giving XCTrack a valid race task (audio cues, countdown).
+    // `g` must be non-empty — `g:[]` triggers an "sss.timeGates is empty"
+    // parse error in XCTrack. `t:1` = RACE, `d` is documented as obsolete
+    // but kept for backward compatibility with older readers.
+    s: { g: ['09:00:00Z'], d: 1, t: 1 },
     o: { v: 2 },
     e: 0, // WGS84
   };

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -1017,12 +1017,13 @@ describe('QR roundtrip — 25_August_NWXC.xctsk → XCTSK QR', () => {
     expect(ourObj.t[6].z.endsWith(r400)).toBe(true);
   });
 
-  it('includes start section s with d and t fields', () => {
-    // g (timeGates) is intentionally omitted — passing g:[] causes XCTrack
-    // to throw "sss.timeGates is empty". We only assert the fields we set.
+  it('includes start section s with race gate at 09:00Z', () => {
+    // Reference QR (FlySkyHy) emits g:[] which XCTrack rejects with
+    // "sss.timeGates is empty". We emit a single early UTC gate so the
+    // task parses as a real race-to-goal with XCTrack's start cues.
     expect(ourObj.s.d).toBe(1);
     expect(ourObj.s.t).toBe(1);
-    expect(ourObj.s.g).toBeUndefined();
+    expect(ourObj.s.g).toEqual(['09:00:00Z']);
   });
 
   it('includes options o matching reference', () => {

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -871,6 +871,21 @@ describe('buildXctrackDeepLink — XCTSK v2 format', () => {
     const obj = JSON.parse(result.slice('XCTSK:'.length));
     expect(obj.e).toBe(0);
   });
+
+  it('emits a 09:00Z start gate for RACE_TO_GOAL tasks', () => {
+    const result = buildXctrackDeepLink(baseTask);
+    const obj = JSON.parse(result.slice('XCTSK:'.length));
+    expect(obj.s.g).toEqual(['09:00:00Z']);
+  });
+
+  it('omits the start gate for OPEN_DISTANCE tasks (free task in XCTrack)', () => {
+    const openTask: ExportTask = { ...baseTask, taskType: 'OPEN_DISTANCE' };
+    const result = buildXctrackDeepLink(openTask);
+    const obj = JSON.parse(result.slice('XCTSK:'.length));
+    expect(obj.s.g).toBeUndefined();
+    expect(obj.s.d).toBe(1);
+    expect(obj.s.t).toBe(1);
+  });
 });
 
 describe('encodeXctskZ — polyline coordinate encoding', () => {


### PR DESCRIPTION
## Summary

- Current QR codes emit `s: { d:1, t:1 }` with no `g` field, which XCTrack treats as a free task — no start gate, no countdown, no audio cue at SSS crossing.
- Per the [XCTrack v2 spec](https://xctrack.org/Competition_Interfaces.html), `s.t = 1` already means RACE; what was missing is a non-empty `s.g` (time gates) array.
- This adds a single `09:00:00Z` gate. 09:00 UTC ≈ 01:00–02:00 PDT, so the gate is effectively always-open for any real flight in this league, while XCTrack now parses the task as race-to-goal and gives pilots proper start cues during the flight.

### Why not `g:[]`?

That was tried previously (see commit `d231325`) — XCTrack rejects empty time-gate arrays with `sss.timeGates is empty`. We need at least one element, hence the single 09:00Z entry.

### Why UTC not local?

The QR can't carry a timezone. 09:00 UTC is "before any reasonable flight" for the NW US (PDT/PST), so it serves as a de-facto always-open gate without us having to encode a real start time.

## Test plan

- [x] `npm test` — 232 passed (11 files); roundtrip test in `tests/routes/tasks.test.ts` updated to assert `s.g === ['09:00:00Z']`
- [x] `npm run typecheck` — clean
- [ ] Manual verify: scan a generated QR with XCTrack on Android — task should show race countdown and play start-cue audio when crossing SSS
- [x] Manual verify: same with FlySkyHy on iOS — should still parse without error (FlySkyHy was already tolerant of `g:[]` in the reference QR)