### PR TITLE
Fix stale schema in reprocess INSERT (unblocks §9.3 rollout)

### DIFF
--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -209,15 +209,20 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
       const essTs = attempt.essCrossing ? new Date(attempt.essCrossing.crossingTime).toISOString() : null;
       const goalTs = attempt.goalCrossing ? new Date(attempt.goalCrossing.crossingTime).toISOString() : null;
 
+      // distance_points / time_points / total_points columns were dropped in
+      // migration 0013 (task_results is the single source of truth for scoring).
+      // The matching INSERT in upload.ts was updated then; this one was missed,
+      // so every reprocess run threw "no column named distance_points" and the
+      // boot sweep silently failed for all submissions.
       db.prepare(
         `INSERT INTO flight_attempts (
           id, submission_id, task_id, user_id,
           sss_crossing_time, ess_crossing_time, goal_crossing_time, task_time_s,
           reached_goal, last_turnpoint_index,
-          distance_flown_km, distance_points, time_points, total_points,
+          distance_flown_km,
           has_flagged_crossings, attempt_index, scorer_version,
           created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         attemptId,
         sub.id,
@@ -230,9 +235,6 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
         attempt.reachedGoal ? 1 : 0,
         attempt.lastTurnpointIndex,
         attempt.distanceFlownKm,
-        attempt.distancePoints,
-        attempt.timePoints,
-        attempt.totalPoints,
         attempt.hasFlaggedCrossings ? 1 : 0,
         attempt.attemptIndex,
         SCORER_VERSION,


### PR DESCRIPTION
## Summary
Migration 0013 (2026-05-02) dropped `distance_points`, `time_points`, `total_points` from `flight_attempts` — `task_results` became the single source of truth for scoring. The matching INSERT in `upload.ts` was updated then, but the parallel INSERT in `reprocess.ts` was missed.

That bug stayed dormant because no `SCORER_VERSION` bump had triggered a boot reprocess since. PR #62 bumped to `'1.2'` to roll out the FAI §9.3 fix, so the boot sweep finally fired — and threw `"table flight_attempts has no column named distance_points"` on every one of the 79 submissions, silently leaving every score at the old algorithm's output. Production still shows the old leg-projection+clamp distances despite the §9.3 code being live.

This drops the legacy columns from the `reprocess.ts` INSERT to match the post-0013 schema.

## How this surfaced
- User reported the leaderboard "still looks fucked up" after PR #62 deployed.
- Two pilots on `Flight to the Ford` had identical distance to 13 decimal places (`15.505053412480663` km) — exactly `sum(legSSS→TP1 + legTP1→TP2 + legTP2→TP3)`, the old `completedKm + bestM=0` clamp output.
- Computed locally with the §9.3 algorithm: Josh's correct distance is **15.129 km**.
- Pulled a copy of the prod DB and ran `reprocessStaleSubmissions` locally → all 79 submissions threw the same schema error. Fix verified against the same copy: 79/0, all attempts move to `scorer_version='1.2'`, Josh's row updates to `15.12858275582527` (matches local §9.3 computation).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — pipeline.test.ts and partial-distance.test.ts pass
- [x] Local replay of `reprocessStaleSubmissions` against a copy of prod DB: 79 reprocessed, 0 failed
- [ ] After merge + deploy: watch `fly logs` for `[reprocess] re-running pipeline against 79 submissions for SCORER_VERSION=1.2` and `[reprocess] done: 79 re-scored, 0 failed`, then verify the leaderboard's non-goal distances change off the leg-sum values.