### PR TITLE
Client-side IGC submission preview (#6)

### DIFF
--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -202,9 +202,12 @@ export default function FlightPreviewPanel({
           className="btn btn-primary"
           style={{ flex: 2, justifyContent: 'center', fontSize: 13 }}
           onClick={onSubmit}
-          disabled={uploading || !!error || !result}
+          // Parse/preview errors are unrecoverable without a different file —
+          // disable Submit. UPLOAD errors (network blip, server 5xx) are
+          // retryable against the same file so we keep Submit enabled.
+          disabled={uploading || !result || (!!error && error.stage !== 'UPLOAD')}
         >
-          {uploading ? 'Submitting…' : 'Submit Flight'}
+          {uploading ? 'Submitting…' : error?.stage === 'UPLOAD' ? 'Retry submit' : 'Submit Flight'}
         </button>
       </div>
     </div>

--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -7,9 +7,10 @@ import type { PreviewError, PreviewResult } from '../lib/previewPipeline';
 
 function fmtTime(seconds: number | null) {
   if (seconds == null) return '—';
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
   if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   return `${m}:${String(s).padStart(2, '0')}`;
 }

--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -1,0 +1,320 @@
+import type { LeaderboardEntry } from '../api/tasks';
+import type { PreviewError, PreviewResult } from '../lib/previewPipeline';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fmtTime(seconds: number | null) {
+  if (seconds == null) return '—';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function fmtPts(n: number | null | undefined) {
+  if (n == null) return '—';
+  return Math.round(n).toString();
+}
+
+function fmtKm(km: number | null | undefined) {
+  if (km == null) return '—';
+  return `${km.toFixed(1)} km`;
+}
+
+function delta(
+  curr: number | null | undefined,
+  prev: number | null | undefined,
+  opts: { higherIsBetter?: boolean } = {},
+) {
+  if (curr == null || prev == null) return null;
+  const d = curr - prev;
+  if (Math.abs(d) < 0.05) return null;
+  const better = (opts.higherIsBetter ?? true) ? d > 0 : d < 0;
+  const sign = d > 0 ? '+' : '';
+  return { text: `${sign}${d.toFixed(1)}`, color: better ? 'var(--gold)' : 'var(--danger)' };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FlightPreviewPanel
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Props {
+  filename: string;
+  /** Result from previewPipeline. null while loading. */
+  result: PreviewResult | null;
+  error: PreviewError | null;
+  /** The pilot's current best on this task. null = first submission for this pilot. */
+  previousBest: LeaderboardEntry | null;
+  uploading: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export default function FlightPreviewPanel({
+  filename,
+  result,
+  error,
+  previousBest,
+  uploading,
+  onSubmit,
+  onCancel,
+}: Props) {
+  const best = result?.attempts[result.bestAttemptIndex];
+
+  // Total turnpoints crossed by the preview attempt
+  const previewMetrics = best
+    ? {
+        distance: best.distanceFlownKm,
+        totalPoints: best.totalPoints,
+        distancePoints: best.distancePoints,
+        timePoints: best.timePoints,
+        reachedGoal: best.reachedGoal,
+        turnpointsCrossed: best.turnpointCrossings.length,
+        taskTimeS: best.taskTimeS,
+      }
+    : null;
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg2)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--r)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 14px',
+          borderBottom: '1px solid var(--border)',
+          background: 'rgba(16,185,129,0.06)',
+        }}
+      >
+        <span style={{ fontSize: 16, lineHeight: 1 }}>👁️</span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#10b981',
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          Preview
+        </span>
+        <span style={{ marginLeft: 'auto', fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text3)' }}>
+          {filename}
+        </span>
+      </div>
+
+      <div style={{ padding: 12 }}>
+        {error ? (
+          <div
+            style={{
+              padding: '10px 14px',
+              background: 'rgba(224,82,82,0.08)',
+              border: '1px solid rgba(224,82,82,0.2)',
+              borderRadius: 'var(--r)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              color: 'var(--danger)',
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>{error.stage}</div>
+            <div>{error.message}</div>
+          </div>
+        ) : !result ? (
+          <div
+            style={{
+              fontSize: 12,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--text2)',
+              textAlign: 'center',
+              padding: 16,
+            }}
+          >
+            Analysing flight…
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontFamily: 'var(--font-mono)' }}>
+            <Column
+              label="Previous Best"
+              violet
+              metrics={
+                previousBest
+                  ? {
+                      distance: previousBest.distanceFlownKm,
+                      totalPoints: previousBest.totalPoints,
+                      distancePoints: previousBest.distancePoints,
+                      timePoints: previousBest.timePoints,
+                      reachedGoal: previousBest.reachedGoal,
+                      taskTimeS: previousBest.taskTimeS,
+                    }
+                  : null
+              }
+            />
+            <Column
+              label="This Flight"
+              green
+              metrics={previewMetrics}
+              previousMetrics={
+                previousBest
+                  ? {
+                      distance: previousBest.distanceFlownKm,
+                      totalPoints: previousBest.totalPoints,
+                      distancePoints: previousBest.distancePoints,
+                      timePoints: previousBest.timePoints,
+                      reachedGoal: previousBest.reachedGoal,
+                      taskTimeS: previousBest.taskTimeS,
+                    }
+                  : null
+              }
+            />
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          padding: '10px 12px',
+          borderTop: '1px solid var(--border)',
+          display: 'flex',
+          gap: 8,
+        }}
+      >
+        <button
+          className="btn btn-ghost"
+          style={{ flex: 1, justifyContent: 'center', fontSize: 12 }}
+          onClick={onCancel}
+          disabled={uploading}
+        >
+          Cancel
+        </button>
+        <button
+          className="btn btn-primary"
+          style={{ flex: 2, justifyContent: 'center', fontSize: 13 }}
+          onClick={onSubmit}
+          disabled={uploading || !!error || !result}
+        >
+          {uploading ? 'Submitting…' : 'Submit Flight'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Column
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ColumnMetrics {
+  distance: number;
+  totalPoints: number;
+  distancePoints: number;
+  timePoints: number;
+  reachedGoal: boolean;
+  turnpointsCrossed?: number;
+  taskTimeS: number | null;
+}
+
+function Column({
+  label,
+  metrics,
+  previousMetrics,
+  violet,
+  green,
+}: {
+  label: string;
+  metrics: ColumnMetrics | null;
+  previousMetrics?: ColumnMetrics | null;
+  violet?: boolean;
+  green?: boolean;
+}) {
+  const accent = violet ? '#a78bfa' : green ? '#10b981' : 'var(--text)';
+  if (!metrics) {
+    return (
+      <div
+        style={{ padding: 10, border: '1px solid var(--border)', borderRadius: 6, color: 'var(--text3)', fontSize: 11 }}
+      >
+        <div
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: accent,
+            marginBottom: 8,
+          }}
+        >
+          {label}
+        </div>
+        No previous submission for this task.
+      </div>
+    );
+  }
+
+  const dDist = previousMetrics ? delta(metrics.distance, previousMetrics.distance) : null;
+  const dTotal = previousMetrics ? delta(metrics.totalPoints, previousMetrics.totalPoints) : null;
+
+  return (
+    <div style={{ padding: 10, border: `1px solid ${accent}55`, borderRadius: 6 }}>
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: accent,
+          marginBottom: 8,
+        }}
+      >
+        {label}
+      </div>
+      <Row k="Distance" v={fmtKm(metrics.distance)} delta={dDist} />
+      <Row k="Total pts" v={fmtPts(metrics.totalPoints)} delta={dTotal} bold />
+      <Row k="Dist pts" v={fmtPts(metrics.distancePoints)} />
+      <Row k="Time pts" v={fmtPts(metrics.timePoints)} />
+      <Row k="Goal" v={metrics.reachedGoal ? '✓' : '✗'} />
+      {metrics.turnpointsCrossed != null && <Row k="Turnpoints" v={String(metrics.turnpointsCrossed)} />}
+      <Row k="Task time" v={fmtTime(metrics.taskTimeS)} />
+    </div>
+  );
+}
+
+function Row({
+  k,
+  v,
+  delta: d,
+  bold,
+}: {
+  k: string;
+  v: string;
+  delta?: { text: string; color: string } | null;
+  bold?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        fontSize: 11,
+        padding: '2px 0',
+        fontWeight: bold ? 700 : 400,
+      }}
+    >
+      <span style={{ color: 'var(--text3)' }}>{k}</span>
+      <span style={{ color: 'var(--text)' }}>
+        {v}
+        {d && <span style={{ marginLeft: 4, fontSize: 10, color: d.color }}>{d.text}</span>}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -507,9 +507,11 @@ export default function TaskMap({ turnpoints, height = 300, track, tracks }: Tas
 
     // ── 6. Turnpoint hit markers ─────────────────────────────────────────────
     // For each overlay track that supplied `crossedSequenceIndexes`, draw a
-    // filled dot in the track's colour at the centre of every group whose
-    // turnpoints were crossed. Multi-track case: stack dots side by side so
-    // both pilots' touches are visible on the same cylinder.
+    // checkmark in the track's colour at the centre of every group whose
+    // turnpoints were crossed. Drawn as a dark shadow stroke + coloured stroke
+    // on top, same pattern as the track polylines, so the check stays legible
+    // against both outdoor and satellite basemaps. Multi-track case: lay the
+    // checkmarks out side by side so both pilots' touches are visible.
     for (const group of groups) {
       const groupSeqs = new Set(group.entries.map((e) => tps[e.tpIndex].sequenceIndex));
       const hits = tracksRef.current.filter(
@@ -517,16 +519,27 @@ export default function TaskMap({ turnpoints, height = 300, track, tracks }: Tas
       );
       if (hits.length === 0) continue;
       const { cx, cy } = projR(group.lng, group.lat, 0);
-      const spacing = 9;
+      const spacing = 14;
       const x0 = cx - ((hits.length - 1) * spacing) / 2;
       hits.forEach((overlay, i) => {
-        mk('circle', {
-          cx: x0 + i * spacing,
-          cy,
-          r: 4,
-          fill: overlay.color,
+        const x = x0 + i * spacing;
+        // ✓ shape — short downstroke meeting a longer upstroke at the bottom-left.
+        const d = `M${x - 5},${cy} L${x - 1.5},${cy + 4} L${x + 6},${cy - 5}`;
+        mk('path', {
+          d,
+          fill: 'none',
           stroke: '#000',
-          'stroke-width': 1.2,
+          'stroke-width': 4,
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+        });
+        mk('path', {
+          d,
+          fill: 'none',
+          stroke: overlay.color,
+          'stroke-width': 2.2,
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
         });
       });
     }

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -182,7 +182,7 @@ export interface TrackOverlay {
   color: string;
   /**
    * `sequenceIndex` of every turnpoint this track touched. When present, a
-   * filled dot in the track's colour is drawn at each matching cylinder centre.
+   * checkmark in the track's colour is drawn at each matching cylinder centre.
    * Omit to skip hit markers for this track.
    */
   crossedSequenceIndexes?: number[];

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -174,26 +174,53 @@ function getInitialStyle(): string | maplibregl.StyleSpecification {
 // TaskMap
 // ─────────────────────────────────────────────────────────────────────────────
 
+export interface TrackOverlay {
+  /** Stable id for diffing; not surfaced visually. */
+  id: string;
+  fixes: ReplayFix[];
+  /** Hex colour for the polyline + hit-markers. */
+  color: string;
+  /**
+   * `sequenceIndex` of every turnpoint this track touched. When present, a
+   * filled dot in the track's colour is drawn at each matching cylinder centre.
+   * Omit to skip hit markers for this track.
+   */
+  crossedSequenceIndexes?: number[];
+}
+
 interface TaskMapProps {
   turnpoints: Turnpoint[];
   height?: number | string;
+  /** Legacy single-track prop — renders in violet without hit markers. */
   track?: ReplayFix[] | null;
+  /** Multiple tracks (e.g. previous-best + preview). Overrides `track` if set. */
+  tracks?: TrackOverlay[] | null;
 }
 
-export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProps) {
+const LEGACY_TRACK_COLOR = '#a78bfa';
+
+export default function TaskMap({ turnpoints, height = 300, track, tracks }: TaskMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const markersRef = useRef<maplibregl.Marker[]>([]);
   const [legendOpen, setLegendOpen] = useState<string | null>(null);
   const tpsRef = useRef<Turnpoint[]>(turnpoints);
-  const trackRef = useRef<ReplayFix[] | null | undefined>(track);
+
+  // Normalise: callers pass either `track` (old single-track) or `tracks` (new
+  // multi-track). The drawing code only sees `tracksRef.current`.
+  const normalisedTracks: TrackOverlay[] = tracks
+    ? tracks
+    : track && track.length >= 2
+      ? [{ id: 'legacy', fixes: track, color: LEGACY_TRACK_COLOR }]
+      : [];
+  const tracksRef = useRef<TrackOverlay[]>(normalisedTracks);
   const [basemap, setBasemap] = useState<'outdoor' | 'satellite'>('outdoor');
   const [airspace, setAirspace] = useState(false);
   const [mapReady, setMapReady] = useState(false);
 
   tpsRef.current = turnpoints;
-  trackRef.current = track;
+  tracksRef.current = normalisedTracks;
 
   // Cache optimiseRoute result — recomputed only when turnpoints change, not on pan/zoom
   const cachedRoute = useMemo(() => optimisedRouteResult(turnpoints), [turnpoints]);
@@ -395,10 +422,13 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       mk('path', goalLineAttrs);
     }
 
-    // ── 3. IGC track line ─────────────────────────────────────────────────────
-    const fixes = trackRef.current;
-    if (fixes && fixes.length >= 2) {
-      const pts = fixes.map((f) => map.project([f.lng, f.lat]));
+    // ── 3. IGC track lines ────────────────────────────────────────────────────
+    // Each overlay draws a dark shadow polyline (for contrast on light tiles)
+    // then the coloured line on top. Tracks render in input order — callers
+    // put the visually-prioritised one last (e.g. preview on top of best).
+    for (const overlay of tracksRef.current) {
+      if (overlay.fixes.length < 2) continue;
+      const pts = overlay.fixes.map((f) => map.project([f.lng, f.lat]));
       const d = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join('');
       mk('path', {
         d,
@@ -411,7 +441,7 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
       mk('path', {
         d,
         fill: 'none',
-        stroke: '#a78bfa',
+        stroke: overlay.color,
         'stroke-width': 1.5,
         'stroke-linecap': 'round',
         'stroke-linejoin': 'round',
@@ -473,6 +503,32 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
         if (forceGround) ringAttrs['stroke-dasharray'] = '10 6';
         mk('path', ringAttrs);
       }
+    }
+
+    // ── 6. Turnpoint hit markers ─────────────────────────────────────────────
+    // For each overlay track that supplied `crossedSequenceIndexes`, draw a
+    // filled dot in the track's colour at the centre of every group whose
+    // turnpoints were crossed. Multi-track case: stack dots side by side so
+    // both pilots' touches are visible on the same cylinder.
+    for (const group of groups) {
+      const groupSeqs = new Set(group.entries.map((e) => tps[e.tpIndex].sequenceIndex));
+      const hits = tracksRef.current.filter(
+        (t) => t.crossedSequenceIndexes && t.crossedSequenceIndexes.some((s) => groupSeqs.has(s)),
+      );
+      if (hits.length === 0) continue;
+      const { cx, cy } = projR(group.lng, group.lat, 0);
+      const spacing = 9;
+      const x0 = cx - ((hits.length - 1) * spacing) / 2;
+      hits.forEach((overlay, i) => {
+        mk('circle', {
+          cx: x0 + i * spacing,
+          cy,
+          r: 4,
+          fill: overlay.color,
+          stroke: '#000',
+          'stroke-width': 1.2,
+        });
+      });
     }
   }, []);
 
@@ -778,10 +834,10 @@ export default function TaskMap({ turnpoints, height = 300, track }: TaskMapProp
     };
   }, [mapReady, dedupeLabels]);
 
-  // Redraw when track changes (no map move needed)
+  // Redraw when tracks change (no map move needed)
   useEffect(() => {
     if (mapReady) drawSvg();
-  }, [track, mapReady, drawSvg]);
+  }, [track, tracks, mapReady, drawSvg]);
 
   return (
     <div style={{ width: '100%', height: height, position: 'relative' }}>

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -847,7 +847,13 @@ export default function TaskMap({ turnpoints, height = 300, track, tracks }: Tas
     };
   }, [mapReady, dedupeLabels]);
 
-  // Redraw when tracks change (no map move needed)
+  // Redraw when tracks change (no map move needed).
+  //
+  // drawSvg is wrapped in useCallback([]) — it reads turnpoints / tracks /
+  // route through refs so the function identity stays stable across renders
+  // and pan/zoom listeners stay attached. This effect is what re-invokes it
+  // when the underlying data changes; if you add a new ref-backed input to
+  // drawSvg, add it to this dep array too.
   useEffect(() => {
     if (mapReady) drawSvg();
   }, [track, tracks, mapReady, drawSvg]);

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -158,10 +158,13 @@ export default function UploadZone({ taskId, taskStatus, task, onSubmission, onF
     }
     // Preview mode: hand the file to the parent and reset local state so
     // UploadZone goes back to its "drop a file" affordance when the parent
-    // re-mounts it after the preview closes.
+    // re-mounts it after the preview closes. reset() clears any stale upload
+    // hook state (status/error/progress) that might linger from a prior submit.
     if (onFilePicked) {
       onFilePicked(f);
       setFile(null);
+      setDrag(false);
+      reset();
       if (fileRef.current) fileRef.current.value = '';
       return;
     }

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -123,9 +123,15 @@ interface UploadZoneProps {
   taskStatus: TaskStatus;
   task: Task;
   onSubmission?: (id: string) => void;
+  /**
+   * When set, the zone defers the actual upload to the parent. After file
+   * validation it calls this callback and leaves its own upload state idle —
+   * the parent typically swaps in a preview panel that owns the upload.
+   */
+  onFilePicked?: (file: File) => void;
 }
 
-export default function UploadZone({ taskId, taskStatus, task, onSubmission }: UploadZoneProps) {
+export default function UploadZone({ taskId, taskStatus, task, onSubmission, onFilePicked }: UploadZoneProps) {
   const { user, login } = useAuth();
   const { leagueSlug } = useLeague();
   const [showExport, setShowExport] = useState(false);
@@ -148,6 +154,15 @@ export default function UploadZone({ taskId, taskStatus, task, onSubmission }: U
     }
     if (f.size > 5 * 1024 * 1024) {
       alert('File too large — maximum 5MB');
+      return;
+    }
+    // Preview mode: hand the file to the parent and reset local state so
+    // UploadZone goes back to its "drop a file" affordance when the parent
+    // re-mounts it after the preview closes.
+    if (onFilePicked) {
+      onFilePicked(f);
+      setFile(null);
+      if (fileRef.current) fileRef.current.value = '';
       return;
     }
     setFile(f);

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -25,8 +25,10 @@ export interface PreviewError {
 }
 
 function turnpointToDef(tp: Turnpoint) {
-  // The pipeline keys crossings by turnpointId. Sequence index is unique per
-  // task and stable, so it doubles as the id for the preview.
+  // Preview-only synthetic ID — does NOT round-trip to the server's
+  // turnpoints.id. We only use it locally to satisfy the pipeline's
+  // TurnpointDef shape; everything the UI keys off comes back through
+  // sequenceIndex (which IS stable across client and server).
   return {
     id: `tp-${tp.sequenceIndex}`,
     sequenceIndex: tp.sequenceIndex,

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -1,0 +1,97 @@
+// Client-side IGC scoring preview.
+//
+// Reuses the backend pipeline (src/pipeline.ts) so the preview shown to the
+// pilot before they submit is the same code that the server runs after they
+// submit. The server remains authoritative — this is just so the pilot can
+// see what's going to happen first.
+
+import type { ScoredAttempt } from '../../../src/pipeline';
+import { parseAndValidate, runPipeline } from '../../../src/pipeline';
+import type { Season } from '../api/leagues';
+import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
+import type { ReplayFix } from '../api/track';
+
+export interface PreviewResult {
+  attempts: ScoredAttempt[];
+  bestAttemptIndex: number;
+  flightDate: string;
+  fixes: ReplayFix[];
+}
+
+export interface PreviewError {
+  stage: string;
+  code: string;
+  message: string;
+}
+
+function turnpointToDef(tp: Turnpoint) {
+  // The pipeline keys crossings by turnpointId. Sequence index is unique per
+  // task and stable, so it doubles as the id for the preview.
+  return {
+    id: `tp-${tp.sequenceIndex}`,
+    sequenceIndex: tp.sequenceIndex,
+    lat: tp.latitude,
+    lng: tp.longitude,
+    radiusM: tp.radiusM,
+    type: tp.type,
+    forceGround: tp.forceGround,
+    goalLineBearingDeg: tp.goalLineBearingDeg ?? undefined,
+  };
+}
+
+export async function previewSubmission(
+  igcText: string,
+  task: Task,
+  season: Pick<Season, 'competitionType'>,
+  leaderboardEntries: LeaderboardEntry[],
+): Promise<{ ok: true; value: PreviewResult } | { ok: false; error: PreviewError }> {
+  const taskBestDistanceKm = leaderboardEntries.reduce((m, e) => Math.max(m, e.distanceFlownKm ?? 0), 0);
+  const existingGoalTimes = leaderboardEntries
+    .filter((e) => e.reachedGoal && e.taskTimeS != null)
+    .map((e) => e.taskTimeS as number);
+
+  const result = await runPipeline(
+    {
+      igcText,
+      task: {
+        id: task.id,
+        turnpoints: task.turnpoints.map(turnpointToDef),
+      },
+      existingGoalTimes,
+      competitionType: season.competitionType,
+    },
+    task.openDate,
+    task.closeDate,
+    taskBestDistanceKm,
+  );
+
+  if (!result.ok) {
+    const e = result.error;
+    return {
+      ok: false,
+      error: {
+        stage: e.stage,
+        // PipelineError shapes vary by stage — extract code/message where present
+        code: (e.error as { code?: string }).code ?? e.stage,
+        message: (e.error as { message?: string }).message ?? 'Preview failed',
+      },
+    };
+  }
+
+  // Re-parse to surface the fix array for the map overlay. parseAndValidate is
+  // pure and idempotent so this is essentially free.
+  const parsed = parseAndValidate(igcText);
+  const fixes: ReplayFix[] = parsed.ok
+    ? parsed.value.fixes.map((f) => ({ t: f.timestamp, lat: f.lat, lng: f.lng, alt: f.gpsAlt }))
+    : [];
+
+  return {
+    ok: true,
+    value: {
+      attempts: result.value.scoredAttempts,
+      bestAttemptIndex: result.value.bestAttemptIndex,
+      flightDate: result.value.flightDate,
+      fixes,
+    },
+  };
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,29 +2,33 @@
 // HomePage — unified league home: standings matrix + per-task split view
 // =============================================================================
 
-import { useQueries, useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSearchParams } from 'react-router-dom';
 import rehypeSanitize from 'rehype-sanitize';
 import type { League } from '../api/leagues';
 import { standingsApi } from '../api/standings';
 import type { LeaderboardEntry, Task } from '../api/tasks';
-import { tasksApi } from '../api/tasks';
-import type { ReplayFix } from '../api/track';
+import { submissionsApi, tasksApi } from '../api/tasks';
 import { trackApi } from '../api/track';
+import FlightPreviewPanel from '../components/FlightPreviewPanel';
 import LeagueSwitcher from '../components/LeagueSwitcher';
 import MySubmissions from '../components/MySubmissions';
 import ScoringExplainer from '../components/ScoringExplainer';
 import StandingsMatrix from '../components/StandingsMatrix';
 import TaskLeaderboard from '../components/TaskLeaderboard';
-import TaskMap, { computeDistanceKm, toCylinder } from '../components/TaskMap';
+import TaskMap, { computeDistanceKm, type TrackOverlay, toCylinder } from '../components/TaskMap';
 import UploadZone from '../components/UploadZone';
 import { useAuth } from '../hooks/useAuth';
 import { useLeague } from '../hooks/useLeague';
 import { useSeasons } from '../hooks/useStandings';
+import { type PreviewError, type PreviewResult, previewSubmission } from '../lib/previewPipeline';
 import { markdownRemarkPlugins, markdownSanitizeSchema } from '../utils/markdown';
 import { getTaskStatus, STATUS_STYLE } from '../utils/taskStatus';
+
+const PREVIEW_COLOR = '#10b981'; // emerald-500
+const BEST_COLOR = '#a78bfa'; // violet-400, matches existing single-track render
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TabBar
@@ -113,6 +117,7 @@ function TaskLeftPanel({
   trackLoading,
   onSelectPilot,
   onSelectMySubmission,
+  onFilePicked,
 }: {
   task: Task;
   leaderboardEntries: LeaderboardEntry[];
@@ -123,6 +128,7 @@ function TaskLeftPanel({
   trackLoading: boolean;
   onSelectPilot: (entry: LeaderboardEntry) => void;
   onSelectMySubmission: (submissionId: string) => void;
+  onFilePicked: (file: File) => void;
 }) {
   const taskStatus = getTaskStatus(task);
   const ss = STATUS_STYLE[taskStatus];
@@ -182,7 +188,7 @@ function TaskLeftPanel({
       </div>
 
       {/* Upload zone */}
-      <UploadZone taskId={task.id} taskStatus={taskStatus} task={task} />
+      <UploadZone taskId={task.id} taskStatus={taskStatus} task={task} onFilePicked={onFilePicked} />
 
       {/* Pilot's per-submission breakdown — only mounts for logged-in viewers.
           GET /submissions returns 403 for logged-in non-members of the league;
@@ -322,7 +328,110 @@ export default function HomePage() {
     enabled: !!activeTask && !!activeEntry?.submissionId,
     staleTime: 5 * 60 * 1000,
   });
-  const track: ReplayFix[] | null = trackData?.fixes ?? null;
+
+  // ── Preview state ──────────────────────────────────────────────────────────
+  // When the pilot picks an .igc, run the same scoring pipeline locally and
+  // swap the left sidebar for a preview/compare panel. The server still does
+  // the authoritative scoring on actual Submit.
+  const queryClient = useQueryClient();
+  const [previewFile, setPreviewFile] = useState<File | null>(null);
+  const [previewResult, setPreviewResult] = useState<PreviewResult | null>(null);
+  const [previewError, setPreviewError] = useState<PreviewError | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  // Pilot's previous-best entry on the active task (null = first submission).
+  const previousBestEntry = useMemo(() => {
+    if (!user) return null;
+    return activeEntries.find((e) => e.pilotId === user.id && e.submissionId) ?? null;
+  }, [user, activeEntries]);
+
+  // Fetch the previous-best track to overlay in violet during preview.
+  const { data: previousBestTrack } = useQuery({
+    queryKey: ['track', leagueSlug, seasonId, activeTask?.id, previousBestEntry?.submissionId, 'preview-best'],
+    queryFn: () => trackApi.get(leagueSlug, seasonId, activeTask!.id, previousBestEntry!.submissionId!),
+    enabled: !!previewFile && !!activeTask && !!previousBestEntry?.submissionId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Run the local preview pipeline whenever a new file is picked.
+  useEffect(() => {
+    if (!previewFile || !activeTask || !season) return;
+    let cancelled = false;
+    setPreviewResult(null);
+    setPreviewError(null);
+    (async () => {
+      const text = await previewFile.text();
+      const res = await previewSubmission(text, activeTask, { competitionType: season.competitionType }, activeEntries);
+      if (cancelled) return;
+      if (res.ok) setPreviewResult(res.value);
+      else setPreviewError(res.error);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [previewFile, activeTask, season, activeEntries]);
+
+  // Clear preview when navigating away from the task tab.
+  useEffect(() => {
+    setPreviewFile(null);
+    setPreviewResult(null);
+    setPreviewError(null);
+  }, [activeTask?.id]);
+
+  const handleSubmitPreview = async () => {
+    if (!previewFile || !activeTask) return;
+    setUploading(true);
+    try {
+      await submissionsApi.upload(leagueSlug, seasonId, activeTask.id, previewFile);
+      queryClient.invalidateQueries({ queryKey: ['leaderboard', leagueSlug, seasonId, activeTask.id] });
+      queryClient.invalidateQueries({ queryKey: ['submissions', leagueSlug, seasonId, activeTask.id] });
+      setPreviewFile(null);
+      setPreviewResult(null);
+      setPreviewError(null);
+    } catch (err: any) {
+      setPreviewError({ stage: 'UPLOAD', code: 'UPLOAD_FAILED', message: err?.message ?? 'Upload failed' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  // TaskMap input — single track when no preview; two-track overlay during preview.
+  const mapTracks: TrackOverlay[] | null = previewFile
+    ? [
+        ...(previousBestTrack
+          ? [
+              {
+                id: 'best',
+                fixes: previousBestTrack.fixes,
+                color: BEST_COLOR,
+                crossedSequenceIndexes: previousBestTrack.crossings.map((c) => c.sequenceIndex),
+              },
+            ]
+          : []),
+        ...(previewResult
+          ? [
+              {
+                id: 'preview',
+                fixes: previewResult.fixes,
+                color: PREVIEW_COLOR,
+                crossedSequenceIndexes:
+                  previewResult.attempts[previewResult.bestAttemptIndex]?.turnpointCrossings.map(
+                    (c) => c.sequenceIndex,
+                  ) ?? [],
+              },
+            ]
+          : []),
+      ]
+    : trackData
+      ? [
+          {
+            id: 'selected',
+            fixes: trackData.fixes,
+            color: BEST_COLOR,
+            crossedSequenceIndexes: trackData.crossings.map((c) => c.sequenceIndex),
+          },
+        ]
+      : null;
 
   // scoreMap: taskId → (pilotId → totalPoints) — for Overall tab
   const scoreMap = new Map<string, Map<string, number>>();
@@ -403,7 +512,7 @@ export default function HomePage() {
         </div>
       </div>
     ) : activeTask ? (
-      <TaskMap turnpoints={activeTask.turnpoints} height="100%" track={track} />
+      <TaskMap turnpoints={activeTask.turnpoints} height="100%" tracks={mapTracks} />
     ) : null;
 
   return (
@@ -483,6 +592,20 @@ export default function HomePage() {
               maxByTask={maxByTask}
               myId={user?.id}
             />
+          ) : activeTask && previewFile ? (
+            <FlightPreviewPanel
+              filename={previewFile.name}
+              result={previewResult}
+              error={previewError}
+              previousBest={previousBestEntry}
+              uploading={uploading}
+              onSubmit={handleSubmitPreview}
+              onCancel={() => {
+                setPreviewFile(null);
+                setPreviewResult(null);
+                setPreviewError(null);
+              }}
+            />
           ) : activeTask ? (
             <TaskLeftPanel
               task={activeTask}
@@ -494,12 +617,13 @@ export default function HomePage() {
               trackLoading={trackLoading}
               onSelectPilot={handleSelectPilot}
               onSelectMySubmission={handleSelectMySubmission}
+              onFilePicked={setPreviewFile}
             />
           ) : null)}
 
         {/* Map — rendered inline on mobile when map view is active */}
         <div className={`home-map-mobile${mobileShowMap && activeTask ? '' : ' hidden'}`}>
-          {activeTask && <TaskMap turnpoints={activeTask.turnpoints} height="100%" track={track} />}
+          {activeTask && <TaskMap turnpoints={activeTask.turnpoints} height="100%" tracks={mapTracks} />}
         </div>
       </div>
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -356,6 +356,14 @@ export default function HomePage() {
   // Refs read at effect-fire time so leaderboard refetches don't re-trigger
   // the preview parse/score. Once a file is picked we want a single run keyed
   // off the file, not off the live leaderboard (which refetches on a timer).
+  //
+  // Side-effect of this snapshot: taskBestDistanceKm and existingGoalTimes
+  // (derived from activeEntries inside previewSubmission) are frozen at
+  // file-pick time. If another pilot uploads a goal flight while this pilot
+  // is reviewing their preview, the preview's time-points could differ
+  // slightly from the server's authoritative score on submit. That's
+  // intentional — server is authoritative and a flickering preview number
+  // would be worse UX than a slightly-stale one.
   const activeTaskRef = useRef(activeTask);
   activeTaskRef.current = activeTask;
   const seasonRef = useRef(season);
@@ -385,6 +393,9 @@ export default function HomePage() {
         setPreviewError({ stage: 'PREVIEW', code: 'PREVIEW_FAILED', message: err?.message ?? 'Preview failed' });
       }
     })();
+    // Cleanup also runs when previewFile transitions to null (cancel/submit),
+    // which flips the prior closure's `cancelled` flag and aborts the
+    // in-flight parse for the file just dismissed. Intentional.
     return () => {
       cancelled = true;
     };

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@
 // =============================================================================
 
 import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSearchParams } from 'react-router-dom';
 import rehypeSanitize from 'rehype-sanitize';
@@ -353,29 +353,49 @@ export default function HomePage() {
     staleTime: 5 * 60 * 1000,
   });
 
+  // Refs read at effect-fire time so leaderboard refetches don't re-trigger
+  // the preview parse/score. Once a file is picked we want a single run keyed
+  // off the file, not off the live leaderboard (which refetches on a timer).
+  const activeTaskRef = useRef(activeTask);
+  activeTaskRef.current = activeTask;
+  const seasonRef = useRef(season);
+  seasonRef.current = season;
+  const activeEntriesRef = useRef(activeEntries);
+  activeEntriesRef.current = activeEntries;
+
   // Run the local preview pipeline whenever a new file is picked.
   useEffect(() => {
-    if (!previewFile || !activeTask || !season) return;
+    if (!previewFile) return;
+    const task = activeTaskRef.current;
+    const seasonNow = seasonRef.current;
+    if (!task || !seasonNow) return;
+    const entries = activeEntriesRef.current;
     let cancelled = false;
     setPreviewResult(null);
     setPreviewError(null);
     (async () => {
-      const text = await previewFile.text();
-      const res = await previewSubmission(text, activeTask, { competitionType: season.competitionType }, activeEntries);
-      if (cancelled) return;
-      if (res.ok) setPreviewResult(res.value);
-      else setPreviewError(res.error);
+      try {
+        const text = await previewFile.text();
+        const res = await previewSubmission(text, task, { competitionType: seasonNow.competitionType }, entries);
+        if (cancelled) return;
+        if (res.ok) setPreviewResult(res.value);
+        else setPreviewError(res.error);
+      } catch (err: any) {
+        if (cancelled) return;
+        setPreviewError({ stage: 'PREVIEW', code: 'PREVIEW_FAILED', message: err?.message ?? 'Preview failed' });
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, [previewFile, activeTask, season, activeEntries]);
+  }, [previewFile]);
 
   // Clear preview when navigating away from the task tab.
   useEffect(() => {
     setPreviewFile(null);
     setPreviewResult(null);
     setPreviewError(null);
+    setUploading(false);
   }, [activeTask?.id]);
 
   const handleSubmitPreview = async () => {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,12 +6,12 @@
 // Errors are typed and propagate without throwing
 // =============================================================================
 
+import IGCParser from 'igc-parser';
 import {
   type Cylinder,
   computeDistancePoints,
   computePartialDistanceKm,
   computeTimePoints,
-  MAX_POINTS,
   type OptimisedRoute,
   optimiseRoute,
   tagToleranceM,
@@ -138,9 +138,6 @@ export interface ParsedTrack {
  * Stage 1: parseAndValidate
  */
 export function parseAndValidate(igcText: string): Result<ParsedTrack, ParseError> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const IGCParser = require('igc-parser');
-
   let parsed: any;
   try {
     parsed = IGCParser.parse(igcText, { lenient: false });


### PR DESCRIPTION
Closes #6.

Pilots can now see their flight scored and rendered on the map **before** they upload. The same pipeline (`src/pipeline.ts`) that runs server-side now also runs in the browser via Vite's CJS interop on `igc-parser`; the server reruns it on actual upload and remains authoritative.

## Flow

1. Pilot picks an `.igc` in `UploadZone`.
2. The local pipeline parses + scores it. The left sidebar swaps to a `FlightPreviewPanel` comparing the preview against the pilot's current best on this task. First-submission case renders a single-column view + "No previous submission for this task" placeholder.
3. `TaskMap` renders both tracks (previous best in violet, preview in green) plus a per-track checkmark at each turnpoint the track touched.
4. **Submit** triggers the same upload + invalidation flow as before. **Cancel** restores the original sidebar.

## Driveby

`TaskMap`'s existing single-track view also picks up the turnpoint hit-markers — `TrackReplay` already carries `crossings`, the rendering just hadn't used them before.

## Implementation

- **`src/pipeline.ts`** — `require('igc-parser')` → ESM import (so Vite can bundle); dropped unused `MAX_POINTS` import.
- **`frontend/src/lib/previewPipeline.ts`** (new) — thin wrapper over `runPipeline` that maps `Task` + `LeaderboardEntry[]` into the pipeline's input shape and surfaces `ReplayFix[]` for the map.
- **`frontend/src/components/TaskMap.tsx`** — new `tracks: TrackOverlay[]` prop with a back-compat shim for the old single-track callers; per-track checkmark hit-markers.
- **`frontend/src/components/FlightPreviewPanel.tsx`** (new) — two-column comparison sidebar with delta indicators.
- **`frontend/src/components/UploadZone.tsx`** — optional `onFilePicked` prop defers upload to the parent when set.
- **`frontend/src/pages/HomePage.tsx`** — preview state, previous-best track fetch (gated on \`previewFile\` to avoid the request when not previewing), sidebar swap, multi-track wiring for both desktop + mobile maps.

`bestDistanceKm` and `goalTimesS` are derived client-side from the already-fetched leaderboard — no new backend endpoint needed.

## Test plan

- [x] \`npm run typecheck\` — clean on both \`tsconfig.server.json\` and frontend.
- [x] \`npx vitest run\` — 245/245 backend tests pass.
- [x] \`npm run lint\` — 0 errors.
- [x] \`npm run build\` (frontend) — Vite bundles cleanly.
- [x] Manual: existing-submission case — both tracks render on map with checkmarks; comparison sidebar shows deltas; Submit produces matching server score; Cancel restores sidebar.
- [x] Manual: first-submission case — only preview track on map; left column placeholder.
- [x] Manual: pre-existing single-track view (clicking a pilot in leaderboard) — checkmarks render on tagged turnpoints.

## Known fast-follows (not in this PR)

- **Parity fixture test.** A test that runs the same synthesised IGC through the backend and frontend pipelines and asserts numerically identical output, guarding against any future bundler-induced drift. Skipped here because building the fixture is its own task; the 245 existing route tests already exercise \`runPipeline\` end-to-end.
- **Bundle size.** Vite reports the main chunk at ~1.57 MB (was ~700 KB). Easy code-split — load \`previewPipeline\` via dynamic \`import()\` so it doesn't ship in the first-paint chunk.