### PR TITLE
Implement FAI §9.3 flown distance for non-goal pilots

### DIFF
--- a/src/shared/pipeline.test.ts
+++ b/src/shared/pipeline.test.ts
@@ -193,6 +193,6 @@ describe('tagToleranceM', () => {
 describe('SCORER_VERSION', () => {
   it('is set so the boot reprocess loop has a concrete current value to compare', () => {
     // If you bump the version intentionally, update this expectation.
-    expect(SCORER_VERSION).toBe('1.1');
+    expect(SCORER_VERSION).toBe('1.2');
   });
 });

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -25,7 +25,7 @@ import {
 // whose stored flight_attempts.scorer_version differs from this constant.
 // =============================================================================
 
-export const SCORER_VERSION = '1.1';
+export const SCORER_VERSION = '1.2';
 
 // Re-export so existing `import { tagToleranceM } from './shared/pipeline'`
 // paths keep working. The canonical helper lives in `./task-engine`.
@@ -865,9 +865,18 @@ export function calculateDistances(attempts: AttemptTrace[], fixes: Fix[], task:
     }
 
     const sssTime = attempt.sssCrossing.crossingTime;
-    const pilotFixes = fixes.filter((f) => f.timestamp >= sssTime).map((f) => ({ lat: f.lat, lng: f.lng }));
+    const pilotFixes = fixes
+      .filter((f) => f.timestamp >= sssTime)
+      .map((f) => ({ lat: f.lat, lng: f.lng, timestamp: f.timestamp }));
 
-    const dist = computePartialDistanceKm(route, cylinders, attempt.lastTurnpointIndex, pilotFixes);
+    // FAI §9.3: feed the ordered (sequenceIndex, crossingTime) pairs so the
+    // distance routine can advance reachedIdx fix-by-fix.
+    const crossings = attempt.turnpointCrossings.map((c) => ({
+      sequenceIndex: c.sequenceIndex,
+      crossingTime: c.crossingTime,
+    }));
+
+    const dist = computePartialDistanceKm(route, cylinders, crossings, pilotFixes);
     return { ...attempt, distanceFlownKm: dist };
   });
 }

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -245,42 +245,79 @@ export function computeDistanceKm(cylinders: Cylinder[]): number {
 }
 
 // =============================================================================
-// PARTIAL DISTANCE  (non-goal pilots)
-// Compute best achieved distance along the optimal route for a pilot who
-// did not reach goal, given their GPS track from the SSS crossing onward.
+// FLOWN DISTANCE  (non-goal pilots) — FAI Sporting Code §9.3
+//
+// §9.3: "we determine for each point where the pilot is still flying the
+//  remaining distance to goal from that point, considering any previously
+//  reached control zones. For this the same method is used as for calculating
+//  the task distance. Then we calculate the flight distance as the task
+//  distance minus the smallest of those remaining distances."
+//
+// Algorithm: at every post-SSS fix, build the *remaining task* as
+//   [fix-as-0-radius-cylinder, ...cylinders after the last reached one],
+// run the route optimiser on it, and remember the smallest remaining
+// distance seen. The pilot's flown distance is taskDistance minus that
+// minimum.
+//
+// This supersedes the previous "project the fix onto the next leg's
+// direction vector and clamp to legLen" approximation, which (a) hid all
+// extra progress past an un-tagged next TP, and (b) over-credited tracks
+// that drifted laterally off-line.
+//
+// The `crossings` argument carries the (sequenceIndex, crossingTime) pairs
+// in time order, so the loop can keep `reachedIdx` in sync with each fix's
+// timestamp in a single O(N) sweep.
 // =============================================================================
 
 export function computePartialDistanceKm(
   route: OptimisedRoute,
   cylinders: Cylinder[],
-  lastTpIdx: number, // index of last TP achieved (0 = only SSS crossed)
-  pilotFixes: Array<{ lat: number; lng: number }>,
+  crossings: Array<{ sequenceIndex: number; crossingTime: number }>,
+  pilotFixes: Array<{ lat: number; lng: number; timestamp: number }>,
 ): number {
+  if (pilotFixes.length === 0) return 0;
   const n = cylinders.length;
+  if (n < 2) return 0;
 
-  const completedKm = route.legDistancesKm.slice(0, lastTpIdx).reduce((s, d) => s + d, 0);
+  const taskKm = route.totalDistanceKm;
 
-  if (lastTpIdx >= n - 1) return route.totalDistanceKm;
+  // Walk crossings alongside the fix stream so reachedIdx tracks how many
+  // cylinders the pilot has tagged by each fix's timestamp.
+  let crossingPtr = 0;
+  let reachedIdx = -1;
+  let minRemainingKm = taskKm;
 
-  // Project into local flat space
-  const oLat = cylinders.reduce((s, c) => s + c.lat, 0) / n;
-  const oLng = cylinders.reduce((s, c) => s + c.lng, 0) / n;
+  for (const f of pilotFixes) {
+    while (crossingPtr < crossings.length && crossings[crossingPtr].crossingTime <= f.timestamp) {
+      const idx = crossings[crossingPtr].sequenceIndex;
+      if (idx > reachedIdx) reachedIdx = idx;
+      crossingPtr++;
+    }
 
-  const lastLocal = project(route.touchPoints[lastTpIdx].lat, route.touchPoints[lastTpIdx].lng, oLat, oLng);
-  const nextLocal = project(route.touchPoints[lastTpIdx + 1].lat, route.touchPoints[lastTpIdx + 1].lng, oLat, oLng);
+    // Goal-tagged attempts are handled by calculateDistances (it short-circuits
+    // to the full route distance), but guard here too.
+    if (reachedIdx >= n - 1) {
+      minRemainingKm = 0;
+      break;
+    }
 
-  const legDir = normalise(sub(nextLocal, lastLocal));
-  const legLenM = route.legDistancesKm[lastTpIdx] * 1000;
+    // Remaining task: pilot's current point as a 0-radius "cylinder" anchor,
+    // followed by every cylinder the pilot has not yet tagged (including
+    // GOAL). Run the same route optimiser used for the task itself.
+    const start: Cylinder = { lat: f.lat, lng: f.lng, radiusM: 0, type: 'CYLINDER' };
+    const remaining: Cylinder[] = [start, ...cylinders.slice(reachedIdx + 1)];
 
-  let bestM = 0;
-  for (const fix of pilotFixes) {
-    const fixLocal = project(fix.lat, fix.lng, oLat, oLng);
-    const dot = (fixLocal.x - lastLocal.x) * legDir.x + (fixLocal.y - lastLocal.y) * legDir.y;
-    const clamped = Math.max(0, Math.min(legLenM, dot));
-    if (clamped > bestM) bestM = clamped;
+    let remDistKm: number;
+    try {
+      remDistKm = optimiseRoute(remaining).totalDistanceKm;
+    } catch {
+      continue;
+    }
+
+    if (remDistKm < minRemainingKm) minRemainingKm = remDistKm;
   }
 
-  return completedKm + bestM / 1000;
+  return Math.max(0, taskKm - minRemainingKm);
 }
 
 // =============================================================================

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -301,6 +301,21 @@ export function computePartialDistanceKm(
       break;
     }
 
+    // Defensive: when only GOAL remains and the fix is geographically inside
+    // the goal cylinder, the pilot has effectively reached goal. Normally the
+    // detector tags this directly (reachedGoal=true → handled upstream) but
+    // if a missed goal tag leaks through, the 2-cylinder optimiseRoute would
+    // route from the 0-radius anchor to the goal-boundary touch point on the
+    // near side and report a small positive remaining distance — under-
+    // crediting the pilot. Treat this case as 0 remaining explicitly.
+    if (reachedIdx === n - 2) {
+      const goal = cylinders[n - 1];
+      if (haversineKm(f.lat, f.lng, goal.lat, goal.lng) * 1000 <= goal.radiusM) {
+        minRemainingKm = 0;
+        break;
+      }
+    }
+
     // Remaining task: pilot's current point as a 0-radius "cylinder" anchor,
     // followed by every cylinder the pilot has not yet tagged (including
     // GOAL). Run the same route optimiser used for the task itself.

--- a/tests/partial-distance.test.ts
+++ b/tests/partial-distance.test.ts
@@ -98,6 +98,27 @@ describe('computePartialDistanceKm — anchor points on the optimised line', () 
     const d = computePartialDistanceKm(ROUTE, TASK, crossings, fixes);
     expect(d).toBeCloseTo(TASK_KM, 1);
   });
+
+  it('pilot has a fix inside GOAL cylinder without a tagged goal crossing → full task distance', () => {
+    // Edge case: detector somehow didn't tag goal (e.g. validity filter
+    // dropped the entry segment) but the pilot has a fix geographically
+    // inside the goal cylinder. Without the defensive guard, the 2-cylinder
+    // optimiseRoute([fix-0r, goal]) routes to the near-side boundary and
+    // returns a positive remaining distance, under-crediting the pilot.
+    const crossings = [
+      { sequenceIndex: 0, crossingTime: 0 },
+      { sequenceIndex: 1, crossingTime: 100_000 },
+      { sequenceIndex: 2, crossingTime: 200_000 },
+    ];
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.7, -122.0, 200_000),
+      fix(47.8, -122.0, 300_000), // GOAL centre — inside the cylinder
+    ];
+    const d = computePartialDistanceKm(ROUTE, TASK, crossings, fixes);
+    expect(d).toBeCloseTo(TASK_KM, 1);
+  });
 });
 
 // ── The bug: tracks that diverge laterally must get DIFFERENT distances ─────

--- a/tests/partial-distance.test.ts
+++ b/tests/partial-distance.test.ts
@@ -1,0 +1,169 @@
+// =============================================================================
+// computePartialDistanceKm — FAI Sporting Code §9.3 (Flown distance)
+//
+// §9.3: "we determine for each point where the pilot is still flying the
+// remaining distance to goal from that point, considering any previously
+// reached control zones … Then we calculate the flight distance as the task
+// distance minus the smallest of those remaining distances."
+//
+// These tests pin the behaviour the spec demands. The pre-fix implementation
+// projected fixes onto a single next-leg direction vector and clamped to
+// legLen — which (a) silently capped credit at the next TP for pilots who
+// flew past without tagging it, (b) ignored perpendicular excursions and so
+// gave identical scores to laterally-divergent tracks with the same axial
+// progress. The §9.3 algorithm — re-run the route optimiser from each fix
+// through the unreached cylinders — fixes both.
+// =============================================================================
+import { describe, expect, it } from 'vitest';
+import { type Cylinder, computePartialDistanceKm, optimiseRoute } from '../src/shared/task-engine';
+
+// ── Shared task geometry ────────────────────────────────────────────────────
+// Four collinear cylinders along the −122° meridian, 0.1° (≈ 11.12 km) apart,
+// each 400 m radius. The chord SSS_centre → GOAL_centre passes through every
+// cylinder, so the optimised route walks the meridian touching SSS's north
+// boundary, both interior centres, and GOAL's south boundary.
+
+const TASK: Cylinder[] = [
+  { lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+  { lat: 47.6, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+  { lat: 47.7, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+  { lat: 47.8, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+];
+
+const ROUTE = optimiseRoute(TASK);
+const TASK_KM = ROUTE.totalDistanceKm;
+
+// Crossings: SSS at t=0, TP1 at t=100_000 ms.
+const CROSS_SSS_TP1 = [
+  { sequenceIndex: 0, crossingTime: 0 },
+  { sequenceIndex: 1, crossingTime: 100_000 },
+];
+
+function fix(lat: number, lng: number, tMs: number) {
+  return { lat, lng, timestamp: tMs };
+}
+
+// ── Sanity ──────────────────────────────────────────────────────────────────
+
+describe('computePartialDistanceKm — sanity', () => {
+  it('returns 0 for an empty fix list', () => {
+    expect(computePartialDistanceKm(ROUTE, TASK, [], [])).toBe(0);
+  });
+
+  it('task distance is approximately 32.56 km (anchors the absolute scale)', () => {
+    // 0.1°(lat) × 111.194 km/° × 3 legs − 2×400 m (SSS + GOAL boundary offsets)
+    // = 33.358 − 0.800 = 32.558 km
+    expect(TASK_KM).toBeCloseTo(32.558, 2);
+  });
+});
+
+// ── Anchoring behaviour: each fix maps to an expected distance ──────────────
+
+describe('computePartialDistanceKm — anchor points on the optimised line', () => {
+  it('pilot stationary at SSS exit gets ~0 km credit', () => {
+    const fixes = [fix(47.503596, -122.0, 0)]; // SSS boundary north
+    const d = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1.slice(0, 1), fixes);
+    expect(d).toBeCloseTo(0, 1);
+  });
+
+  it('pilot tagged TP1 and stopped there gets ~SSS→TP1 leg distance (≈ 10.72 km)', () => {
+    const fixes = [fix(47.503596, -122.0, 0), fix(47.6, -122.0, 100_000)];
+    const d = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1, fixes);
+    expect(d).toBeCloseTo(10.72, 1);
+  });
+
+  it('pilot tagged TP1 and landed halfway to TP2 gets ~SSS→TP1 + half leg (≈ 16.28 km)', () => {
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.65, -122.0, 200_000), // 5.56 km past TP1 along the leg
+    ];
+    const d = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1, fixes);
+    expect(d).toBeCloseTo(16.28, 1);
+  });
+
+  it('pilot drifted onto GOAL boundary without entering gets ~full task distance', () => {
+    // Pilot tagged SSS, TP1, TP2; landed on the south face of the goal cylinder.
+    const crossings = [
+      { sequenceIndex: 0, crossingTime: 0 },
+      { sequenceIndex: 1, crossingTime: 100_000 },
+      { sequenceIndex: 2, crossingTime: 200_000 },
+    ];
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.7, -122.0, 200_000),
+      fix(47.796404, -122.0, 300_000), // GOAL boundary south, didn't enter
+    ];
+    const d = computePartialDistanceKm(ROUTE, TASK, crossings, fixes);
+    expect(d).toBeCloseTo(TASK_KM, 1);
+  });
+});
+
+// ── The bug: tracks that diverge laterally must get DIFFERENT distances ─────
+
+describe('computePartialDistanceKm — lateral divergence (was: same score)', () => {
+  // Two pilots, identical reached set (SSS + TP1), identical axial progress
+  // (both reach 47.65 latitude = 5.56 km past TP1 along the leg direction),
+  // but pilot WIDE lands 0.05° east of the leg (≈ 3.74 km off-line) while
+  // pilot NARROW only 0.01° east (≈ 0.75 km off-line).
+  //
+  // Old code: projects both onto legDir = (0, 1); both report bestM ≈ 5.56 km,
+  // → identical distanceFlownKm.
+  // §9.3:    routes the remaining task through TP2 from each landing point;
+  // WIDE has to fly further to reach TP2, so its remaining distance is larger
+  // and its credited bestDistance is smaller. NARROW gets MORE credit.
+
+  const fixesNarrow = [fix(47.503596, -122.0, 0), fix(47.6, -122.0, 100_000), fix(47.65, -122.01, 200_000)];
+  const fixesWide = [fix(47.503596, -122.0, 0), fix(47.6, -122.0, 100_000), fix(47.65, -122.05, 200_000)];
+
+  it('NARROW (closer to optimised line) gets more credit than WIDE', () => {
+    const dN = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1, fixesNarrow);
+    const dW = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1, fixesWide);
+    expect(dN).toBeGreaterThan(dW);
+    // The gap is the difference in "extra detour" needed to reach TP2 — bounded
+    // below by (wide_offset − narrow_offset) projected through TP2 geometry.
+    expect(dN - dW).toBeGreaterThan(0.5);
+  });
+});
+
+// ── The bug: tracks that overshoot past an un-tagged TP must NOT clamp ──────
+
+describe('computePartialDistanceKm — overshoot past an unreached TP', () => {
+  // Pilot CLOSE: flies past TP2 latitude but stays 1 km east of the meridian,
+  // so they never enter TP2. Best moment was while east of TP2 boundary
+  // (≈ 0.6 km outside).
+  // Pilot FAR: same east-offset profile but they wing it 5 km past TP2 latitude
+  // before veering further east. Their closest approach to TP2 is similar to
+  // CLOSE's (≈ same offset at the same latitude band), so §9.3 puts them on
+  // similar bestDistance. But the OLD projection-and-clamp would have given
+  // both exactly legLenM credit on the TP1→TP2 leg regardless of the lateral
+  // miss — overstating progress by ~1 km.
+  //
+  // Concrete assertion: §9.3 must give STRICTLY LESS than SSS→TP2-edge for
+  // a pilot who flew past TP2 without entering. The old leg-clamp pinned this
+  // to exactly leg(SSS→TP1)+leg(TP1→TP2).
+
+  it('pilot overshoots TP2 latitude but never tags it → distance < SSS→TP2 sum', () => {
+    const ssToTp1 = ROUTE.legDistancesKm[0];
+    const tp1ToTp2 = ROUTE.legDistancesKm[1];
+    const oldClampValue = ssToTp1 + tp1ToTp2;
+
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.65, -122.01, 200_000),
+      fix(47.7, -122.012, 300_000), // east of TP2 by ≈ 0.9 km — outside cylinder
+      fix(47.75, -122.015, 400_000),
+      fix(47.78, -122.02, 500_000),
+    ];
+    const d = computePartialDistanceKm(ROUTE, TASK, CROSS_SSS_TP1, fixes);
+
+    // §9.3: the pilot still has to fly the residual perpendicular distance to
+    // TP2 boundary on top of TP2→GOAL — so they get less than the full
+    // SSS→TP2 sum.
+    expect(d).toBeLessThan(oldClampValue);
+    // Sanity: they did make real progress (well beyond just tagging TP1).
+    expect(d).toBeGreaterThan(ssToTp1 + 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrite `computePartialDistanceKm` (src/shared/task-engine.ts) to follow **FAI Sporting Code S7F §9.3**: for each flying fix, run the route optimiser on `[fix-as-0-radius-cyl, ...unreached cylinders, goal]` and credit the pilot with `taskDistance − min(remainingDistance)`.
- Update `calculateDistances` caller (src/shared/pipeline.ts) to pass the ordered crossings + fix timestamps the new algorithm needs.
- Bump `SCORER_VERSION` to `1.2` so the boot-time `reprocessStaleSubmissions` sweep replays every existing IGC under the new algorithm.

## Why
The old algorithm projected each fix onto the next-leg direction vector and clamped to `legLen`. This silently:
1. **Caps credit at the next TP boundary** — two pilots who overshoot an un-tagged TP by 50 m vs 5 km get the same number. This is the "different distance down optimised, same score" symptom from prod.
2. **Ignores lateral excursions** — a pilot drifting 5 km off the leg line gets the same credit as one tracking it perfectly, as long as their axial progress matches.

§9.3 fixes both because the route optimiser must actually route from the pilot's position through the remaining TPs to goal — perpendicular detour to an un-tagged TP costs real kilometres, and lateral excursion shows up as a longer remaining path.

## Test plan
- [x] New `tests/partial-distance.test.ts` (8 tests) covers:
  - sanity (empty fixes, anchored task distance)
  - 4 anchor scenarios (SSS exit ≈ 0, at TP1 ≈ SSS→TP1 leg, halfway to TP2, at goal entry edge ≈ taskDistance)
  - lateral divergence: NARROW pilot (0.01° east of line) gets > 0.5 km more credit than WIDE pilot (0.05° east) at identical axial progress — directly exercises the bug
  - overshoot of un-tagged TP gets strictly less than `leg(SSS→TP1) + leg(TP1→TP2)`
- [x] `npm run typecheck` clean
- [x] `npx biome check` clean on touched files
- [x] All 62 existing scoring/pipeline tests still pass (including the `pipeline-parity` 3.65 km goal-pilot snapshot)
- [ ] **Manual:** verify `[reprocess]` log line fires at boot and old `distance_flown_km` values shift on tasks where pilots flew past un-tagged TPs

## Rules reference
FAI Sporting Code S7F – XC Scoring 2025 v1.0, §9.3 "Flown distance":
> we determine for each point where the pilot is still flying the remaining distance to goal from that point, considering any previously reached control zones. … Then we calculate the flight distance as the task distance minus the smallest of those remaining distances.