### PR TITLE
Fast-follows for client-side preview (#58)

### DIFF
--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -45,7 +45,8 @@ function formatTimeDelta(currS: number, prevS: number) {
   const formatted =
     h > 0 ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}` : `${m}:${String(s).padStart(2, '0')}`;
   const sign = d > 0 ? '+' : '−';
-  // Faster (negative delta) is better — green; slower is red.
+  // Faster (negative delta) is better — paints with var(--gold), the
+  // codebase's "good outcome" token. Slower is red (--danger).
   return { text: `${sign}${formatted}`, color: d < 0 ? 'var(--gold)' : 'var(--danger)' };
 }
 

--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -25,17 +25,28 @@ function fmtKm(km: number | null | undefined) {
   return `${km.toFixed(1)} km`;
 }
 
-function delta(
-  curr: number | null | undefined,
-  prev: number | null | undefined,
-  opts: { higherIsBetter?: boolean } = {},
-) {
+// Generic delta for "higher is better" metrics (distance, points). Time uses
+// the dedicated formatTimeDelta below — inverted polarity + units-aware text.
+function delta(curr: number | null | undefined, prev: number | null | undefined) {
   if (curr == null || prev == null) return null;
   const d = curr - prev;
   if (Math.abs(d) < 0.05) return null;
-  const better = (opts.higherIsBetter ?? true) ? d > 0 : d < 0;
   const sign = d > 0 ? '+' : '';
-  return { text: `${sign}${d.toFixed(1)}`, color: better ? 'var(--gold)' : 'var(--danger)' };
+  return { text: `${sign}${d.toFixed(1)}`, color: d > 0 ? 'var(--gold)' : 'var(--danger)' };
+}
+
+function formatTimeDelta(currS: number, prevS: number) {
+  const d = currS - prevS;
+  if (Math.abs(d) < 1) return null;
+  const abs = Math.floor(Math.abs(d));
+  const h = Math.floor(abs / 3600);
+  const m = Math.floor((abs % 3600) / 60);
+  const s = abs % 60;
+  const formatted =
+    h > 0 ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}` : `${m}:${String(s).padStart(2, '0')}`;
+  const sign = d > 0 ? '+' : '−';
+  // Faster (negative delta) is better — green; slower is red.
+  return { text: `${sign}${formatted}`, color: d < 0 ? 'var(--gold)' : 'var(--danger)' };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -266,6 +277,13 @@ function Column({
 
   const dDist = previousMetrics ? delta(metrics.distance, previousMetrics.distance) : null;
   const dTotal = previousMetrics ? delta(metrics.totalPoints, previousMetrics.totalPoints) : null;
+  // Task time is inverse: faster (lower) is better. Format the delta as a
+  // signed h:mm:ss / mm:ss so it sits next to the H:MM:SS readout sensibly
+  // (a "+45.0" raw-seconds delta next to "1:23:45" reads awkwardly).
+  const dTime =
+    previousMetrics && metrics.taskTimeS != null && previousMetrics.taskTimeS != null
+      ? formatTimeDelta(metrics.taskTimeS, previousMetrics.taskTimeS)
+      : null;
 
   return (
     <div style={{ padding: 10, border: `1px solid ${accent}55`, borderRadius: 6 }}>
@@ -287,7 +305,7 @@ function Column({
       <Row k="Time pts" v={fmtPts(metrics.timePoints)} />
       <Row k="Goal" v={metrics.reachedGoal ? '✓' : '✗'} />
       {metrics.turnpointsCrossed != null && <Row k="Turnpoints" v={String(metrics.turnpointsCrossed)} />}
-      <Row k="Task time" v={fmtTime(metrics.taskTimeS)} />
+      <Row k="Task time" v={fmtTime(metrics.taskTimeS)} delta={dTime} />
     </div>
   );
 }

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -69,7 +69,16 @@ const leaderboardEntries = [
 
 describe('previewSubmission parity — frontend wraps runPipeline against shared fixture', () => {
   it('parses, scores, and reaches goal with numbers identical to the backend snapshot', async () => {
-    const res = await previewSubmission(FIXTURE_INPUT.igcText, task, { competitionType: 'XC' }, leaderboardEntries);
+    // currentUserId='new-pilot' so we don't dedup against the prior finisher
+    // (different pilotId), keeping the leaderboard's goal time + total in the
+    // pool for the normalisation calc.
+    const res = await previewSubmission(
+      FIXTURE_INPUT.igcText,
+      task,
+      { competitionType: 'XC' },
+      leaderboardEntries,
+      'new-pilot',
+    );
 
     expect(res.ok).toBe(true);
     if (!res.ok) return;

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -1,0 +1,108 @@
+// =============================================================================
+// Pipeline parity — frontend half
+// =============================================================================
+//
+// Runs the shared fixture through previewSubmission (which wraps the same
+// runPipeline the backend uses) and asserts the same numbers the backend
+// parity test asserts in tests/pipeline-parity.test.ts.
+//
+// If Vite's CJS interop, esbuild's transpile, or any browser-vs-Node JS
+// quirk ever drifts the two runtime paths, both tests start diverging
+// against the same fixture — the failure points straight at the bundler.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import {
+  FIXTURE_INPUT,
+  FIXTURE_TASK_CLOSE_DATE,
+  FIXTURE_TASK_OPEN_DATE,
+  FIXTURE_TURNPOINTS,
+} from '../../../src/shared/pipeline-parity-fixture';
+import type { Task, Turnpoint } from '../api/tasks';
+import { previewSubmission } from './previewPipeline';
+
+// Adapt the pipeline-shaped fixture turnpoints to the frontend's API shape.
+// previewSubmission re-maps them via its own turnpointToDef, so this is the
+// inverse of that mapping and exercises the full client surface.
+const turnpoints: Turnpoint[] = FIXTURE_TURNPOINTS.map((tp) => ({
+  name: tp.id,
+  latitude: tp.lat,
+  longitude: tp.lng,
+  radiusM: tp.radiusM,
+  type: tp.type,
+  sequenceIndex: tp.sequenceIndex,
+  forceGround: tp.forceGround,
+  goalLineBearingDeg: tp.goalLineBearingDeg ?? null,
+}));
+
+const task: Task = {
+  id: FIXTURE_INPUT.task.id,
+  name: 'Parity Fixture',
+  description: null,
+  taskType: 'RACE_TO_GOAL',
+  status: 'published',
+  openDate: FIXTURE_TASK_OPEN_DATE,
+  closeDate: FIXTURE_TASK_CLOSE_DATE,
+  taskValue: null,
+  pilotCount: 0,
+  goalCount: 1,
+  turnpoints,
+};
+
+// Match FIXTURE_INPUT.existingGoalTimes ([120]) — previewSubmission derives
+// existingGoalTimes from leaderboard entries with reachedGoal && taskTimeS.
+const leaderboardEntries = [
+  {
+    rank: 1,
+    pilotName: 'Prior Finisher',
+    pilotId: 'prior',
+    submissionId: null,
+    distanceFlownKm: 3.65,
+    reachedGoal: true,
+    taskTimeS: 120,
+    distancePoints: 0,
+    timePoints: 0,
+    totalPoints: 0,
+    hasFlaggedCrossings: false,
+  },
+];
+
+describe('previewSubmission parity — frontend wraps runPipeline against shared fixture', () => {
+  it('parses, scores, and reaches goal with numbers identical to the backend snapshot', async () => {
+    const res = await previewSubmission(FIXTURE_INPUT.igcText, task, { competitionType: 'XC' }, leaderboardEntries);
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.value.flightDate).toBe('2026-01-23');
+
+    const best = res.value.attempts[res.value.bestAttemptIndex];
+    expect(best.reachedGoal).toBe(true);
+    expect(best.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+    expect(best.taskTimeS).not.toBeNull();
+
+    // Same parsing/distance/timing numbers as tests/pipeline-parity.test.ts.
+    // Divergence here = client and server scoring drift.
+    expect(best.distanceFlownKm).toBeCloseTo(3.65, 2);
+    expect(best.taskTimeS).toBeGreaterThan(0);
+
+    // previewSubmission also applies the same task-level normalisation that
+    // rebuildTaskResults runs server-side. Fixture setup:
+    //   - prior finisher: goal at 120 s → raw 1000 dist + 1000 time = 2000
+    //   - preview: goal at ~148 s → raw 1000 dist + 0 time = 1000
+    //   - winner raw = 2000 → scale = 1000 / 2000 = 0.5
+    //   - preview normalised: 500 dist + 0 time = 500
+    // If this assertion ever drifts, either the normalisation logic changed
+    // or the underlying scoring formulas did — both cases want a closer look
+    // because the backend's rebuildTaskResults would have followed suit.
+    expect(best.distancePoints).toBeCloseTo(500, 0);
+    expect(best.timePoints).toBeCloseTo(0, 0);
+    expect(best.totalPoints).toBeCloseTo(500, 0);
+
+    // Frontend-only: previewSubmission also surfaces fixes for the map. Each
+    // B record should produce one fix.
+    expect(res.value.fixes).toHaveLength(5);
+    expect(res.value.fixes[0].lat).toBeCloseTo(47.495, 3);
+    expect(res.value.fixes[4].lat).toBeCloseTo(47.54, 3);
+  });
+});

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -52,29 +52,49 @@ function turnpointToDef(tp: Turnpoint) {
  * Best" — leading to nonsense like "less distance = more points" when the
  * existing leaderboard has been heavily compressed.
  *
- * Approach: pool the preview alongside the existing leaderboard, recompute
- * raw dist + time points for everyone using the new bestDist and the new
+ * Approach: pool the preview alongside the existing leaderboard (excluding
+ * the current pilot's stale row — the preview replaces it), recompute raw
+ * dist + time points for everyone using the new bestDist and the new
  * goal-time pool, find the would-be winner's raw total, scale.
  */
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
 function normalizePreviewPoints(
   preview: ScoredAttempt,
   leaderboard: LeaderboardEntry[],
+  currentUserId: string | undefined,
   taskValue: number,
 ): { distancePoints: number; timePoints: number; totalPoints: number } {
+  // Drop the current pilot's existing leaderboard row — their preview replaces
+  // it as their best-attempt candidate. Keeping both would double-count this
+  // pilot in the goal-time pool (skewing tMin/tMax) and treat their old
+  // total as a separate "competitor" against themselves.
+  const others = currentUserId ? leaderboard.filter((e) => e.pilotId !== currentUserId) : leaderboard;
+
   // bestDist drives the non-goal distance points formula. Include the preview
   // — if it flew further than anyone else, it sets the new bestDist.
-  const bestDist = Math.max(preview.distanceFlownKm, ...leaderboard.map((e) => e.distanceFlownKm ?? 0), 0);
+  // Caveat: leaderboard.distanceFlownKm is each pilot's best-ATTEMPT distance,
+  // not their max across all attempts. In the (narrow) case where a pilot's
+  // non-best attempt flew further than their best attempt, the server's
+  // rebuildTaskResults would see a larger bestDist via MAX(distance_flown_km)
+  // over flight_attempts. The preview can't observe that without an extra API.
+  const bestDist = Math.max(preview.distanceFlownKm, ...others.map((e) => e.distanceFlownKm ?? 0), 0);
   // Time points use the global goal-time pool. Include the preview's time if
   // it reached goal.
   const allGoalTimes: number[] = [
-    ...leaderboard.filter((e) => e.reachedGoal && e.taskTimeS != null).map((e) => e.taskTimeS as number),
+    ...others.filter((e) => e.reachedGoal && e.taskTimeS != null).map((e) => e.taskTimeS as number),
     ...(preview.reachedGoal && preview.taskTimeS != null ? [preview.taskTimeS] : []),
   ];
 
+  // rebuildTaskResults rounds each total to 0.1 BEFORE picking the winner.
+  // Mirror that here so a floating-point ε doesn't shift the winner and
+  // therefore the global scale.
   const rawTotal = (d: number, reachedGoal: boolean, t: number | null) => {
     const dp = computeDistancePoints(d, bestDist > 0 ? bestDist : 1, reachedGoal);
     const tp = reachedGoal && t != null ? computeTimePoints(t, allGoalTimes) : 0;
-    return dp + tp;
+    return round1(dp + tp);
   };
 
   const previewRawDist = computeDistancePoints(
@@ -84,13 +104,13 @@ function normalizePreviewPoints(
   );
   const previewRawTime =
     preview.reachedGoal && preview.taskTimeS != null ? computeTimePoints(preview.taskTimeS, allGoalTimes) : 0;
-  const previewRawTotal = previewRawDist + previewRawTime;
+  const previewRawTotal = round1(previewRawDist + previewRawTime);
 
   // Winner total across (existing best per pilot) + (this preview). Same
   // formula rebuildTaskResults uses; we treat the preview as a candidate
   // attempt — if it wins, it becomes the basis for the new scale.
   let winnerRaw = previewRawTotal;
-  for (const e of leaderboard) {
+  for (const e of others) {
     const r = rawTotal(e.distanceFlownKm, e.reachedGoal, e.taskTimeS);
     if (r > winnerRaw) winnerRaw = r;
   }
@@ -100,12 +120,12 @@ function normalizePreviewPoints(
   }
 
   const scale = taskValue / winnerRaw;
-  const distancePoints = Math.round(previewRawDist * scale * 10) / 10;
-  const timePoints = Math.round(previewRawTime * scale * 10) / 10;
+  const distancePoints = round1(previewRawDist * scale);
+  const timePoints = round1(previewRawTime * scale);
   return {
     distancePoints,
     timePoints,
-    totalPoints: Math.round((distancePoints + timePoints) * 10) / 10,
+    totalPoints: round1(distancePoints + timePoints),
   };
 }
 
@@ -133,6 +153,7 @@ export async function previewSubmission(
   task: Task,
   season: Pick<Season, 'competitionType'>,
   leaderboardEntries: LeaderboardEntry[],
+  currentUserId: string | undefined,
 ): Promise<{ ok: true; value: PreviewResult } | { ok: false; error: PreviewError }> {
   // Parse once up front. runPipelineFromParsed reuses this so we don't pay the
   // ~50-200 ms parse cost twice on multi-hour 1-Hz tracks.
@@ -177,7 +198,12 @@ export async function previewSubmission(
   // scale as the leaderboard's "Previous Best" comparison shows.
   const bestIdx = result.value.bestAttemptIndex;
   const bestAttempt = result.value.scoredAttempts[bestIdx];
-  const normalized = normalizePreviewPoints(bestAttempt, leaderboardEntries, task.taskValue ?? MAX_POINTS);
+  const normalized = normalizePreviewPoints(
+    bestAttempt,
+    leaderboardEntries,
+    currentUserId,
+    task.taskValue ?? MAX_POINTS,
+  );
   const normalizedAttempts = result.value.scoredAttempts.map((a, i) => (i === bestIdx ? { ...a, ...normalized } : a));
 
   return {

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -1,12 +1,13 @@
 // Client-side IGC scoring preview.
 //
-// Reuses the backend pipeline (src/pipeline.ts) so the preview shown to the
-// pilot before they submit is the same code that the server runs after they
-// submit. The server remains authoritative — this is just so the pilot can
-// see what's going to happen first.
+// Reuses the backend pipeline (src/shared/pipeline.ts) so the preview shown
+// to the pilot before they submit is the same code that the server runs
+// after they submit. The server remains authoritative — this is just so
+// the pilot can see what's going to happen first.
 
-import type { ScoredAttempt } from '../../../src/shared/pipeline';
-import { parseAndValidate, runPipeline } from '../../../src/shared/pipeline';
+import type { PipelineError, ScoredAttempt } from '../../../src/shared/pipeline';
+import { parseAndValidate, runPipelineFromParsed } from '../../../src/shared/pipeline';
+import { computeDistancePoints, computeTimePoints, MAX_POINTS } from '../../../src/shared/task-engine';
 import type { Season } from '../api/leagues';
 import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
 import type { ReplayFix } from '../api/track';
@@ -19,7 +20,7 @@ export interface PreviewResult {
 }
 
 export interface PreviewError {
-  stage: string;
+  stage: PipelineError['stage'] | 'PREVIEW' | 'UPLOAD';
   code: string;
   message: string;
 }
@@ -41,18 +42,112 @@ function turnpointToDef(tp: Turnpoint) {
   };
 }
 
+/**
+ * Mirror the task-level normalisation that `rebuildTaskResults` runs server-
+ * side after every upload (src/job-queue.ts). The pipeline returns raw GAP
+ * points (max 1000 each for dist + time); the leaderboard shows those points
+ * rescaled so the winner's total equals the task's `normalized_score` (1000
+ * by default). Without applying the same scale here, the preview's "Total
+ * pts" would be on a different scale from the comparison panel's "Previous
+ * Best" — leading to nonsense like "less distance = more points" when the
+ * existing leaderboard has been heavily compressed.
+ *
+ * Approach: pool the preview alongside the existing leaderboard, recompute
+ * raw dist + time points for everyone using the new bestDist and the new
+ * goal-time pool, find the would-be winner's raw total, scale.
+ */
+function normalizePreviewPoints(
+  preview: ScoredAttempt,
+  leaderboard: LeaderboardEntry[],
+  taskValue: number,
+): { distancePoints: number; timePoints: number; totalPoints: number } {
+  // bestDist drives the non-goal distance points formula. Include the preview
+  // — if it flew further than anyone else, it sets the new bestDist.
+  const bestDist = Math.max(preview.distanceFlownKm, ...leaderboard.map((e) => e.distanceFlownKm ?? 0), 0);
+  // Time points use the global goal-time pool. Include the preview's time if
+  // it reached goal.
+  const allGoalTimes: number[] = [
+    ...leaderboard.filter((e) => e.reachedGoal && e.taskTimeS != null).map((e) => e.taskTimeS as number),
+    ...(preview.reachedGoal && preview.taskTimeS != null ? [preview.taskTimeS] : []),
+  ];
+
+  const rawTotal = (d: number, reachedGoal: boolean, t: number | null) => {
+    const dp = computeDistancePoints(d, bestDist > 0 ? bestDist : 1, reachedGoal);
+    const tp = reachedGoal && t != null ? computeTimePoints(t, allGoalTimes) : 0;
+    return dp + tp;
+  };
+
+  const previewRawDist = computeDistancePoints(
+    preview.distanceFlownKm,
+    bestDist > 0 ? bestDist : 1,
+    preview.reachedGoal,
+  );
+  const previewRawTime =
+    preview.reachedGoal && preview.taskTimeS != null ? computeTimePoints(preview.taskTimeS, allGoalTimes) : 0;
+  const previewRawTotal = previewRawDist + previewRawTime;
+
+  // Winner total across (existing best per pilot) + (this preview). Same
+  // formula rebuildTaskResults uses; we treat the preview as a candidate
+  // attempt — if it wins, it becomes the basis for the new scale.
+  let winnerRaw = previewRawTotal;
+  for (const e of leaderboard) {
+    const r = rawTotal(e.distanceFlownKm, e.reachedGoal, e.taskTimeS);
+    if (r > winnerRaw) winnerRaw = r;
+  }
+
+  if (winnerRaw <= 0) {
+    return { distancePoints: 0, timePoints: 0, totalPoints: 0 };
+  }
+
+  const scale = taskValue / winnerRaw;
+  const distancePoints = Math.round(previewRawDist * scale * 10) / 10;
+  const timePoints = Math.round(previewRawTime * scale * 10) / 10;
+  return {
+    distancePoints,
+    timePoints,
+    totalPoints: Math.round((distancePoints + timePoints) * 10) / 10,
+  };
+}
+
+// Discriminated narrow on PipelineError.stage so the compiler surfaces
+// breakage when a new stage is added or an existing stage's error shape
+// changes. The cast-through-any version this replaced was silently losing
+// DATE-stage details (DateValidationError has no `message` field).
+function describePipelineError(e: PipelineError): PreviewError {
+  switch (e.stage) {
+    case 'PARSE':
+      return { stage: 'PARSE', code: e.error.code, message: e.error.message };
+    case 'DATE':
+      return {
+        stage: 'DATE',
+        code: e.error.code,
+        message: `Flight date ${e.error.flightDate} is outside the task window ${e.error.taskOpen} – ${e.error.taskClose}.`,
+      };
+    case 'DETECTION':
+      return { stage: 'DETECTION', code: e.error.code, message: e.error.message };
+  }
+}
+
 export async function previewSubmission(
   igcText: string,
   task: Task,
   season: Pick<Season, 'competitionType'>,
   leaderboardEntries: LeaderboardEntry[],
 ): Promise<{ ok: true; value: PreviewResult } | { ok: false; error: PreviewError }> {
+  // Parse once up front. runPipelineFromParsed reuses this so we don't pay the
+  // ~50-200 ms parse cost twice on multi-hour 1-Hz tracks.
+  const parsed = parseAndValidate(igcText);
+  if (!parsed.ok) {
+    return { ok: false, error: { stage: 'PARSE', code: parsed.error.code, message: parsed.error.message } };
+  }
+
   const taskBestDistanceKm = leaderboardEntries.reduce((m, e) => Math.max(m, e.distanceFlownKm ?? 0), 0);
   const existingGoalTimes = leaderboardEntries
     .filter((e) => e.reachedGoal && e.taskTimeS != null)
     .map((e) => e.taskTimeS as number);
 
-  const result = await runPipeline(
+  const result = await runPipelineFromParsed(
+    parsed.value,
     {
       igcText,
       task: {
@@ -68,30 +163,28 @@ export async function previewSubmission(
   );
 
   if (!result.ok) {
-    const e = result.error;
-    return {
-      ok: false,
-      error: {
-        stage: e.stage,
-        // PipelineError shapes vary by stage — extract code/message where present
-        code: (e.error as { code?: string }).code ?? e.stage,
-        message: (e.error as { message?: string }).message ?? 'Preview failed',
-      },
-    };
+    return { ok: false, error: describePipelineError(result.error) };
   }
 
-  // Re-parse to surface the fix array for the map overlay. parseAndValidate is
-  // pure and idempotent so this is essentially free.
-  const parsed = parseAndValidate(igcText);
-  const fixes: ReplayFix[] = parsed.ok
-    ? parsed.value.fixes.map((f) => ({ t: f.timestamp, lat: f.lat, lng: f.lng, alt: f.gpsAlt }))
-    : [];
+  const fixes: ReplayFix[] = parsed.value.fixes.map((f) => ({
+    t: f.timestamp,
+    lat: f.lat,
+    lng: f.lng,
+    alt: f.gpsAlt,
+  }));
+
+  // Apply task-level normalisation so the preview's points land in the same
+  // scale as the leaderboard's "Previous Best" comparison shows.
+  const bestIdx = result.value.bestAttemptIndex;
+  const bestAttempt = result.value.scoredAttempts[bestIdx];
+  const normalized = normalizePreviewPoints(bestAttempt, leaderboardEntries, task.taskValue ?? MAX_POINTS);
+  const normalizedAttempts = result.value.scoredAttempts.map((a, i) => (i === bestIdx ? { ...a, ...normalized } : a));
 
   return {
     ok: true,
     value: {
-      attempts: result.value.scoredAttempts,
-      bestAttemptIndex: result.value.bestAttemptIndex,
+      attempts: normalizedAttempts,
+      bestAttemptIndex: bestIdx,
       flightDate: result.value.flightDate,
       fixes,
     },

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -373,6 +373,8 @@ export default function HomePage() {
   seasonRef.current = season;
   const activeEntriesRef = useRef(activeEntries);
   activeEntriesRef.current = activeEntries;
+  const userIdRef = useRef(user?.id);
+  userIdRef.current = user?.id;
 
   // Run the local preview pipeline whenever a new file is picked.
   useEffect(() => {
@@ -388,7 +390,13 @@ export default function HomePage() {
       try {
         const [{ previewSubmission }, text] = await Promise.all([import('../lib/previewPipeline'), previewFile.text()]);
         if (cancelled) return;
-        const res = await previewSubmission(text, task, { competitionType: seasonNow.competitionType }, entries);
+        const res = await previewSubmission(
+          text,
+          task,
+          { competitionType: seasonNow.competitionType },
+          entries,
+          userIdRef.current,
+        );
         if (cancelled) return;
         if (res.ok) setPreviewResult(res.value);
         else setPreviewError(res.error);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -23,7 +23,10 @@ import UploadZone from '../components/UploadZone';
 import { useAuth } from '../hooks/useAuth';
 import { useLeague } from '../hooks/useLeague';
 import { useSeasons } from '../hooks/useStandings';
-import { type PreviewError, type PreviewResult, previewSubmission } from '../lib/previewPipeline';
+// previewPipeline is imported dynamically inside the file-picked effect below
+// so the pipeline + igc-parser don't ship to first-paint. Types stay static
+// (erased at build time, no runtime cost).
+import type { PreviewError, PreviewResult } from '../lib/previewPipeline';
 import { markdownRemarkPlugins, markdownSanitizeSchema } from '../utils/markdown';
 import { getTaskStatus, STATUS_STYLE } from '../utils/taskStatus';
 
@@ -383,7 +386,8 @@ export default function HomePage() {
     setPreviewError(null);
     (async () => {
       try {
-        const text = await previewFile.text();
+        const [{ previewSubmission }, text] = await Promise.all([import('../lib/previewPipeline'), previewFile.text()]);
+        if (cancelled) return;
         const res = await previewSubmission(text, task, { competitionType: seasonNow.competitionType }, entries);
         if (cancelled) return;
         if (res.ok) setPreviewResult(res.value);

--- a/src/shared/pipeline-parity-fixture.ts
+++ b/src/shared/pipeline-parity-fixture.ts
@@ -34,8 +34,9 @@ import type { PipelineInput, TurnpointDef } from './pipeline';
 //   • Fix at 47.520 is INSIDE TP1 (47.52, r=400m).
 //   • Fix at 47.540 is INSIDE GOAL (47.54, r=400m).
 //
-// → SSS crossing between fixes 0 and 2, TP1 crossing between 2 and 3,
-//   GOAL crossing between 3 and 4. Pilot reaches goal.
+// → Stage 3 detects an outward SSS crossing (inside→outside) between
+//   fixes 1 and 2, a TP1 crossing between fixes 2 and 3, and a GOAL
+//   crossing between fixes 3 and 4. Pilot reaches goal.
 
 export const FIXTURE_IGC = [
   'AXLK00001',

--- a/src/shared/pipeline-parity-fixture.ts
+++ b/src/shared/pipeline-parity-fixture.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// Pipeline parity fixture
+// =============================================================================
+//
+// A synthetic IGC + task pair that exercises parse, date validation, attempt
+// detection, distance calculation, and scoring. Imported by BOTH the backend
+// vitest suite (tests/pipeline-parity.test.ts) and the frontend vitest suite
+// (frontend/src/lib/previewPipeline.test.ts).
+//
+// The point of the parity test: same code path on both sides should produce
+// numerically identical output. If Vite's bundling, esbuild's transpile, or
+// igc-parser's interop ever drift between Node and browser, this catches it.
+//
+// Pure module — no Node or DOM globals. Safe to import from either side.
+// =============================================================================
+
+import type { PipelineInput, TurnpointDef } from './pipeline';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Synthetic IGC — 5 fixes traveling due north along -122°, one per minute.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Lat coords in IGC's DDMMmmm format (degrees + minutes×1000):
+//   47.495° → 47°29.700′ → 4729700
+//   47.500° → 47°30.000′ → 4730000
+//   47.510° → 47°30.600′ → 4730600
+//   47.520° → 47°31.200′ → 4731200
+//   47.540° → 47°32.400′ → 4732400
+//
+// Geometry:
+//   • Fix at 47.495 is south of and OUTSIDE SSS (47.50, r=400m).
+//   • Fix at 47.500 is INSIDE SSS (at its centre).
+//   • Fix at 47.510 is OUTSIDE SSS, between SSS and TP1.
+//   • Fix at 47.520 is INSIDE TP1 (47.52, r=400m).
+//   • Fix at 47.540 is INSIDE GOAL (47.54, r=400m).
+//
+// → SSS crossing between fixes 0 and 2, TP1 crossing between 2 and 3,
+//   GOAL crossing between 3 and 4. Pilot reaches goal.
+
+export const FIXTURE_IGC = [
+  'AXLK00001',
+  'HFDTE230126', // Flight date 2026-01-23
+  'B1000004729700N12200000WA0050000500',
+  'B1001004730000N12200000WA0050000500',
+  'B1002004730600N12200000WA0050000500',
+  'B1003004731200N12200000WA0050000500',
+  'B1004004732400N12200000WA0050000500',
+].join('\n');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task: 3 turnpoints in a straight line going north.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const FIXTURE_TURNPOINTS: TurnpointDef[] = [
+  { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+  { id: 'tp1', sequenceIndex: 1, lat: 47.52, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+  { id: 'goal', sequenceIndex: 2, lat: 47.54, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+];
+
+export const FIXTURE_INPUT: PipelineInput = {
+  igcText: FIXTURE_IGC,
+  task: { id: 'fixture-task', turnpoints: FIXTURE_TURNPOINTS },
+  existingGoalTimes: [120], // one prior finisher in 2 minutes — gives this attempt provisional time points
+  competitionType: 'XC',
+};
+
+export const FIXTURE_TASK_OPEN_DATE = '2026-01-01';
+export const FIXTURE_TASK_CLOSE_DATE = '2026-01-31';
+export const FIXTURE_TASK_BEST_DISTANCE_KM = 4.4; // roughly the task length

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -1004,11 +1004,25 @@ export async function runPipeline(
   taskCloseDate: string,
   taskBestDistanceKm: number,
 ): Promise<Result<PipelineResult, PipelineError>> {
-  // Stage 1: Parse
   const parseResult = parseAndValidate(input.igcText);
   if (!parseResult.ok) return err({ stage: 'PARSE', error: parseResult.error });
-  const track = parseResult.value;
+  return runPipelineFromParsed(parseResult.value, input, taskOpenDate, taskCloseDate, taskBestDistanceKm);
+}
 
+/**
+ * Run stages 2-7 against an already-parsed track. Use this when the caller
+ * already has a `ParsedTrack` in hand and would otherwise pay the IGC parse
+ * cost a second time. The client-side preview is the only current caller —
+ * it needs the parsed `fixes` for the map overlay AND the scored result,
+ * and parsing a 1-Hz multi-hour track twice dominates preview latency.
+ */
+export async function runPipelineFromParsed(
+  track: ParsedTrack,
+  input: PipelineInput,
+  taskOpenDate: string,
+  taskCloseDate: string,
+  taskBestDistanceKm: number,
+): Promise<Result<PipelineResult, PipelineError>> {
   // Stage 2: Date validation
   const dateResult = validateFlightDate(track, taskOpenDate, taskCloseDate);
   if (!dateResult.ok) return err({ stage: 'DATE', error: dateResult.error });

--- a/tests/pipeline-parity.test.ts
+++ b/tests/pipeline-parity.test.ts
@@ -2,12 +2,14 @@
 // Pipeline parity — backend half
 // =============================================================================
 //
-// Runs the shared fixture through runPipeline on the Node side and snapshots
-// the numeric output. The frontend half (frontend/src/lib/previewPipeline.test.ts)
-// runs the same fixture through previewSubmission (which wraps runPipeline)
-// and asserts identical numbers. If Vite, esbuild, or igc-parser ever drift
-// between the two runtime paths, both tests will diverge in lockstep — the
-// failure points straight at the bundler.
+// Runs the shared fixture through runPipeline on the Node side and asserts
+// the raw pipeline output (distance ≈ 3.65 km, reaches goal, expected
+// turnpoint sequence). The frontend half (frontend/src/lib/previewPipeline.test.ts)
+// runs the same fixture through previewSubmission (which adds task-level
+// normalisation on top) and locks down the post-normalisation numbers. Together
+// the two tests guard the path from IGC bytes → leaderboard-scale points; if
+// Vite, esbuild, or igc-parser ever drift between Node and the browser, both
+// tests diverge in lockstep — the failure points straight at the bundler.
 // =============================================================================
 
 import { describe, expect, it } from 'vitest';

--- a/tests/pipeline-parity.test.ts
+++ b/tests/pipeline-parity.test.ts
@@ -1,0 +1,50 @@
+// =============================================================================
+// Pipeline parity — backend half
+// =============================================================================
+//
+// Runs the shared fixture through runPipeline on the Node side and snapshots
+// the numeric output. The frontend half (frontend/src/lib/previewPipeline.test.ts)
+// runs the same fixture through previewSubmission (which wraps runPipeline)
+// and asserts identical numbers. If Vite, esbuild, or igc-parser ever drift
+// between the two runtime paths, both tests will diverge in lockstep — the
+// failure points straight at the bundler.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../src/shared/pipeline';
+import {
+  FIXTURE_INPUT,
+  FIXTURE_TASK_BEST_DISTANCE_KM,
+  FIXTURE_TASK_CLOSE_DATE,
+  FIXTURE_TASK_OPEN_DATE,
+} from '../src/shared/pipeline-parity-fixture';
+
+describe('pipeline parity — backend runPipeline against shared fixture', () => {
+  it('parses, scores, and reaches goal with deterministic numbers', async () => {
+    const result = await runPipeline(
+      FIXTURE_INPUT,
+      FIXTURE_TASK_OPEN_DATE,
+      FIXTURE_TASK_CLOSE_DATE,
+      FIXTURE_TASK_BEST_DISTANCE_KM,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.flightDate).toBe('2026-01-23');
+
+    const best = result.value.scoredAttempts[result.value.bestAttemptIndex];
+    expect(best.reachedGoal).toBe(true);
+    expect(best.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+    expect(best.taskTimeS).not.toBeNull();
+
+    // Snapshot the numeric outputs that previewSubmission also reports. The
+    // frontend test asserts these same numbers — divergence = bundler drift.
+    // 3.65 km = optimised cylinder-to-cylinder path: 4.45 km centre-to-centre
+    // (SSS at 47.50, GOAL at 47.54) minus one 400 m radius off each end.
+    expect(best.distanceFlownKm).toBeCloseTo(3.65, 2);
+    expect(best.distancePoints).toBeGreaterThan(0);
+    expect(best.totalPoints).toBeGreaterThan(0);
+    expect(best.taskTimeS).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #58.

Six follow-ups from the PR #57 review pass, plus one bug surfaced after the merge.

## Fixes the user-reported bug

**Normalised preview points to match the leaderboard scale.** Post-merge feedback: a 3.4 km preview was showing +138 pts vs a 6.3 km previous best. The pipeline returns raw GAP points (max 1000 each for dist + time); the leaderboard displays the same points after \`rebuildTaskResults\` rescales them so the winner's total equals \`normalized_score\` (default 1000). On a task with a strong leader the leaderboard scale is heavily compressed, and the raw preview numbers floated above the compressed comparison. \`normalizePreviewPoints\` now mirrors the server's scaling client-side: pools the preview alongside the leaderboard, recomputes raw points using the new \`bestDist\` and goal-time pool, finds the would-be winner's raw total, scales. Preview points now land in the same scale as the panel's "Previous Best".

## Other fast-follows from issue #58

- **Eliminated double-parse.** Extracted \`runPipelineFromParsed(track, …)\` from \`runPipeline\`. \`previewPipeline\` parses once, runs stages 2-7 against the same parsed track, and reads fixes off it directly — no more re-parse for the map overlay. \`runPipeline\` is a thin wrapper for the server callers, signature unchanged.
- **Code-split previewPipeline.** Switched the static import in HomePage to a dynamic \`import('../lib/previewPipeline')\` inside the file-picked effect. Pipeline + igc-parser (~22 KB) now ship as a lazy chunk loaded only when a pilot picks a file. Types stay static (erased at build time).
- **Wired delta polarity for Task time.** Dedicated \`formatTimeDelta\` formats the diff as signed H:MM:SS / MM:SS instead of raw seconds, inverts polarity so faster = green / slower = red, uses unicode minus for visual differentiation. Dropped the unused \`higherIsBetter\` option on the generic \`delta\`.
- **Discriminated-union narrow on PipelineError.** The old \`(e.error as { … }).code ?? …\` cast was silently degrading DATE-stage errors to just the stage label (DateValidationError has no \`message\`). Replaced with a typed \`switch\` on \`e.stage\` that builds a real DATE message from \`flightDate / taskOpen / taskClose\`. Compile errors now surface if any stage adds or renames a field.

## Parity fixture test

\`src/shared/pipeline-parity-fixture.ts\` exports a synthesised 5-fix IGC (due-north through SSS → TP1 → GOAL) and the matching task. Imported by both:
- **Backend** (\`tests/pipeline-parity.test.ts\`) — asserts \`runPipeline\` produces the expected geometric outputs (distance ≈ 3.65 km, reaches goal, correct turnpoint sequence).
- **Frontend** (\`frontend/src/lib/previewPipeline.test.ts\`) — asserts \`previewSubmission\` produces the same underlying numbers AND that normalisation scales them correctly (with a configured prior finisher at 120 s, preview at ~148 s gives ~500 dist pts + ~0 time pts = ~500 total).

If Vite's CJS interop, esbuild's transpile, or any Node-vs-browser quirk ever drifts the two runtime paths, both tests diverge in lockstep — the failure points at the bundler instead of at the scoring code.

## Test plan

- [x] \`npx vitest run\` (root) — 246/246 ✓ (245 prior + 1 new parity test)
- [x] frontend \`npx vitest run\` — 30/30 ✓ (29 prior + 1 new parity test)
- [x] \`npm run typecheck\` — clean on both \`tsconfig.server.json\` and frontend
- [x] \`npm run lint\` — 0 errors
- [x] Frontend \`npm run build\` — main chunk 1,554 KB (vs 1,574 KB pre-split) + 21.82 KB lazy \`previewPipeline\` chunk