### PR TITLE
fix(deploy): install root deps in docker client-builder so tsc resolves igc-parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,24 @@ FROM node:20-alpine AS client-builder
 ARG VITE_MAPTILER_KEY
 ARG VITE_OPENAIP_KEY
 
+# Root deps install at /build first. The frontend bundle reaches into
+# src/shared/ (pipeline.ts, task-engine.ts) for shared scoring code, and
+# pipeline.ts imports `igc-parser`. tsc/vite resolve that module via Node's
+# parent-directory walk from the importing file's location — pipeline.ts at
+# /build/src/shared/pipeline.ts must see node_modules at /build, not just
+# /build/frontend (a sibling, not an ancestor). --ignore-scripts skips
+# better-sqlite3's native build, which isn't needed for the frontend bundle.
+WORKDIR /build
+COPY package*.json ./
+RUN npm ci --ignore-scripts
+
 WORKDIR /build/frontend
 
 COPY frontend/package*.json ./
 RUN npm ci
 
 COPY frontend/ ./
-# Shared code imported by frontend components via relative path
+# Shared code imported by frontend components via relative path.
 COPY src/shared/ ../src/shared/
 
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,13 @@ ARG VITE_OPENAIP_KEY
 # pipeline.ts imports `igc-parser`. tsc/vite resolve that module via Node's
 # parent-directory walk from the importing file's location — pipeline.ts at
 # /build/src/shared/pipeline.ts must see node_modules at /build, not just
-# /build/frontend (a sibling, not an ancestor). --ignore-scripts skips
-# better-sqlite3's native build, which isn't needed for the frontend bundle.
+# /build/frontend (a sibling, not an ancestor). --omit=dev keeps the layer
+# small (skips server-only vitest/biome/tsx/etc); igc-parser is a regular
+# dep so it lands. --ignore-scripts skips better-sqlite3's native build,
+# which isn't needed for the frontend bundle.
 WORKDIR /build
 COPY package*.json ./
-RUN npm ci --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts
 
 WORKDIR /build/frontend
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,6 @@
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/ui": "^4.1.0",
-        "igc-parser": "^2.0.0",
         "jsdom": "^28.1.0",
         "typescript": "^5.3.3",
         "vite": "^5.1.4",
@@ -2819,16 +2818,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/flight-recorder-manufacturers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flight-recorder-manufacturers/-/flight-recorder-manufacturers-2.0.0.tgz",
-      "integrity": "sha512-FhSY7XslPkhYGdBBVRLLExoKqiLWbKuxPEx3O3a443hp8VOrcvE+ibibigVplQbaNipVG3pSPTZPTFJPIfcO8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2964,19 +2953,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/igc-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/igc-parser/-/igc-parser-2.0.0.tgz",
-      "integrity": "sha512-bsJZjPaZRmT8ElFvNgsn5p5rNV6KLilQaRt4fvspufvHeHoeAWpZqsm2UBlwxTnapxnYmhRwaCazZELY4H01BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flight-recorder-manufacturers": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/indent-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/ui": "^4.1.0",
-    "igc-parser": "^2.0.0",
     "jsdom": "^28.1.0",
     "typescript": "^5.3.3",
     "vite": "^5.1.4",


### PR DESCRIPTION
Second attempt at the deploy fix. PR #60's approach (adding \`igc-parser\` to \`frontend/package.json\`) wasn't enough — Deploy still fails with:

\`\`\`
../src/shared/pipeline.ts(9,23): error TS2307: Cannot find module 'igc-parser' or its corresponding type declarations.
\`\`\`

## Why #60 wasn't enough

When tsc (and vite) follow \`import IGCParser from 'igc-parser'\` from \`pipeline.ts\`, they walk Node's module-resolution chain from the **importing file's directory**. \`pipeline.ts\` now lives at \`/build/src/shared/pipeline.ts\` in the docker stage, so the walk is:

\`\`\`
/build/src/shared/node_modules → /build/src/node_modules
→ /build/node_modules → /node_modules
\`\`\`

Adding the dep to \`frontend/package.json\` put \`igc-parser\` at \`/build/frontend/node_modules\` — a **sibling** of \`/build/src\`, not an ancestor. tsc never sees it.

Locally the build works only because the repo root has a \`node_modules/\` at \`/Users/.../xc-league/node_modules\` that IS reachable as an ancestor of \`src/shared/pipeline.ts\`. So the symptom is invisible outside of the docker stage.

## Fix

Add the root \`npm ci\` to the client-builder stage **before** the frontend install. That puts \`igc-parser\` at \`/build/node_modules\`, reachable from \`/build/src/shared/pipeline.ts\` exactly like the local repo layout. \`--ignore-scripts\` skips \`better-sqlite3\`'s native build, which isn't needed for the frontend bundle.

Dropped the redundant \`igc-parser\` entry from \`frontend/package.json\` now that the root install is the canonical source. Future shared deps imported by \`src/shared\` code follow the same pattern automatically — no per-dep maintenance.

## Test plan

- [x] Local \`frontend npm run build\` — green (unchanged from baseline)
- [x] \`npm run typecheck\` — clean
- [x] \`npx vitest run\` — 245/245 ✓
- [ ] CI \`Deploy\` job goes green on merge — the actual verification (local docker build is glacially slow on colima; not blocking on it given the analysis is concrete)

## Followup needed on #59

PR #59 already rebased onto post-#60 main. After this merges to main, #59 doesn't need another rebase — the only file overlap with this PR is \`Dockerfile\` (which #59 doesn't touch) and \`frontend/package.json\` (which #59 also doesn't touch).