### PR TITLE
Implement FAI S7F §12.2 time points formula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Test frontend
+        run: npm test --prefix frontend

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   ci:

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -584,7 +584,7 @@ runPipeline result
 | `detectAttempts` | Quadratic formula (parameterised segment-circle intersection); linear time interpolation at parameter `t`; goal line via segment-segment intersection; multiple SSS crossings → multiple attempts | `NO_SSS_CROSSING` |
 | `classifyGroundState` | 30s sustained speed window classifies each fix `GROUND` / `AIRBORNE` / `UNKNOWN`; 60s window around `GROUND_ONLY` crossing stores `detectedMaxSpeedKmh` | (no error — informational only) |
 | `calculateDistances` | Vincenty geodesic (`geographiclib-geodesic`) for point-to-point legs; goal pilots get full `optimisedDistanceKm`; partial pilots get cumulative distance + closest approach to next TP | — |
-| `scoreAttempts` | **Distance:** `938 * sqrt(d_pilot / d_best)` (or 938 for goal). **Time:** `938 * (1 - ((t_pilot - t_min) / (t_max - t_min))^(2/3))` — provisional until task closes | — |
+| `scoreAttempts` | **Distance:** `938 * sqrt(d_pilot / d_best)` (or 938 for goal). **Time (FAI S7F §12.2):** `938 * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best))^(5/6))`, times in hours — provisional until task closes | — |
 | `selectBestAttempt` | Priority: (1) reached goal, (2) highest total points, (3) lowest task time | — |
 
 **Rescoring:** When a new goal pilot is detected, `RESCORE_TASK` job calls `rescoreTimePoints` — the same GAP formula applied across all known goal times for that task. `task_results` and `season_standings` are updated atomically via follow-up jobs.

--- a/frontend/src/components/ScoringExplainer.tsx
+++ b/frontend/src/components/ScoringExplainer.tsx
@@ -136,7 +136,7 @@ export default function ScoringExplainer() {
           pill="TIME"
           pillColor="#4a9eff"
           label="Goal pilots only"
-          sub="Measures your speed through the speed section. Faster pilots and days with more goal crossings earn more time points. Provisional until the task closes — final standings depend on the full field."
+          sub="Measures your speed through the speed section against the fastest pilot in goal (FAI S7F §12.2). You only score zero if you take longer than the best time plus its square root. Provisional until the task closes — a faster finisher can still lower everyone's time points."
         />
         <div
           style={{

--- a/frontend/src/components/ScoringExplainer.tsx
+++ b/frontend/src/components/ScoringExplainer.tsx
@@ -136,7 +136,7 @@ export default function ScoringExplainer() {
           pill="TIME"
           pillColor="#4a9eff"
           label="Goal pilots only"
-          sub="Measures your speed through the speed section against the fastest pilot in goal (FAI S7F §12.2). You only score zero if you take longer than the best time plus its square root. Provisional until the task closes — a faster finisher can still lower everyone's time points."
+          sub="Measures your speed through the speed section against the fastest pilot in goal (FAI S7F §12.2). You score zero only when your time reaches the best time plus the square root of the best time, measured in hours — a 1h best time means zero at 2h. Provisional until the task closes — a faster finisher can still lower everyone's time points."
         />
         <div
           style={{

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -96,17 +96,18 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
     expect(best.taskTimeS).toBeGreaterThan(0);
 
     // previewSubmission also applies the same task-level normalisation that
-    // rebuildTaskResults runs server-side. Fixture setup:
+    // rebuildTaskResults runs server-side. Fixture setup (§12.2 time points):
     //   - prior finisher: goal at 120 s → raw 1000 dist + 1000 time = 2000
-    //   - preview: goal at ~148 s → raw 1000 dist + 0 time = 1000
+    //   - preview: goal ~27 s slower; t_best = 120 s → raw time 929.6,
+    //     so raw 1000 dist + 929.6 time = 1929.6
     //   - winner raw = 2000 → scale = 1000 / 2000 = 0.5
-    //   - preview normalised: 500 dist + 0 time = 500
+    //   - preview normalised: 500 dist + 464.8 time = 964.8
     // If this assertion ever drifts, either the normalisation logic changed
     // or the underlying scoring formulas did — both cases want a closer look
     // because the backend's rebuildTaskResults would have followed suit.
     expect(best.distancePoints).toBeCloseTo(500, 0);
-    expect(best.timePoints).toBeCloseTo(0, 0);
-    expect(best.totalPoints).toBeCloseTo(500, 0);
+    expect(best.timePoints).toBeCloseTo(464.8, 1);
+    expect(best.totalPoints).toBeCloseTo(964.8, 1);
 
     // Frontend-only: previewSubmission also surfaces fixes for the map. Each
     // B record should produce one fix.

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -69,8 +69,9 @@ function normalizePreviewPoints(
 ): { distancePoints: number; timePoints: number; totalPoints: number } {
   // Drop the current pilot's existing leaderboard row — their preview replaces
   // it as their best-attempt candidate. Keeping both would double-count this
-  // pilot in the goal-time pool (skewing tMin/tMax) and treat their old
-  // total as a separate "competitor" against themselves.
+  // pilot in the goal-time pool (potentially pinning t_best to their old,
+  // faster time) and treat their old total as a separate "competitor"
+  // against themselves.
   const others = currentUserId ? leaderboard.filter((e) => e.pilotId !== currentUserId) : leaderboard;
 
   // bestDist drives the non-goal distance points formula. Include the preview

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -311,10 +311,9 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   // task in the DB.)
   let bestDistKm = 0;
   for (const a of attempts) if (a.distance_flown_km > bestDistKm) bestDistKm = a.distance_flown_km;
-  // Build the goal-times set from the *fastest* goal time per pilot. Without
-  // dedup, a pilot who uploads the same goal flight twice (or two different
-  // goal flights) would contribute multiple entries and shift tMin/tMax for
-  // everyone — scoring should depend on one attempt per pilot.
+  // Build the goal-times set from the *fastest* goal time per pilot. The
+  // §12.2 formula only depends on t_best, which slower duplicates can't
+  // shift, but scoring should still depend on one attempt per pilot.
   const fastestGoalTimeByPilot = new Map<string, number>();
   for (const a of attempts) {
     if (a.reached_goal !== 1 || a.task_time_s === null) continue;

--- a/src/shared/SCORING.md
+++ b/src/shared/SCORING.md
@@ -24,18 +24,19 @@ The square root curve rewards pilots who fly further but does not linearly scale
 
 ### Time Points
 
-Only goal pilots receive time points.
+Only goal pilots receive time points. The curve is the FAI Sporting Code S7F §12.2 formula:
 
-| Condition | Formula |
-|---|---|
-| Sole finisher, or all goal pilots finish in the same time | `1000` |
-| Otherwise | `1000 × (1 - ((t − t_min) / (t_max − t_min))^(2/3))` |
+```
+SpeedFraction = max(0, 1 - ((t − t_best) / √t_best)^(5/6))
+timePoints    = 1000 × SpeedFraction
+```
 
-- `t` — this pilot's task time (SSS crossing → goal crossing)
-- `t_min` — fastest goal time
-- `t_max` — slowest goal time
+- `t` — this pilot's task time **in hours** (ESS crossing if the task has an ESS, else goal crossing, measured from the SSS crossing)
+- `t_best` — the fastest task time among pilots who reached goal, in hours
 
-The `^(2/3)` exponent gives more weight to the faster end — a pilot 50% of the way through the time spread loses much less than 500 points.
+The cutoff is absolute, anchored to the winner: a pilot scores zero time points only when
+their time is at or beyond `t_best + √t_best` (e.g. best time 1h → zero at 2h; best time
+4h → zero at 6h). A sole finisher is their own `t_best` and scores the full 1000.
 
 Non-goal pilots receive **0 time points**.
 
@@ -86,4 +87,4 @@ Pilots are ranked by total points descending. Tie-breaking is not currently impl
 
 ## Rescoring
 
-Time points are recalculated every time a new result is submitted while a task is open. This means a pilot's score can change when other pilots submit results that shift `t_min` or `t_max`. Scores are finalized when an admin freezes the task.
+Time points are recalculated every time a new result is submitted while a task is open. Because the §12.2 formula depends only on the fastest goal time, a pilot's time points change only when someone submits a *faster* goal time (shifting `t_best`); slower finishers arriving later never affect existing scores. Scores are finalized when an admin freezes the task.

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -892,9 +892,9 @@ export function calculateDistances(attempts: AttemptTrace[], fixes: Fix[], task:
  *   Goal: distancePoints = MAX_POINTS
  *   Else: distancePoints = MAX_POINTS * sqrt(dist / bestDist)
  *
- * Time points (goal pilots only):
- *   timePoints = MAX_POINTS * (1 - ((t_pilot - t_min) / (t_max - t_min)) ^ (2/3))
- *   Sole finisher or all same time: timePoints = MAX_POINTS
+ * Time points (goal pilots only) — FAI S7F §12.2:
+ *   timePoints = MAX_POINTS * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best)) ^ (5/6))
+ *   (times in hours; t_best = fastest goal time; sole finisher gets MAX_POINTS)
  */
 export function scoreAttempts(
   attempts: AttemptTrace[],

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -353,18 +353,24 @@ export function computeDistancePoints(distKm: number, bestDistKm: number, reache
 }
 
 /**
- * Time points for one goal pilot.
- *   Sole finisher or all same time: MAX_POINTS
- *   Otherwise: MAX_POINTS * (1 - ((t - t_min) / (t_max - t_min)) ^ (2/3))
+ * Time points for one goal pilot — FAI Sporting Code S7F §12.2.
+ *
+ *   SpeedFraction = max(0, 1 - ((T - BestTime) / sqrt(BestTime)) ^ (5/6))
+ *   TimePoints    = SpeedFraction * MAX_POINTS
+ *
+ * Times in the formula are in HOURS (per the spec). BestTime is the fastest
+ * task time among goal pilots. A pilot scores zero only when their time is at
+ * or beyond BestTime + sqrt(BestTime) — an absolute cutoff anchored to the
+ * winner's time, not to the slowest finisher.
  *
  * @param taskTimeS      This pilot's task time in seconds
  * @param allGoalTimesS  All goal pilots' task times including this one
  */
 export function computeTimePoints(taskTimeS: number, allGoalTimesS: number[]): number {
   if (allGoalTimesS.length === 0) return MAX_POINTS;
-  const tMin = Math.min(...allGoalTimesS);
-  const tMax = Math.max(...allGoalTimesS);
-  if (tMin === tMax) return MAX_POINTS;
-  const ratio = (taskTimeS - tMin) / (tMax - tMin);
-  return Math.round(MAX_POINTS * (1 - ratio ** (2 / 3)) * 10) / 10;
+  const bestTimeH = Math.min(...allGoalTimesS) / 3600;
+  if (bestTimeH <= 0) return taskTimeS <= 0 ? MAX_POINTS : 0;
+  const excessH = Math.max(0, taskTimeS / 3600 - bestTimeH);
+  const speedFraction = Math.max(0, 1 - (excessH / Math.sqrt(bestTimeH)) ** (5 / 6));
+  return Math.round(MAX_POINTS * speedFraction * 10) / 10;
 }

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -396,30 +396,30 @@ describe('rebuildTaskResults', () => {
       .all(taskTime.id) as any[];
     expect(rows).toHaveLength(4);
 
-    // tMin=3000, tMax=5400; ratio = (t - 3000) / 2400.
-    // time_points = 1000 * (1 - ratio^(2/3)).
+    // FAI S7F §12.2: bestTime=3000s (0.8333h), cutoff at best + sqrt(best) ≈ 6286s.
+    // time_points = 1000 * max(0, 1 - ((t - best) / sqrt(best))^(5/6)), times in hours.
     const byUser = new Map(rows.map((r) => [r.user_id, r]));
     expect(byUser.get(pilot4.id).time_points).toBeCloseTo(1000, 0); // fastest
-    expect(byUser.get(pilot.id).time_points).toBeCloseTo(603, 0); // 3600
-    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(370, 0); // 4200
-    expect(byUser.get(pilot3.id).time_points).toBeCloseTo(0, 0); // slowest
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(757.6, 1); // 3600
+    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(568.1, 1); // 4200
+    expect(byUser.get(pilot3.id).time_points).toBeCloseTo(230.4, 1); // slowest, still inside cutoff
     // distance_points are tied at 1000 (all four flew 50km of best=50km).
     for (const r of rows) expect(r.distance_points).toBeCloseTo(1000, 0);
   });
 
   // Regression: goalTimes is built per-pilot (fastest), not per-attempt.
-  // A pilot uploading two goal flights for the same task must not contribute
-  // two entries to the goal-time set — that would distort tMin/tMax for
-  // everyone else.
+  // Under the §12.2 formula only the fastest time (t_best) matters, so a
+  // pilot's slower duplicate attempts can no longer distort anyone's score —
+  // but the per-pilot dedup guard stays, and a pilot with multiple goal
+  // attempts must still be scored on their fastest one.
   it('dedups goal times by pilot when computing time_points', () => {
     const taskTime = createTestTask(db, season.id, league.id, { name: 'Dedup' });
     db.prepare(`UPDATE tasks SET normalized_score = 2000 WHERE id = ?`).run(taskTime.id);
 
     // Pilot A: two goal attempts in one submission — fastest=3600s, slower=4200s.
-    // (Could also be two different submissions; same bug either way since goalTimes
-    // is built from flight_attempts, not submissions.) If we don't dedup,
-    // goalTimes = [3600, 4200, 3000] → tMin=3000, tMax=4200. With dedup,
-    // goalTimes = [3600, 3000] → tMin=3000, tMax=3600.
+    // (Could also be two different submissions; goalTimes is built from
+    // flight_attempts, not submissions.) Pilot A must be scored on their
+    // fastest attempt (3600), and t_best for the field is pilot B's 3000.
     const subA = createTestSubmission(db, taskTime.id, pilot.id, league.id);
     createTestAttempt(db, subA, taskTime.id, pilot.id, league.id, {
       reachedGoal: true,
@@ -447,10 +447,9 @@ describe('rebuildTaskResults', () => {
       .all(taskTime.id) as any[];
     expect(rows).toHaveLength(2);
     const byUser = new Map(rows.map((r) => [r.user_id, r]));
-    // tMin=3000, tMax=3600 → ratio = (t - 3000) / 600.
-    // Pilot B at 3000: 1000.
-    // Pilot A's *best* is 3600 (slower 4200 is ignored): ratio=1 → 0.
+    // §12.2 with t_best=3000s: pilot B at 3000 → 1000.
+    // Pilot A's *best* is 3600 (slower 4200 is ignored) → 757.6.
     expect(byUser.get(pilot2.id).time_points).toBeCloseTo(1000, 0);
-    expect(byUser.get(pilot.id).time_points).toBeCloseTo(0, 0);
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(757.6, 1);
   });
 });

--- a/tests/time-points.test.ts
+++ b/tests/time-points.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { computeTimePoints, MAX_POINTS } from '../src/shared/task-engine';
+
+const hms = (h: number, m: number, s: number) => h * 3600 + m * 60 + s;
+
+// FAI Sporting Code S7F 2025 §12.2:
+//   SpeedFraction = max(0, 1 - ((T - BestTime) / sqrt(BestTime))^(5/6)), times in hours
+// Pinned against the spec's own worked examples in §12.2.1 Table 2.
+describe('computeTimePoints (FAI S7F §12.2)', () => {
+  it('reproduces the §12.2.1 Table 2 sample distribution', () => {
+    // Row 1: fastest time 1:00 → 80% at 1:08:42, 50% at 1:26:07, 0 at 2:00:00
+    const best1 = hms(1, 0, 0);
+    expect(computeTimePoints(best1, [best1])).toBe(MAX_POINTS);
+    expect(computeTimePoints(hms(1, 8, 42), [best1])).toBeCloseTo(800, 0);
+    expect(computeTimePoints(hms(1, 26, 7), [best1])).toBeCloseTo(500, 0);
+    expect(computeTimePoints(hms(2, 0, 0), [best1])).toBe(0);
+
+    // Row 2: fastest time 2:00 → 80% at 2:12:18, 50% at 2:36:56, 0 at 3:24:51
+    const best2 = hms(2, 0, 0);
+    expect(computeTimePoints(hms(2, 12, 18), [best2])).toBeCloseTo(800, 0);
+    expect(computeTimePoints(hms(2, 36, 56), [best2])).toBeCloseTo(500, 0);
+    expect(computeTimePoints(hms(3, 24, 51), [best2])).toBeCloseTo(0, 0);
+
+    // Row 3: fastest time 3:00 → 80% at 3:15:04, 50% at 3:45:14, 0 at 4:43:55
+    const best3 = hms(3, 0, 0);
+    expect(computeTimePoints(hms(3, 15, 4), [best3])).toBeCloseTo(800, 0);
+    expect(computeTimePoints(hms(3, 45, 14), [best3])).toBeCloseTo(500, 0);
+    expect(computeTimePoints(hms(4, 43, 55), [best3])).toBeCloseTo(0, 0);
+  });
+
+  it('zero cutoff is absolute: BestTime + sqrt(BestTime), independent of other finishers', () => {
+    const best = hms(1, 0, 0);
+    // Just inside the cutoff scores > 0; at/beyond scores exactly 0.
+    expect(computeTimePoints(hms(1, 59, 0), [best])).toBeGreaterThan(0);
+    expect(computeTimePoints(hms(2, 0, 0), [best])).toBe(0);
+    expect(computeTimePoints(hms(5, 0, 0), [best])).toBe(0);
+    // The slowest actual finisher does NOT define the zero point: a pilot only
+    // 12 minutes behind a ~39-minute best time keeps most of their points even
+    // when they are last into goal.
+    expect(computeTimePoints(3032, [2314, 3032])).toBeCloseTo(686.3, 1);
+  });
+
+  it('sole finisher and all-tied fields score full points', () => {
+    expect(computeTimePoints(5000, [5000])).toBe(MAX_POINTS);
+    expect(computeTimePoints(5000, [5000, 5000, 5000])).toBe(MAX_POINTS);
+    expect(computeTimePoints(5000, [])).toBe(MAX_POINTS);
+  });
+
+  it('guards degenerate inputs', () => {
+    // Zero best time: only a zero-time pilot matches it.
+    expect(computeTimePoints(0, [0])).toBe(MAX_POINTS);
+    expect(computeTimePoints(100, [0])).toBe(0);
+    // A pilot faster than the pool minimum (should not happen — the pool
+    // includes the pilot) clamps to full points rather than NaN.
+    expect(computeTimePoints(3000, [3600])).toBe(MAX_POINTS);
+  });
+});


### PR DESCRIPTION
## What

Replaces the homegrown min/max time-points curve with the real FAI Sporting Code S7F 2025 §12.2 formula:

```
SpeedFraction = max(0, 1 - ((T - BestTime) / √BestTime)^(5/6))   (times in hours)
TimePoints    = SpeedFraction × 1000
```

## Why

The old curve normalized against the slowest actual finisher, so the last pilot into goal always scored **exactly 0 time points** regardless of how close they were — most punishing in small fields. Live example (Flight to the Ford, June): 2nd of 2 into goal, 12 minutes behind a 39-minute best time, scored 0. Under §12.2 the zero cutoff is absolute (`BestTime + √BestTime`), so that pilot scores 686.3 raw time points.

## Behavior changes

- Only `t_best` matters now: slower finishers arriving later never change existing scores; a faster finisher lowers everyone's.
- The slowest goal finisher gets a score proportional to how far behind they actually were.
- On deploy, open tasks rescore via the rebuild path — June task standings will change.

## Verification

- New `tests/time-points.test.ts` pins the implementation to the spec's own §12.2.1 Table 2 worked examples (fastest 1:00 → 80% at 1:08:42, 50% at 1:26:07, 0 at 2:00:00; plus the 2:00 and 3:00 rows). All nine cells reproduce exactly.
- Existing regression tests updated to §12.2 expectations; 259 tests pass, typecheck clean.

Part 1 of a stacked series from the S7F compliance audit (bug fixes and spec-deviation fixes follow).