### PR TITLE
Fix scoring bugs from FAI S7F compliance audit (findings 1–9)

### DIFF
--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -225,16 +225,15 @@ export default function FlightPreviewPanel({
                   borderRadius: 6,
                   fontSize: 11,
                   fontFamily: 'var(--font-mono)',
-                  background:
-                    predicted.source === 'existing' ? 'rgba(167,139,250,0.08)' : 'rgba(16,185,129,0.06)',
+                  background: predicted.source === 'existing' ? 'rgba(167,139,250,0.08)' : 'rgba(16,185,129,0.06)',
                   border: `1px solid ${predicted.source === 'existing' ? 'rgba(167,139,250,0.3)' : 'rgba(16,185,129,0.25)'}`,
                   color: 'var(--text)',
                 }}
               >
                 {predicted.source === 'existing' ? (
                   <>
-                    This flight would <strong>not</strong> displace your current best — your leaderboard row
-                    keeps it, at <strong>{fmtPts(predicted.totalPoints)} pts</strong> after upload.
+                    This flight would <strong>not</strong> displace your current best — your leaderboard row keeps it,
+                    at <strong>{fmtPts(predicted.totalPoints)} pts</strong> after upload.
                   </>
                 ) : previousBest ? (
                   <>
@@ -250,8 +249,8 @@ export default function FlightPreviewPanel({
             )}
             {previousBest && predicted?.source === 'preview' && (
               <div style={{ marginTop: 4, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text3)' }}>
-                Previous-best points aren't shown: the leaderboard rescales after every upload, so its stored
-                points aren't comparable with this preview.
+                Previous-best points aren't shown: the leaderboard rescales after every upload, so its stored points
+                aren't comparable with this preview.
               </div>
             )}
           </>

--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -1,5 +1,5 @@
 import type { LeaderboardEntry } from '../api/tasks';
-import type { PreviewError, PreviewResult } from '../lib/previewPipeline';
+import type { PredictedStanding, PreviewError, PreviewResult } from '../lib/previewPipeline';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -61,6 +61,13 @@ interface Props {
   error: PreviewError | null;
   /** The pilot's current best on this task. null = first submission for this pilot. */
   previousBest: LeaderboardEntry | null;
+  /**
+   * The pilot's leaderboard row after this upload (previewPipeline's
+   * PredictedStanding) — points re-normalized under the POST-upload pool.
+   * null while the preview is loading. `source: 'existing'` means the
+   * previewed flight would NOT displace the pilot's current best.
+   */
+  predicted: PredictedStanding | null;
   uploading: boolean;
   onSubmit: () => void;
   onCancel: () => void;
@@ -71,6 +78,7 @@ export default function FlightPreviewPanel({
   result,
   error,
   previousBest,
+  predicted,
   uploading,
   onSubmit,
   onCancel,
@@ -156,41 +164,97 @@ export default function FlightPreviewPanel({
             Analysing flight…
           </div>
         ) : (
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontFamily: 'var(--font-mono)' }}>
-            <Column
-              label="Previous Best"
-              violet
-              metrics={
-                previousBest
-                  ? {
-                      distance: previousBest.distanceFlownKm,
-                      totalPoints: previousBest.totalPoints,
-                      distancePoints: previousBest.distancePoints,
-                      timePoints: previousBest.timePoints,
-                      reachedGoal: previousBest.reachedGoal,
-                      taskTimeS: previousBest.taskTimeS,
-                    }
-                  : null
-              }
-            />
-            <Column
-              label="This Flight"
-              green
-              metrics={previewMetrics}
-              previousMetrics={
-                previousBest
-                  ? {
-                      distance: previousBest.distanceFlownKm,
-                      totalPoints: previousBest.totalPoints,
-                      distancePoints: previousBest.distancePoints,
-                      timePoints: previousBest.timePoints,
-                      reachedGoal: previousBest.reachedGoal,
-                      taskTimeS: previousBest.taskTimeS,
-                    }
-                  : null
-              }
-            />
-          </div>
+          <>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontFamily: 'var(--font-mono)' }}>
+              {/*
+                Single-scale comparison. "This Flight" points are normalized
+                under the POST-upload pool (previewPipeline mirrors the
+                server's rebuildTaskResults), but the previous best's STORED
+                points were normalized under the PRE-upload pool — showing
+                them side by side produced nonsense deltas. So the Previous
+                Best column shows scale-free facts (distance / goal / task
+                time) always, and points only when `predicted` tells us the
+                previous best stays the pilot's row (source 'existing') —
+                in that case predicted's values ARE that flight's
+                re-normalized post-upload points.
+              */}
+              <Column
+                label="Previous Best"
+                violet
+                metrics={
+                  previousBest
+                    ? {
+                        distance: previousBest.distanceFlownKm,
+                        reachedGoal: previousBest.reachedGoal,
+                        taskTimeS: previousBest.taskTimeS,
+                        ...(predicted?.source === 'existing'
+                          ? {
+                              totalPoints: predicted.totalPoints,
+                              distancePoints: predicted.distancePoints,
+                              timePoints: predicted.timePoints,
+                            }
+                          : {}),
+                      }
+                    : null
+                }
+              />
+              <Column
+                label="This Flight"
+                green
+                metrics={previewMetrics}
+                // Facts only — distance/time deltas are scale-free and stay;
+                // points deltas are omitted (pre- vs post-upload scales don't
+                // compare, and the after-upload note below carries the
+                // points story).
+                previousMetrics={
+                  previousBest
+                    ? {
+                        distance: previousBest.distanceFlownKm,
+                        reachedGoal: previousBest.reachedGoal,
+                        taskTimeS: previousBest.taskTimeS,
+                      }
+                    : null
+                }
+              />
+            </div>
+            {predicted && (
+              <div
+                style={{
+                  marginTop: 8,
+                  padding: '8px 10px',
+                  borderRadius: 6,
+                  fontSize: 11,
+                  fontFamily: 'var(--font-mono)',
+                  background:
+                    predicted.source === 'existing' ? 'rgba(167,139,250,0.08)' : 'rgba(16,185,129,0.06)',
+                  border: `1px solid ${predicted.source === 'existing' ? 'rgba(167,139,250,0.3)' : 'rgba(16,185,129,0.25)'}`,
+                  color: 'var(--text)',
+                }}
+              >
+                {predicted.source === 'existing' ? (
+                  <>
+                    This flight would <strong>not</strong> displace your current best — your leaderboard row
+                    keeps it, at <strong>{fmtPts(predicted.totalPoints)} pts</strong> after upload.
+                  </>
+                ) : previousBest ? (
+                  <>
+                    This flight would become your new best — your leaderboard row after upload:{' '}
+                    <strong>{fmtPts(predicted.totalPoints)} pts</strong>.
+                  </>
+                ) : (
+                  <>
+                    Your leaderboard row after upload: <strong>{fmtPts(predicted.totalPoints)} pts</strong>.
+                  </>
+                )}
+              </div>
+            )}
+            {previousBest && predicted?.source === 'preview' && (
+              <div style={{ marginTop: 4, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text3)' }}>
+                Previous-best points aren't shown: the leaderboard rescales after every upload, so its stored
+                points aren't comparable with this preview.
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -232,9 +296,13 @@ export default function FlightPreviewPanel({
 
 interface ColumnMetrics {
   distance: number;
-  totalPoints: number;
-  distancePoints: number;
-  timePoints: number;
+  // Points are optional so the Previous Best column can render facts without
+  // points when the stored (pre-upload-scale) values would be misleading next
+  // to the preview's post-upload-scale numbers. fmtPts renders absent as '—',
+  // and delta() skips rows where either side is missing.
+  totalPoints?: number | null;
+  distancePoints?: number | null;
+  timePoints?: number | null;
   reachedGoal: boolean;
   turnpointsCrossed?: number;
   taskTimeS: number | null;

--- a/frontend/src/components/FlightPreviewPanel.tsx
+++ b/frontend/src/components/FlightPreviewPanel.tsx
@@ -95,6 +95,10 @@ export default function FlightPreviewPanel({
         reachedGoal: best.reachedGoal,
         turnpointsCrossed: best.turnpointCrossings.length,
         taskTimeS: best.taskTimeS,
+        // Truncation-voided crossings (XC) or failed ground checks (HAF).
+        // Surfaced with the same ⚑ glyph the leaderboard uses, so the pilot
+        // isn't shown a clean preview of a flight that will land flagged.
+        flagged: best.hasFlaggedCrossings,
       }
     : null;
 
@@ -245,6 +249,12 @@ export default function FlightPreviewPanel({
                     Your leaderboard row after upload: <strong>{fmtPts(predicted.totalPoints)} pts</strong>.
                   </>
                 )}
+                {predicted.hasFlaggedCrossings && (
+                  <div style={{ marginTop: 4, color: 'var(--warning)' }}>
+                    <strong>⚑</strong> Your leaderboard row will carry the review flag — this track has crossings
+                    flagged for admin review.
+                  </div>
+                )}
               </div>
             )}
             {previousBest && predicted?.source === 'preview' && (
@@ -305,6 +315,12 @@ interface ColumnMetrics {
   reachedGoal: boolean;
   turnpointsCrossed?: number;
   taskTimeS: number | null;
+  /**
+   * hasFlaggedCrossings on the attempt — rendered as the leaderboard's ⚑
+   * glyph. Optional so the Previous Best column (which doesn't set it) stays
+   * unchanged.
+   */
+  flagged?: boolean;
 }
 
 function Column({
@@ -374,6 +390,20 @@ function Column({
       <Row k="Goal" v={metrics.reachedGoal ? '✓' : '✗'} />
       {metrics.turnpointsCrossed != null && <Row k="Turnpoints" v={String(metrics.turnpointsCrossed)} />}
       <Row k="Task time" v={fmtTime(metrics.taskTimeS)} delta={dTime} />
+      {metrics.flagged && (
+        <div
+          style={{
+            marginTop: 6,
+            paddingTop: 6,
+            borderTop: '1px solid var(--border)',
+            fontSize: 10,
+            fontWeight: 700,
+            color: 'var(--warning)',
+          }}
+        >
+          ⚑ flagged for review
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -106,6 +106,19 @@ function ScoreResult({ result, onReset }: { result: SubmissionResponse; onReset:
           </span>
         </div>
       )}
+      {best.hasFlaggedCrossings && (
+        <div
+          style={{
+            marginTop: 8,
+            fontSize: 11,
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 700,
+            color: 'var(--warning)',
+          }}
+        >
+          ⚑ Flagged for review — your leaderboard row carries the review glyph
+        </div>
+      )}
       {prov && (
         <div className="provisional-note" style={{ marginTop: 8 }}>
           ⏳ Scores provisional — final when task closes

--- a/frontend/src/components/UploadZone.tsx
+++ b/frontend/src/components/UploadZone.tsx
@@ -67,6 +67,12 @@ function ScoreResult({ result, onReset }: { result: SubmissionResponse; onReset:
   }
 
   const best = result.bestAttempt;
+  // While the task is open, ALL score components are provisional, not just
+  // time: later uploads can move t_best (lowering time points) and the
+  // task-level normalisation rescales distance points whenever the winner's
+  // raw total or best distance moves. Show every value and flag them all
+  // uniformly rather than hiding one addend of a displayed sum.
+  const prov = result.timePointsProvisional;
   return (
     <div className="result-panel fade-in">
       <div className="result-status">
@@ -81,17 +87,15 @@ function ScoreResult({ result, onReset }: { result: SubmissionResponse; onReset:
       <div className="score-grid">
         <div className="score-cell">
           <div className="score-cell-label">Distance</div>
-          <div className="score-cell-value">{fmtPts(best.distancePoints)}</div>
+          <div className={`score-cell-value${prov ? ' prov' : ''}`}>{fmtPts(best.distancePoints)}</div>
         </div>
         <div className="score-cell">
           <div className="score-cell-label">Time</div>
-          <div className={`score-cell-value ${result.timePointsProvisional ? 'prov' : ''}`}>
-            {result.timePointsProvisional ? '—' : fmtPts(best.timePoints)}
-          </div>
+          <div className={`score-cell-value${prov ? ' prov' : ''}`}>{fmtPts(best.timePoints)}</div>
         </div>
         <div className="score-cell" style={{ border: '1px solid var(--gold-dim)' }}>
           <div className="score-cell-label">Total</div>
-          <div className="score-cell-value gold">{fmtPts(best.totalPoints)}</div>
+          <div className={`score-cell-value gold${prov ? ' prov' : ''}`}>{fmtPts(best.totalPoints)}</div>
         </div>
       </div>
       {best.reachedGoal && (
@@ -102,9 +106,9 @@ function ScoreResult({ result, onReset }: { result: SubmissionResponse; onReset:
           </span>
         </div>
       )}
-      {result.timePointsProvisional && (
+      {prov && (
         <div className="provisional-note" style={{ marginTop: 8 }}>
-          ⏳ Time points provisional — final when task closes
+          ⏳ Scores provisional — final when task closes
         </div>
       )}
       <button className="btn btn-ghost" style={{ marginTop: 10, fontSize: 12 }} onClick={onReset}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -431,3 +431,13 @@ label {
 .tooltip-host:hover .tooltip {
   opacity: 1 !important;
 }
+
+/* Provisional score values (UploadZone): open tasks can still rescore */
+.score-cell-value.prov {
+  opacity: 0.75;
+  font-style: italic;
+}
+.provisional-note {
+  font-size: 12px;
+  color: var(--text3);
+}

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -18,8 +18,8 @@ import {
   FIXTURE_TASK_OPEN_DATE,
   FIXTURE_TURNPOINTS,
 } from '../../../src/shared/pipeline-parity-fixture';
-import type { Task, Turnpoint } from '../api/tasks';
-import { previewSubmission } from './previewPipeline';
+import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
+import { normalizePreviewPoints, previewSubmission } from './previewPipeline';
 
 // Adapt the pipeline-shaped fixture turnpoints to the frontend's API shape.
 // previewSubmission re-maps them via its own turnpointToDef, so this is the
@@ -49,22 +49,26 @@ const task: Task = {
   turnpoints,
 };
 
-// Match FIXTURE_INPUT.existingGoalTimes ([120]) — previewSubmission derives
-// existingGoalTimes from leaderboard entries with reachedGoal && taskTimeS.
-const leaderboardEntries = [
-  {
+function mkEntry(overrides: Partial<LeaderboardEntry> & { pilotId: string }): LeaderboardEntry {
+  return {
     rank: 1,
-    pilotName: 'Prior Finisher',
-    pilotId: 'prior',
+    pilotName: overrides.pilotId,
     submissionId: null,
-    distanceFlownKm: 3.65,
-    reachedGoal: true,
-    taskTimeS: 120,
+    distanceFlownKm: 0,
+    reachedGoal: false,
+    taskTimeS: null,
     distancePoints: 0,
     timePoints: 0,
     totalPoints: 0,
     hasFlaggedCrossings: false,
-  },
+    ...overrides,
+  };
+}
+
+// Match FIXTURE_INPUT.existingGoalTimes ([120]) — previewSubmission derives
+// existingGoalTimes from leaderboard entries with reachedGoal && taskTimeS.
+const leaderboardEntries = [
+  mkEntry({ pilotId: 'prior', pilotName: 'Prior Finisher', distanceFlownKm: 3.65, reachedGoal: true, taskTimeS: 120 }),
 ];
 
 describe('previewSubmission parity — frontend wraps runPipeline against shared fixture', () => {
@@ -96,23 +100,157 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
     expect(best.taskTimeS).toBeGreaterThan(0);
 
     // previewSubmission also applies the same task-level normalisation that
-    // rebuildTaskResults runs server-side. Fixture setup (§12.2 time points):
+    // rebuildTaskResults runs server-side. Fixture setup:
     //   - prior finisher: goal at 120 s → raw 1000 dist + 1000 time = 2000
-    //   - preview: goal ~27 s slower; t_best = 120 s → raw time 929.6,
-    //     so raw 1000 dist + 929.6 time = 1929.6
+    //   - preview: goal at ~147 s → raw 1000 dist + 929.6 time (§12.2,
+    //     anchored at t_best = 120 s)
     //   - winner raw = 2000 → scale = 1000 / 2000 = 0.5
     //   - preview normalised: 500 dist + 464.8 time = 964.8
     // If this assertion ever drifts, either the normalisation logic changed
     // or the underlying scoring formulas did — both cases want a closer look
     // because the backend's rebuildTaskResults would have followed suit.
-    expect(best.distancePoints).toBeCloseTo(500, 0);
+    expect(best.distancePoints).toBeCloseTo(500, 1);
     expect(best.timePoints).toBeCloseTo(464.8, 1);
     expect(best.totalPoints).toBeCloseTo(964.8, 1);
+
+    // First submission for 'new-pilot' — the preview itself is the pilot's
+    // predicted leaderboard row.
+    expect(res.value.predicted.source).toBe('preview');
+    expect(res.value.predicted.totalPoints).toBeCloseTo(964.8, 1);
 
     // Frontend-only: previewSubmission also surfaces fixes for the map. Each
     // B record should produce one fix.
     expect(res.value.fixes).toHaveLength(5);
     expect(res.value.fixes[0].lat).toBeCloseTo(47.495, 3);
     expect(res.value.fixes[4].lat).toBeCloseTo(47.54, 3);
+  });
+
+  it('keeps the current pilot\'s standing goal time in the t_best pool when they preview a slower flight', async () => {
+    // Pilot 'me' holds t_best = 100 s and previews the fixture flight
+    // (goal at ~147.2 s). The server never discards the old attempt, so:
+    //   - goal-time pool stays {100, 120, 147.2} → preview raw time = 879.8
+    //   - me's existing attempt (raw 2000) stays their best AND the winner
+    //   - scale = 1000 / 2000 = 0.5 → preview shows 500 + 439.9 = 939.9
+    //   - predicted row = the existing attempt at the full 1000
+    // The pre-fix code dropped me's row, anchoring t_best at 120 s (preview
+    // time 464.8 normalised) and predicting the preview as me's new row.
+    const entries = [
+      mkEntry({ pilotId: 'me', distanceFlownKm: 3.65, reachedGoal: true, taskTimeS: 100 }),
+      mkEntry({ pilotId: 'other', distanceFlownKm: 3.65, reachedGoal: true, taskTimeS: 120 }),
+    ];
+    const res = await previewSubmission(FIXTURE_INPUT.igcText, task, { competitionType: 'XC' }, entries, 'me');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const best = res.value.attempts[res.value.bestAttemptIndex];
+    expect(best.distancePoints).toBeCloseTo(500, 1);
+    expect(best.timePoints).toBeCloseTo(439.9, 1);
+    expect(best.totalPoints).toBeCloseTo(939.9, 1);
+
+    expect(res.value.predicted.source).toBe('existing');
+    expect(res.value.predicted.taskTimeS).toBe(100);
+    expect(res.value.predicted.distancePoints).toBeCloseTo(500, 1);
+    expect(res.value.predicted.timePoints).toBeCloseTo(500, 1);
+    expect(res.value.predicted.totalPoints).toBeCloseTo(1000, 1);
+  });
+});
+
+describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () => {
+  it('matches the server when the previewing pilot holds t_best (verifier worked example)', () => {
+    // A holds t_best = 3600 s, B in goal at 4500 s, A previews 5400 s,
+    // taskValue 1000. Server truth: pool stays {3600, 4500, 5400}, A's best
+    // attempt remains the 3600 s one → A stays winner at 1000 and B keeps
+    // 685.0 raw time points. The preview's own §12.2 time points anchor at
+    // 3600 s → raw 438.8, scaled by 1000/2000 → 219.4 (NOT the 856.5 total
+    // the pre-fix pool {4500, 5400} produced).
+    const entries = [
+      mkEntry({ pilotId: 'A', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }),
+      mkEntry({ pilotId: 'B', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 4500 }),
+    ];
+    const r = normalizePreviewPoints(
+      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 5400 },
+      entries,
+      'A',
+      1000,
+    );
+
+    expect(r.distancePoints).toBeCloseTo(500, 1);
+    expect(r.timePoints).toBeCloseTo(219.4, 1);
+    expect(r.totalPoints).toBeCloseTo(719.4, 1);
+
+    expect(r.predicted.source).toBe('existing');
+    expect(r.predicted.taskTimeS).toBe(3600);
+    expect(r.predicted.totalPoints).toBeCloseTo(1000, 1);
+  });
+
+  it('predicts the preview as the new row when it beats the existing one (goal beats non-goal)', () => {
+    // compareBestAttempt order: reached goal first. Existing non-goal row
+    // loses to a goal preview even at a matching distance.
+    const entries = [
+      mkEntry({ pilotId: 'me', distanceFlownKm: 50, reachedGoal: false }),
+      mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false }),
+    ];
+    const r = normalizePreviewPoints(
+      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 },
+      entries,
+      'me',
+      1000,
+    );
+
+    // Preview wins → winner raw = 1000 dist + 1000 time (sole goal time) =
+    // 2000, scale 0.5.
+    expect(r.predicted.source).toBe('preview');
+    expect(r.predicted.reachedGoal).toBe(true);
+    expect(r.totalPoints).toBeCloseTo(1000, 1);
+    expect(r.predicted.totalPoints).toBeCloseTo(1000, 1);
+  });
+
+  it('sole pilot with a stored non-goal 30 km row previewing a goal flight: predicted is the preview at the full task value', () => {
+    // Confirmed UI repro: the leaderboard stores the pilot's non-goal 30 km at
+    // 1000 pts (pre-upload scale). Previewing a goal flight must NOT render
+    // "1000 vs 1000, delta 0" — post-upload the goal flight is strictly
+    // better and becomes the pilot's row at the (rescaled) task value. The
+    // panel now sources the pilot's post-upload row from `predicted` instead
+    // of the stored pre-upload points.
+    const entries = [mkEntry({ pilotId: 'me', distanceFlownKm: 30, reachedGoal: false, totalPoints: 1000 })];
+    const r = normalizePreviewPoints({ distanceFlownKm: 30, reachedGoal: true, taskTimeS: 3600 }, entries, 'me', 1000);
+
+    // Preview raw: 1000 dist (full task distance in goal) + 1000 time (sole
+    // goal time) = 2000 → winner → scale 0.5 → normalized 1000.
+    expect(r.totalPoints).toBeCloseTo(1000, 1);
+    expect(r.predicted.source).toBe('preview');
+    expect(r.predicted.reachedGoal).toBe(true);
+    expect(r.predicted.taskTimeS).toBe(3600);
+    expect(r.predicted.totalPoints).toBeCloseTo(1000, 1);
+  });
+
+  it('keeps the existing further non-goal flight as the predicted row and in the bestDist pool', () => {
+    // me's standing 30 km row stays in the bestDist pool (server pools
+    // MAX(distance) over ALL attempts), so the 10 km preview scores
+    // sqrt(10/30) of 1000, and the standing row remains the winner.
+    const entries = [mkEntry({ pilotId: 'me', distanceFlownKm: 30, reachedGoal: false })];
+    const r = normalizePreviewPoints({ distanceFlownKm: 10, reachedGoal: false, taskTimeS: null }, entries, 'me', 1000);
+
+    expect(r.distancePoints).toBeCloseTo(577.4, 1);
+    expect(r.totalPoints).toBeCloseTo(577.4, 1);
+    expect(r.predicted.source).toBe('existing');
+    expect(r.predicted.distanceFlownKm).toBe(30);
+    expect(r.predicted.totalPoints).toBeCloseTo(1000, 1);
+  });
+
+  it('treats the preview as the only candidate when the pilot has no leaderboard row', () => {
+    const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
+    const r = normalizePreviewPoints(
+      { distanceFlownKm: 20, reachedGoal: false, taskTimeS: null },
+      entries,
+      'me',
+      1000,
+    );
+
+    expect(r.predicted.source).toBe('preview');
+    // bestDist = 40 → preview raw = 1000·sqrt(20/40) = 707.1; winner is
+    // 'other' at raw 1000 → scale 1.
+    expect(r.totalPoints).toBeCloseTo(707.1, 1);
   });
 });

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -12,6 +12,7 @@
 // =============================================================================
 
 import { describe, expect, it } from 'vitest';
+import { parseAndValidate, runPipelineFromParsed, type ScoredAttempt } from '../../../src/shared/pipeline';
 import {
   FIXTURE_INPUT,
   FIXTURE_TASK_CLOSE_DATE,
@@ -20,6 +21,18 @@ import {
 } from '../../../src/shared/pipeline-parity-fixture';
 import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
 import { normalizePreviewPoints, previewSubmission } from './previewPipeline';
+
+// Mirror previewPipeline's rounding so scale-application assertions are exact.
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+// normalizePreviewPoints takes a Pick of ScoredAttempt including
+// hasFlaggedCrossings; most tests here don't care about the flag.
+function att(
+  overrides: Pick<ScoredAttempt, 'distanceFlownKm' | 'reachedGoal' | 'taskTimeS'> &
+    Partial<Pick<ScoredAttempt, 'hasFlaggedCrossings'>>,
+): Pick<ScoredAttempt, 'distanceFlownKm' | 'reachedGoal' | 'taskTimeS' | 'hasFlaggedCrossings'> {
+  return { hasFlaggedCrossings: false, ...overrides };
+}
 
 // Adapt the pipeline-shaped fixture turnpoints to the frontend's API shape.
 // previewSubmission re-maps them via its own turnpointToDef, so this is the
@@ -168,7 +181,12 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       mkEntry({ pilotId: 'A', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }),
       mkEntry({ pilotId: 'B', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 4500 }),
     ];
-    const r = normalizePreviewPoints({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 5400 }, entries, 'A', 1000);
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 5400 }),
+      entries,
+      'A',
+      1000,
+    );
 
     expect(r.distancePoints).toBeCloseTo(500, 1);
     expect(r.timePoints).toBeCloseTo(219.4, 1);
@@ -186,7 +204,12 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       mkEntry({ pilotId: 'me', distanceFlownKm: 50, reachedGoal: false }),
       mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false }),
     ];
-    const r = normalizePreviewPoints({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }, entries, 'me', 1000);
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }),
+      entries,
+      'me',
+      1000,
+    );
 
     // Preview wins → winner raw = 1000 dist + 1000 time (sole goal time) =
     // 2000, scale 0.5.
@@ -204,7 +227,12 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
     // panel now sources the pilot's post-upload row from `predicted` instead
     // of the stored pre-upload points.
     const entries = [mkEntry({ pilotId: 'me', distanceFlownKm: 30, reachedGoal: false, totalPoints: 1000 })];
-    const r = normalizePreviewPoints({ distanceFlownKm: 30, reachedGoal: true, taskTimeS: 3600 }, entries, 'me', 1000);
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 30, reachedGoal: true, taskTimeS: 3600 }),
+      entries,
+      'me',
+      1000,
+    );
 
     // Preview raw: 1000 dist (full task distance in goal) + 1000 time (sole
     // goal time) = 2000 → winner → scale 0.5 → normalized 1000.
@@ -220,7 +248,12 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
     // MAX(distance) over ALL attempts), so the 10 km preview scores
     // sqrt(10/30) of 1000, and the standing row remains the winner.
     const entries = [mkEntry({ pilotId: 'me', distanceFlownKm: 30, reachedGoal: false })];
-    const r = normalizePreviewPoints({ distanceFlownKm: 10, reachedGoal: false, taskTimeS: null }, entries, 'me', 1000);
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 10, reachedGoal: false, taskTimeS: null }),
+      entries,
+      'me',
+      1000,
+    );
 
     expect(r.distancePoints).toBeCloseTo(577.4, 1);
     expect(r.totalPoints).toBeCloseTo(577.4, 1);
@@ -231,11 +264,208 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
 
   it('treats the preview as the only candidate when the pilot has no leaderboard row', () => {
     const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
-    const r = normalizePreviewPoints({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null }, entries, 'me', 1000);
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null }),
+      entries,
+      'me',
+      1000,
+    );
 
     expect(r.predicted.source).toBe('preview');
     // bestDist = 40 → preview raw = 1000·sqrt(20/40) = 707.1; winner is
     // 'other' at raw 1000 → scale 1.
     expect(r.totalPoints).toBeCloseTo(707.1, 1);
+  });
+});
+
+// =============================================================================
+// hasFlaggedCrossings on the predicted row
+// =============================================================================
+
+describe('normalizePreviewPoints — predicted row carries hasFlaggedCrossings', () => {
+  it("wires the preview attempt's flag when the preview becomes the pilot's row", () => {
+    const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null, hasFlaggedCrossings: true }),
+      entries,
+      'me',
+      1000,
+    );
+
+    expect(r.predicted.source).toBe('preview');
+    expect(r.predicted.hasFlaggedCrossings).toBe(true);
+  });
+
+  it("wires the existing row's flag when the previous best stays the pilot's row", () => {
+    // Existing goal row beats a non-goal preview; the row keeps ITS flag
+    // state (flagged here), not the clean preview's.
+    const entries = [
+      mkEntry({ pilotId: 'me', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600, hasFlaggedCrossings: true }),
+    ];
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null }),
+      entries,
+      'me',
+      1000,
+    );
+
+    expect(r.predicted.source).toBe('existing');
+    expect(r.predicted.hasFlaggedCrossings).toBe(true);
+  });
+
+  it('keeps the predicted row clean when neither the winning candidate nor the preview is flagged', () => {
+    const entries = [
+      mkEntry({ pilotId: 'me', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600, hasFlaggedCrossings: false }),
+    ];
+    // Flagged preview LOSES to the clean existing row — the flag must not
+    // leak onto the predicted (existing) row.
+    const r = normalizePreviewPoints(
+      att({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null, hasFlaggedCrossings: true }),
+      entries,
+      'me',
+      1000,
+    );
+
+    expect(r.predicted.source).toBe('existing');
+    expect(r.predicted.hasFlaggedCrossings).toBe(false);
+  });
+});
+
+describe('previewSubmission — flagged flight surfaces hasFlaggedCrossings (metrics + predicted path)', () => {
+  it('HAF ground-check failure flags the best attempt and the predicted row', async () => {
+    // HIKE_AND_FLY season with TP1 force-ground. The fixture track flies
+    // through TP1 at ~60 km/h with no 20 s sub-5 km/h window inside the
+    // cylinder, so Stage 4 leaves the crossing unconfirmed and flags the
+    // attempt — exactly what the leaderboard renders as ⚑. The preview panel
+    // reads the flag off attempts[bestAttemptIndex] (metrics path) and off
+    // predicted (after-upload note), so both must carry it.
+    const hafTask: Task = {
+      ...task,
+      turnpoints: turnpoints.map((tp) => (tp.sequenceIndex === 1 ? { ...tp, forceGround: true } : tp)),
+    };
+    const res = await previewSubmission(FIXTURE_INPUT.igcText, hafTask, { competitionType: 'HIKE_AND_FLY' }, [], 'me');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const best = res.value.attempts[res.value.bestAttemptIndex];
+    expect(best.hasFlaggedCrossings).toBe(true);
+
+    expect(res.value.predicted.source).toBe('preview');
+    expect(res.value.predicted.hasFlaggedCrossings).toBe(true);
+  });
+
+  it('clean XC flight previews unflagged on both paths', async () => {
+    const res = await previewSubmission(
+      FIXTURE_INPUT.igcText,
+      task,
+      { competitionType: 'XC' },
+      leaderboardEntries,
+      'new-pilot',
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.value.attempts[res.value.bestAttemptIndex].hasFlaggedCrossings).toBe(false);
+    expect(res.value.predicted.hasFlaggedCrossings).toBe(false);
+  });
+});
+
+// =============================================================================
+// One scale across all previewed attempts
+// =============================================================================
+
+// A track that spawns THREE attempts: north out of the SSS to TP1, back south
+// INTO the SSS (second crossing), out again (third crossing), then TP1 and
+// goal. Crossing direction is irrelevant (§6.2.1) and attempts are not
+// bounded by later SSS crossings, so all three attempts greedily reach goal
+// with different task times. Every inter-fix speed is ≥ ~33 km/h — no
+// stillness, so no landing cutoff, no suppression, no flags.
+//
+// Lat in IGC DDMMmmm: 47.495→4729700, 47.500→4730000, 47.510→4730600,
+// 47.520→4731200, 47.540→4732400 (same geometry as the parity fixture).
+const MULTI_ATTEMPT_IGC = [
+  'AXLK00001',
+  'HFDTE230126',
+  'B1000004729700N12200000WA0050000500', // 47.495 outside SSS
+  'B1001004730000N12200000WA0050000500', // 47.500 inside SSS
+  'B1002004730600N12200000WA0050000500', // 47.510 out → SSS crossing #1
+  'B1003004731200N12200000WA0050000500', // 47.520 TP1
+  'B1004004730000N12200000WA0050000500', // 47.500 back in → SSS crossing #2
+  'B1005004730600N12200000WA0050000500', // 47.510 out again → SSS crossing #3
+  'B1006004731200N12200000WA0050000500', // 47.520 TP1
+  'B1007004732400N12200000WA0050000500', // 47.540 GOAL
+].join('\n');
+
+describe('previewSubmission — every attempt shares the post-upload scale', () => {
+  it('applies the single taskValue/winnerRaw scale to non-best attempts (no raw-1000-scale leftovers)', async () => {
+    // Prior finisher at 120 s holds the winner raw total (2000), so the
+    // normalisation scale is well below 1 — any attempt left on the raw
+    // pipeline scale would stick out.
+    const res = await previewSubmission(
+      MULTI_ATTEMPT_IGC,
+      task,
+      { competitionType: 'XC' },
+      leaderboardEntries,
+      'new-pilot',
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.value.attempts.length).toBeGreaterThanOrEqual(2);
+
+    // Raw pipeline run with the exact inputs previewSubmission derives from
+    // the task + leaderboard (existingGoalTimes [120], best distance 3.65).
+    const parsed = parseAndValidate(MULTI_ATTEMPT_IGC);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const raw = await runPipelineFromParsed(
+      parsed.value,
+      {
+        igcText: MULTI_ATTEMPT_IGC,
+        task: { id: task.id, turnpoints: FIXTURE_TURNPOINTS },
+        existingGoalTimes: [120],
+        competitionType: 'XC',
+      },
+      FIXTURE_TASK_OPEN_DATE,
+      FIXTURE_TASK_CLOSE_DATE,
+      3.65,
+    );
+    expect(raw.ok).toBe(true);
+    if (!raw.ok) return;
+
+    const bestIdx = res.value.bestAttemptIndex;
+    expect(raw.value.bestAttemptIndex).toBe(bestIdx);
+    expect(raw.value.scoredAttempts).toHaveLength(res.value.attempts.length);
+
+    // The scale previewSubmission applied — recomputed through the same
+    // exported entry point it uses.
+    const { scale, ...bestNormalized } = normalizePreviewPoints(
+      raw.value.scoredAttempts[bestIdx],
+      leaderboardEntries,
+      'new-pilot',
+      1000,
+    );
+    expect(scale).toBeGreaterThan(0);
+    expect(scale).toBeLessThan(1); // guard: the scale actually moves the numbers
+
+    res.value.attempts.forEach((a, i) => {
+      const r = raw.value.scoredAttempts[i];
+      if (i === bestIdx) {
+        // Best attempt: the fully pooled recomputation (leaderboard values).
+        expect(a.distancePoints).toBeCloseTo(bestNormalized.distancePoints, 5);
+        expect(a.timePoints).toBeCloseTo(bestNormalized.timePoints, 5);
+        expect(a.totalPoints).toBeCloseTo(bestNormalized.totalPoints, 5);
+      } else {
+        // Non-best attempts: raw pipeline points × the SAME scale. Before
+        // the fix these came back untouched on the raw 1000-point scale.
+        expect(r.totalPoints).toBeGreaterThan(0);
+        expect(a.distancePoints).toBeCloseTo(round1(r.distancePoints * scale), 5);
+        expect(a.timePoints).toBeCloseTo(round1(r.timePoints * scale), 5);
+        expect(a.totalPoints).toBeCloseTo(round1(a.distancePoints + a.timePoints), 5);
+        expect(a.totalPoints).toBeLessThan(r.totalPoints);
+      }
+    });
   });
 });

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -125,7 +125,7 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
     expect(res.value.fixes[4].lat).toBeCloseTo(47.54, 3);
   });
 
-  it('keeps the current pilot\'s standing goal time in the t_best pool when they preview a slower flight', async () => {
+  it("keeps the current pilot's standing goal time in the t_best pool when they preview a slower flight", async () => {
     // Pilot 'me' holds t_best = 100 s and previews the fixture flight
     // (goal at ~147.2 s). The server never discards the old attempt, so:
     //   - goal-time pool stays {100, 120, 147.2} → preview raw time = 879.8
@@ -168,12 +168,7 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       mkEntry({ pilotId: 'A', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }),
       mkEntry({ pilotId: 'B', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 4500 }),
     ];
-    const r = normalizePreviewPoints(
-      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 5400 },
-      entries,
-      'A',
-      1000,
-    );
+    const r = normalizePreviewPoints({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 5400 }, entries, 'A', 1000);
 
     expect(r.distancePoints).toBeCloseTo(500, 1);
     expect(r.timePoints).toBeCloseTo(219.4, 1);
@@ -191,12 +186,7 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       mkEntry({ pilotId: 'me', distanceFlownKm: 50, reachedGoal: false }),
       mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false }),
     ];
-    const r = normalizePreviewPoints(
-      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 },
-      entries,
-      'me',
-      1000,
-    );
+    const r = normalizePreviewPoints({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }, entries, 'me', 1000);
 
     // Preview wins → winner raw = 1000 dist + 1000 time (sole goal time) =
     // 2000, scale 0.5.
@@ -241,12 +231,7 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
 
   it('treats the preview as the only candidate when the pilot has no leaderboard row', () => {
     const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
-    const r = normalizePreviewPoints(
-      { distanceFlownKm: 20, reachedGoal: false, taskTimeS: null },
-      entries,
-      'me',
-      1000,
-    );
+    const r = normalizePreviewPoints({ distanceFlownKm: 20, reachedGoal: false, taskTimeS: null }, entries, 'me', 1000);
 
     expect(r.predicted.source).toBe('preview');
     // bestDist = 40 → preview raw = 1000·sqrt(20/40) = 707.1; winner is

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -14,6 +14,13 @@ import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
 import type { ReplayFix } from '../api/track';
 
 export interface PreviewResult {
+  /**
+   * All detected attempts, with distancePoints/timePoints/totalPoints
+   * uniformly re-expressed on the post-upload leaderboard scale (the same
+   * `taskValue / winnerRaw` factor for every attempt). Only the best
+   * attempt's points feed the leaderboard; non-best attempts' points are
+   * informational.
+   */
   attempts: ScoredAttempt[];
   bestAttemptIndex: number;
   flightDate: string;
@@ -36,6 +43,13 @@ export interface PredictedStanding {
   distancePoints: number;
   timePoints: number;
   totalPoints: number;
+  /**
+   * Whether the pilot's post-upload leaderboard row would carry the ⚑ review
+   * flag. Derivable for both sources: the existing row exposes it on
+   * LeaderboardEntry, and the preview's best attempt carries it directly
+   * (truncation-voided crossings on XC, failed ground checks on HAF).
+   */
+  hasFlaggedCrossings: boolean;
 }
 
 export interface PreviewError {
@@ -91,11 +105,22 @@ function round1(n: number): number {
 // Exported for tests. `preview` only needs the scoring-relevant fields of a
 // ScoredAttempt so tests don't have to fabricate crossings.
 export function normalizePreviewPoints(
-  preview: Pick<ScoredAttempt, 'distanceFlownKm' | 'reachedGoal' | 'taskTimeS'>,
+  preview: Pick<ScoredAttempt, 'distanceFlownKm' | 'reachedGoal' | 'taskTimeS' | 'hasFlaggedCrossings'>,
   leaderboard: LeaderboardEntry[],
   currentUserId: string | undefined,
   taskValue: number,
-): { distancePoints: number; timePoints: number; totalPoints: number; predicted: PredictedStanding } {
+): {
+  distancePoints: number;
+  timePoints: number;
+  totalPoints: number;
+  /**
+   * taskValue / winner's raw total — the single post-upload scale. Callers
+   * apply it to every non-best attempt so the whole attempts array is on one
+   * scale. 0 when no attempt scores (winner raw total ≤ 0).
+   */
+  scale: number;
+  predicted: PredictedStanding;
+} {
   const existing = (currentUserId && leaderboard.find((e) => e.pilotId === currentUserId)) || null;
   const others = existing ? leaderboard.filter((e) => e !== existing) : leaderboard;
 
@@ -159,11 +184,13 @@ export function normalizePreviewPoints(
   if (winnerRaw <= 0) {
     return {
       ...zero,
+      scale: 0,
       predicted: {
         source: existingWins ? 'existing' : 'preview',
         distanceFlownKm: existingWins && existing ? existing.distanceFlownKm : preview.distanceFlownKm,
         reachedGoal: existingWins && existing ? existing.reachedGoal : preview.reachedGoal,
         taskTimeS: existingWins && existing ? existing.taskTimeS : preview.taskTimeS,
+        hasFlaggedCrossings: existingWins && existing ? existing.hasFlaggedCrossings : preview.hasFlaggedCrossings,
         ...zero,
       },
     };
@@ -184,6 +211,7 @@ export function normalizePreviewPoints(
           distanceFlownKm: existing.distanceFlownKm,
           reachedGoal: existing.reachedGoal,
           taskTimeS: existing.taskTimeS,
+          hasFlaggedCrossings: existing.hasFlaggedCrossings,
           ...normalize(existingRaw),
         }
       : {
@@ -191,10 +219,11 @@ export function normalizePreviewPoints(
           distanceFlownKm: preview.distanceFlownKm,
           reachedGoal: preview.reachedGoal,
           taskTimeS: preview.taskTimeS,
+          hasFlaggedCrossings: preview.hasFlaggedCrossings,
           ...previewNormalized,
         };
 
-  return { ...previewNormalized, predicted };
+  return { ...previewNormalized, scale, predicted };
 }
 
 // Discriminated narrow on PipelineError.stage so the compiler surfaces
@@ -266,13 +295,22 @@ export async function previewSubmission(
   // scale as the leaderboard's "Previous Best" comparison shows.
   const bestIdx = result.value.bestAttemptIndex;
   const bestAttempt = result.value.scoredAttempts[bestIdx];
-  const { predicted, ...normalized } = normalizePreviewPoints(
+  const { predicted, scale, ...normalized } = normalizePreviewPoints(
     bestAttempt,
     leaderboardEntries,
     currentUserId,
     task.taskValue ?? MAX_POINTS,
   );
-  const normalizedAttempts = result.value.scoredAttempts.map((a, i) => (i === bestIdx ? { ...a, ...normalized } : a));
+  // One scale for the whole array: the best attempt gets the fully pooled
+  // recomputation (its points are what the leaderboard would show); every
+  // other attempt has its raw pipeline points multiplied by the SAME scale so
+  // no attempt is left on the raw 1000-point scale next to normalized ones.
+  const normalizedAttempts = result.value.scoredAttempts.map((a, i) => {
+    if (i === bestIdx) return { ...a, ...normalized };
+    const distancePoints = round1(a.distancePoints * scale);
+    const timePoints = round1(a.timePoints * scale);
+    return { ...a, distancePoints, timePoints, totalPoints: round1(distancePoints + timePoints) };
+  });
 
   return {
     ok: true,

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -1,9 +1,10 @@
 // Client-side IGC scoring preview.
 //
-// Reuses the backend pipeline (src/shared/pipeline.ts) so the preview shown
-// to the pilot before they submit is the same code that the server runs
-// after they submit. The server remains authoritative — this is just so
-// the pilot can see what's going to happen first.
+// Runs the pilot's track through the same shared pipeline code the server
+// runs (src/shared/pipeline.ts), then mirrors the server's task-level
+// normalisation (rebuildTaskResults in src/job-queue.ts) from the
+// leaderboard snapshot it was given. The server remains authoritative —
+// this is just so the pilot can see what's going to happen first.
 
 import type { PipelineError, ScoredAttempt } from '../../../src/shared/pipeline';
 import { parseAndValidate, runPipelineFromParsed } from '../../../src/shared/pipeline';
@@ -17,6 +18,24 @@ export interface PreviewResult {
   bestAttemptIndex: number;
   flightDate: string;
   fixes: ReplayFix[];
+  /**
+   * What the pilot's leaderboard row would show after this upload. The server
+   * keeps a pilot's previous better attempt (compareBestAttempt in
+   * src/job-queue.ts), so this is the better of (existing row, preview) —
+   * `source: 'existing'` means the previewed flight would NOT displace the
+   * pilot's current best.
+   */
+  predicted: PredictedStanding;
+}
+
+export interface PredictedStanding {
+  source: 'preview' | 'existing';
+  distanceFlownKm: number;
+  reachedGoal: boolean;
+  taskTimeS: number | null;
+  distancePoints: number;
+  timePoints: number;
+  totalPoints: number;
 }
 
 export interface PreviewError {
@@ -52,27 +71,33 @@ function turnpointToDef(tp: Turnpoint) {
  * Best" — leading to nonsense like "less distance = more points" when the
  * existing leaderboard has been heavily compressed.
  *
- * Approach: pool the preview alongside the existing leaderboard (excluding
- * the current pilot's stale row — the preview replaces it), recompute raw
- * dist + time points for everyone using the new bestDist and the new
- * goal-time pool, find the would-be winner's raw total, scale.
+ * Approach: pool the preview alongside the FULL existing leaderboard —
+ * including the current pilot's own row. Uploads never replace prior
+ * attempts server-side: rebuildTaskResults pools goal times and best
+ * distance across ALL non-deleted attempts and keeps the pilot's previous
+ * attempt as their result when it beats the new one (compareBestAttempt).
+ * Dropping the pilot's row here would move t_best when they hold it —
+ * e.g. pilot A holds t_best = 3600 s, B in goal at 4500 s, A previews a
+ * 5400 s flight: the server keeps the pool at {3600, 4500, 5400} (A stays
+ * winner at 1000, B keeps 685.0 raw time points), whereas a pool without
+ * A's row would wrongly anchor t_best at 4500 s. The pilot's row and the
+ * preview together contribute ONE winner-scale candidate: whichever of the
+ * two the server would keep as their best attempt.
  */
 function round1(n: number): number {
   return Math.round(n * 10) / 10;
 }
 
-function normalizePreviewPoints(
-  preview: ScoredAttempt,
+// Exported for tests. `preview` only needs the scoring-relevant fields of a
+// ScoredAttempt so tests don't have to fabricate crossings.
+export function normalizePreviewPoints(
+  preview: Pick<ScoredAttempt, 'distanceFlownKm' | 'reachedGoal' | 'taskTimeS'>,
   leaderboard: LeaderboardEntry[],
   currentUserId: string | undefined,
   taskValue: number,
-): { distancePoints: number; timePoints: number; totalPoints: number } {
-  // Drop the current pilot's existing leaderboard row — their preview replaces
-  // it as their best-attempt candidate. Keeping both would double-count this
-  // pilot in the goal-time pool (potentially pinning t_best to their old,
-  // faster time) and treat their old total as a separate "competitor"
-  // against themselves.
-  const others = currentUserId ? leaderboard.filter((e) => e.pilotId !== currentUserId) : leaderboard;
+): { distancePoints: number; timePoints: number; totalPoints: number; predicted: PredictedStanding } {
+  const existing = (currentUserId && leaderboard.find((e) => e.pilotId === currentUserId)) || null;
+  const others = existing ? leaderboard.filter((e) => e !== existing) : leaderboard;
 
   // bestDist drives the non-goal distance points formula. Include the preview
   // — if it flew further than anyone else, it sets the new bestDist.
@@ -81,53 +106,95 @@ function normalizePreviewPoints(
   // non-best attempt flew further than their best attempt, the server's
   // rebuildTaskResults would see a larger bestDist via MAX(distance_flown_km)
   // over flight_attempts. The preview can't observe that without an extra API.
-  const bestDist = Math.max(preview.distanceFlownKm, ...others.map((e) => e.distanceFlownKm ?? 0), 0);
-  // Time points use the global goal-time pool. Include the preview's time if
-  // it reached goal.
+  const bestDist = Math.max(preview.distanceFlownKm, ...leaderboard.map((e) => e.distanceFlownKm ?? 0), 0);
+  // Time points use the global goal-time pool: every pilot's goal time —
+  // the current pilot's existing one included — plus the preview's if it
+  // reached goal. t_best is a min over the pool, so keeping both of the
+  // current pilot's times matches the server's per-pilot-fastest pooling.
   const allGoalTimes: number[] = [
-    ...others.filter((e) => e.reachedGoal && e.taskTimeS != null).map((e) => e.taskTimeS as number),
+    ...leaderboard.filter((e) => e.reachedGoal && e.taskTimeS != null).map((e) => e.taskTimeS as number),
     ...(preview.reachedGoal && preview.taskTimeS != null ? [preview.taskTimeS] : []),
   ];
 
-  // rebuildTaskResults rounds each total to 0.1 BEFORE picking the winner.
-  // Mirror that here so a floating-point ε doesn't shift the winner and
-  // therefore the global scale.
-  const rawTotal = (d: number, reachedGoal: boolean, t: number | null) => {
+  const rawPoints = (d: number, reachedGoal: boolean, t: number | null) => {
     const dp = computeDistancePoints(d, bestDist > 0 ? bestDist : 1, reachedGoal);
     const tp = reachedGoal && t != null ? computeTimePoints(t, allGoalTimes) : 0;
-    return round1(dp + tp);
+    return { dp, tp };
+  };
+  // rebuildTaskResults keeps raw totals at full precision (rounding to 0.1
+  // happens exactly once, on the persisted post-normalisation values) —
+  // mirror that so the winner pick and scale match the server's.
+  const rawTotal = (d: number, reachedGoal: boolean, t: number | null) => {
+    const { dp, tp } = rawPoints(d, reachedGoal, t);
+    return dp + tp;
   };
 
-  const previewRawDist = computeDistancePoints(
-    preview.distanceFlownKm,
-    bestDist > 0 ? bestDist : 1,
-    preview.reachedGoal,
-  );
-  const previewRawTime =
-    preview.reachedGoal && preview.taskTimeS != null ? computeTimePoints(preview.taskTimeS, allGoalTimes) : 0;
-  const previewRawTotal = round1(previewRawDist + previewRawTime);
+  const previewRaw = rawPoints(preview.distanceFlownKm, preview.reachedGoal, preview.taskTimeS);
+  const previewRawTotal = previewRaw.dp + previewRaw.tp;
 
-  // Winner total across (existing best per pilot) + (this preview). Same
-  // formula rebuildTaskResults uses; we treat the preview as a candidate
-  // attempt — if it wins, it becomes the basis for the new scale.
-  let winnerRaw = previewRawTotal;
+  // Server best-attempt order (compareBestAttempt in src/job-queue.ts):
+  // reached goal first, then higher total, then lower task time — ties keep
+  // the existing attempt.
+  const existingRaw = existing ? rawPoints(existing.distanceFlownKm, existing.reachedGoal, existing.taskTimeS) : null;
+  const existingRawTotal = existingRaw ? existingRaw.dp + existingRaw.tp : null;
+  const existingWins =
+    existing != null &&
+    existingRawTotal != null &&
+    (existing.reachedGoal !== preview.reachedGoal
+      ? existing.reachedGoal
+      : existingRawTotal !== previewRawTotal
+        ? existingRawTotal > previewRawTotal
+        : (existing.taskTimeS ?? Number.POSITIVE_INFINITY) <= (preview.taskTimeS ?? Number.POSITIVE_INFINITY));
+
+  // Winner total across each pilot's would-be best attempt. The current
+  // pilot contributes one candidate: whichever of (existing row, preview)
+  // the server would keep.
+  let winnerRaw = existingWins && existingRawTotal != null ? existingRawTotal : previewRawTotal;
   for (const e of others) {
     const r = rawTotal(e.distanceFlownKm, e.reachedGoal, e.taskTimeS);
     if (r > winnerRaw) winnerRaw = r;
   }
 
+  const zero = { distancePoints: 0, timePoints: 0, totalPoints: 0 };
   if (winnerRaw <= 0) {
-    return { distancePoints: 0, timePoints: 0, totalPoints: 0 };
+    return {
+      ...zero,
+      predicted: {
+        source: existingWins ? 'existing' : 'preview',
+        distanceFlownKm: existingWins && existing ? existing.distanceFlownKm : preview.distanceFlownKm,
+        reachedGoal: existingWins && existing ? existing.reachedGoal : preview.reachedGoal,
+        taskTimeS: existingWins && existing ? existing.taskTimeS : preview.taskTimeS,
+        ...zero,
+      },
+    };
   }
 
   const scale = taskValue / winnerRaw;
-  const distancePoints = round1(previewRawDist * scale);
-  const timePoints = round1(previewRawTime * scale);
-  return {
-    distancePoints,
-    timePoints,
-    totalPoints: round1(distancePoints + timePoints),
+  const normalize = (raw: { dp: number; tp: number }) => {
+    const distancePoints = round1(raw.dp * scale);
+    const timePoints = round1(raw.tp * scale);
+    return { distancePoints, timePoints, totalPoints: round1(distancePoints + timePoints) };
   };
+
+  const previewNormalized = normalize(previewRaw);
+  const predicted: PredictedStanding =
+    existingWins && existing && existingRaw
+      ? {
+          source: 'existing',
+          distanceFlownKm: existing.distanceFlownKm,
+          reachedGoal: existing.reachedGoal,
+          taskTimeS: existing.taskTimeS,
+          ...normalize(existingRaw),
+        }
+      : {
+          source: 'preview',
+          distanceFlownKm: preview.distanceFlownKm,
+          reachedGoal: preview.reachedGoal,
+          taskTimeS: preview.taskTimeS,
+          ...previewNormalized,
+        };
+
+  return { ...previewNormalized, predicted };
 }
 
 // Discriminated narrow on PipelineError.stage so the compiler surfaces
@@ -199,7 +266,7 @@ export async function previewSubmission(
   // scale as the leaderboard's "Previous Best" comparison shows.
   const bestIdx = result.value.bestAttemptIndex;
   const bestAttempt = result.value.scoredAttempts[bestIdx];
-  const normalized = normalizePreviewPoints(
+  const { predicted, ...normalized } = normalizePreviewPoints(
     bestAttempt,
     leaderboardEntries,
     currentUserId,
@@ -214,6 +281,7 @@ export async function previewSubmission(
       bestAttemptIndex: bestIdx,
       flightDate: result.value.flightDate,
       fixes,
+      predicted,
     },
   };
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -641,6 +641,7 @@ export default function HomePage() {
               result={previewResult}
               error={previewError}
               previousBest={previousBestEntry}
+              predicted={previewResult?.predicted ?? null}
               uploading={uploading}
               onSubmit={handleSubmitPreview}
               onCancel={() => {

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -259,18 +259,22 @@ interface ScoredAttemptRow {
   total_points: number;
 }
 
+// One decimal place, per S7F §12 — the only rounding in the scoring path.
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
 // Goal first, then highest points, then fastest time (NULLs last).
 // Returns negative if a is the better attempt.
 //
 // Note: this priority order intentionally differs from the rank-sort below
-// (which is total_points → task_time_s → reached_goal). For the *picker*
-// goal-attempt > non-goal-attempt is meaningful even at equal total_points
-// because we want the goal-recording attempt's metadata (task_time_s,
-// crossings) preferred. For the *rank* a goal pilot's total_points already
-// exceeds any non-goal pilot's by construction, so the reached_goal tier is
-// never load-bearing — kept only as a final tiebreaker. If a future scoring
-// change ever lets non-goal pilots out-score goal pilots, this divergence
-// will need a second look.
+// (which is total_points → goal pilots' task_time_s → reached_goal). For the
+// *picker* goal-attempt > non-goal-attempt is meaningful even at equal
+// total_points because we want the goal-recording attempt's metadata
+// (task_time_s, crossings) preferred. In the *rank*, reached_goal is
+// load-bearing: under the §12.2 absolute cutoff a slow goal pilot scores 0
+// time points and can tie a bestDist non-goal pilot on total_points — the
+// goal pilot then ranks first via the reached_goal tier.
 function compareBestAttempt(a: ScoredAttemptRow, b: ScoredAttemptRow): number {
   if (a.reached_goal !== b.reached_goal) return b.reached_goal - a.reached_goal;
   if (a.total_points !== b.total_points) return b.total_points - a.total_points;
@@ -322,11 +326,16 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   }
   const goalTimes = Array.from(fastestGoalTimeByPilot.values());
 
+  // Points stay at full precision here — best-attempt selection and the
+  // normalisation scale both work on unrounded values so that rounding to
+  // one decimal happens exactly once, on the persisted result (S7F
+  // round-once principle; rounding before scaling compounds to ~0.2 pt of
+  // error, enough to flip adjacent ranks).
   const scored: ScoredAttemptRow[] = attempts.map((a) => {
     const distance_points = computeDistancePoints(a.distance_flown_km, bestDistKm, a.reached_goal === 1);
     const time_points =
       a.reached_goal === 1 && a.task_time_s !== null ? computeTimePoints(a.task_time_s, goalTimes) : 0;
-    const total_points = Math.round((distance_points + time_points) * 10) / 10;
+    const total_points = distance_points + time_points;
     return { ...a, distance_points, time_points, total_points };
   });
 
@@ -353,23 +362,30 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
     // reduce, not Math.max(...arr): see note at bestDistKm above.
     let winnerTotal = 0;
     for (const r of bestList) if (r.total_points > winnerTotal) winnerTotal = r.total_points;
-    if (winnerTotal > 0) {
-      const scale = normalized / winnerTotal;
-      bestList = bestList.map((r) => {
-        const distance_points = Math.round(r.distance_points * scale * 10) / 10;
-        const time_points = Math.round(r.time_points * scale * 10) / 10;
-        const total_points = Math.round((distance_points + time_points) * 10) / 10;
-        return { ...r, distance_points, time_points, total_points };
-      });
-    }
+    // Scale the raw (unrounded) components, then round each once and
+    // re-derive total from the rounded components so dp + tp = total holds
+    // exactly on persisted rows. winnerTotal = 0 means every component is
+    // exactly 0, so scale = 1 is a safe passthrough there.
+    const scale = winnerTotal > 0 ? normalized / winnerTotal : 1;
+    bestList = bestList.map((r) => {
+      const distance_points = round1(r.distance_points * scale);
+      const time_points = round1(r.time_points * scale);
+      const total_points = round1(distance_points + time_points);
+      return { ...r, distance_points, time_points, total_points };
+    });
   }
 
-  // Rank by total_points DESC, task_time_s ASC (NULLs last), reached_goal DESC.
+  // Rank by total_points DESC, task_time_s ASC (goal pilots only, NULLs last),
+  // reached_goal DESC. task_time_s is stored for any ESS crossing, including
+  // pilots who landed short of goal — but §13.1 sets the PG time-points
+  // parameter to 0%, so a speed-section time must earn nothing (not even rank
+  // order) without reaching goal. Treat non-goal times as absent.
   // Ties share a rank (RANK semantics, matching the previous SQL window).
+  const rankTimeS = (r: ScoredAttemptRow): number | null => (r.reached_goal === 1 ? r.task_time_s : null);
   bestList.sort((a, b) => {
     if (b.total_points !== a.total_points) return b.total_points - a.total_points;
-    const at = a.task_time_s ?? Number.POSITIVE_INFINITY;
-    const bt = b.task_time_s ?? Number.POSITIVE_INFINITY;
+    const at = rankTimeS(a) ?? Number.POSITIVE_INFINITY;
+    const bt = rankTimeS(b) ?? Number.POSITIVE_INFINITY;
     if (at !== bt) return at - bt;
     return b.reached_goal - a.reached_goal;
   });
@@ -388,7 +404,7 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   let prevRank = 0;
   for (let i = 0; i < bestList.length; i++) {
     const r = bestList[i];
-    const key = `${r.total_points}|${r.task_time_s ?? 'null'}|${r.reached_goal}`;
+    const key = `${r.total_points}|${rankTimeS(r) ?? 'null'}|${r.reached_goal}`;
     const rank = key === prevKey ? prevRank : i + 1;
     prevKey = key;
     prevRank = rank;

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -1769,12 +1769,14 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       // Verify task belongs to this season/league
       const existingTask = db
         .prepare(
-          `SELECT t.id, t.open_date, t.close_date
+          `SELECT t.id, t.open_date, t.close_date, t.normalized_score
          FROM tasks t
          JOIN seasons s ON s.id = t.season_id
          WHERE t.id = ? AND t.season_id = ? AND s.league_id = ? AND t.deleted_at IS NULL`,
         )
-        .get(taskId, seasonId, league.id) as { id: string; open_date: string; close_date: string } | undefined;
+        .get(taskId, seasonId, league.id) as
+        | { id: string; open_date: string; close_date: string; normalized_score: number | null }
+        | undefined;
 
       if (!existingTask) {
         return reply.status(404).send({ error: 'Task not found' });
@@ -1867,7 +1869,17 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
       updates.push("updated_at = datetime('now')");
       params.push(taskId);
 
-      db.prepare(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`).run(...params);
+      // task_results rows store points pre-scaled by normalized_score, so a
+      // changed task value must rescale them immediately — otherwise the
+      // leaderboard and standings stay on the old scale until the next
+      // upload/delete/restart triggers a rebuild.
+      const taskValueChanged =
+        body.taskValue !== undefined && (body.taskValue ?? null) !== existingTask.normalized_score;
+
+      db.transaction(() => {
+        db.prepare(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`).run(...params);
+        if (taskValueChanged) rebuildTaskResults(db, taskId);
+      })();
 
       const task = db
         .prepare(

--- a/src/shared/pipeline.test.ts
+++ b/src/shared/pipeline.test.ts
@@ -193,6 +193,6 @@ describe('tagToleranceM', () => {
 describe('SCORER_VERSION', () => {
   it('is set so the boot reprocess loop has a concrete current value to compare', () => {
     // If you bump the version intentionally, update this expectation.
-    expect(SCORER_VERSION).toBe('1.2');
+    expect(SCORER_VERSION).toBe('1.3');
   });
 });

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -25,7 +25,7 @@ import {
 // whose stored flight_attempts.scorer_version differs from this constant.
 // =============================================================================
 
-export const SCORER_VERSION = '1.2';
+export const SCORER_VERSION = '1.3';
 
 // Re-export so existing `import { tagToleranceM } from './shared/pipeline'`
 // paths keep working. The canonical helper lives in `./task-engine`.
@@ -273,57 +273,120 @@ export interface AttemptTrace {
   lastTurnpointIndex: number;
   taskTimeS: number | null; // (ESS or goal crossing time - SSS crossing time) / 1000
   distanceFlownKm: number; // populated by calculateDistances (initialised to 0 here)
+  // XC only: the GLOBAL landing cutoff for the whole track — the start of the
+  // first landing-stillness window (≥ 30 s of every fix below 5 km/h with a
+  // gpsAlt range under 15 m) that begins at/after the track's first valid SSS
+  // crossing. A §12.1 XC flight ends at the first landing, so the same cutoff
+  // applies to every attempt: fixes and crossings from this timestamp onward
+  // are post-landing and dead, and attempts whose SSS crossing postdates the
+  // cutoff are suppressed before they exist. null when the pilot never went
+  // still, or for HAF where ground travel is legitimate.
+  landingCutoffMs?: number | null;
+  // Set when the landing cutoff voided at least one otherwise-valid crossing
+  // (a turnpoint/goal crossing past the cutoff, or a whole suppressed
+  // attempt). Surfaces as hasFlaggedCrossings (⚑) so admins can review the
+  // truncation instead of it failing silently. Distance-only truncation
+  // (no voided crossing) does not set it.
+  truncationVoidedCrossing?: boolean;
 }
 
 /**
  * Stage 3: detectAttempts
  *
- * For each SSS outward crossing:
+ * For each SSS boundary crossing (either direction — §6.2.1/§9.2.1 make the
+ * crossing direction irrelevant, so entry-style starts work too):
  *   - Greedily match remaining TPs forward using segment-circle intersection
  *   - Build an AttemptTrace per SSS crossing
  */
-export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<AttemptTrace[], AttemptDetectionError> {
+export function detectAttempts(
+  fixes: Fix[],
+  task: TaskDefinition,
+  competitionType: 'XC' | 'HIKE_AND_FLY',
+): Result<AttemptTrace[], AttemptDetectionError> {
   if (task.turnpoints.length < 2) {
     return err({ code: 'NO_SSS_CROSSING', message: 'Task has fewer than 2 turnpoints' });
   }
 
   const sss = task.turnpoints[0];
 
-  // ── Step 1: Find all SSS outward crossings ──────────────────────────────────
+  // ── Step 1: Find all SSS boundary crossings ─────────────────────────────────
   // FAI Sporting Code S7F §9.1.3 tolerance: a fix at distance d from the
   // cylinder centre is "inside" iff d ≤ r + tolerance. The boundary effectively
-  // shifts outward by `tagToleranceM(r)`. For SSS this means the exit gate
-  // widens — pilots get the benefit of the doubt that they are still inside
+  // shifts outward by `tagToleranceM(r)` — pilots get the benefit of the doubt
   // near the boundary.
+  //
+  // §6.2.1/§9.2.1: a valid crossing is "into or out of the turnpoint's
+  // tolerance zone, in any direction". Every boundary crossing — entry, exit,
+  // or both legs of a graze-through — spawns an attempt; Stage 7 picks the
+  // best, so extra attempts are harmless.
+  //
+  // Movement gate (XC only): an XC start is flown, not walked. A boundary
+  // crossing only spawns an attempt when the crossing segment shows movement
+  // — the faster of its two endpoint fixes is at least
+  // SSS_CROSSING_MIN_SPEED_KMH. This ignores on-foot crossings (~4–6 km/h
+  // walk-in to an entry-style start) and parked-drift crossings, which
+  // previously anchored the landing scan at launch prep and silently zeroed
+  // the whole flight; a walk-in track now gets the explicit NO_SSS_CROSSING
+  // error again. Accepted edge: a pilot parked exactly on the boundary in
+  // strong wind loses that particular crossing and starts on a later one. A
+  // fix with an unknown speed passes the gate (benefit of the doubt). HAF is
+  // exempt — travelling on foot is the point of the game there.
   const sssCrossings: Array<{ fixIndex: number; t: number; crossingTime: number }> = [];
   const sssEffectiveR = sss.radiusM + tagToleranceM(sss.radiusM);
+  const applyMovementGate = competitionType === 'XC';
 
   for (let i = 0; i < fixes.length - 1; i++) {
     const a = fixes[i];
     const b = fixes[i + 1];
+    const segmentMaxSpeed = Math.max(
+      a.derivedSpeedKmh ?? Number.POSITIVE_INFINITY,
+      b.derivedSpeedKmh ?? Number.POSITIVE_INFINITY,
+    );
+    if (applyMovementGate && segmentMaxSpeed < SSS_CROSSING_MIN_SPEED_KMH) continue;
     const aLocal = projectToLocal(a.lat, a.lng, sss.lat, sss.lng);
     const bLocal = projectToLocal(b.lat, b.lng, sss.lat, sss.lng);
-    const distA = Math.sqrt(aLocal.x ** 2 + aLocal.y ** 2);
-    const distB = Math.sqrt(bLocal.x ** 2 + bLocal.y ** 2);
 
-    // Outward: inside → outside (against the effective boundary)
-    if (distA <= sssEffectiveR && distB > sssEffectiveR) {
-      const t = segmentIntersectsCircle(aLocal, bLocal, sssEffectiveR);
-      if (t !== null) {
-        sssCrossings.push({ fixIndex: i, t, crossingTime: interpolateCrossingTime(a, b, t) });
-      }
+    for (const t of segmentCircleBoundaryCrossings(aLocal, bLocal, sssEffectiveR)) {
+      sssCrossings.push({ fixIndex: i, t, crossingTime: interpolateCrossingTime(a, b, t) });
     }
   }
 
   if (sssCrossings.length === 0) {
-    return err({ code: 'NO_SSS_CROSSING', message: 'No SSS outward cylinder crossing was detected in the track' });
+    return err({ code: 'NO_SSS_CROSSING', message: 'No SSS cylinder crossing was detected in the track' });
   }
+
+  // XC: a landed pilot's later fixes (packing up, walking, car retrieve)
+  // must not earn crossings or distance — §9.3 counts only points "where
+  // the pilot is still flying", §12.1 only "up until the pilot landed".
+  // The landing is GLOBAL to the track: the start of the first
+  // landing-stillness window (≥ 30 s in which every fix is below 5 km/h
+  // AND the gpsAlt range stays under 15 m — a glider parked in ridge lift
+  // bobs in altitude; a landed pilot's GPS alt is flat within noise) that
+  // begins at/after the FIRST valid SSS crossing. Anchoring at the first
+  // crossing keeps pre-launch rigging stillness out of scope; using one
+  // cutoff for every attempt means a post-landing retrieve that re-crosses
+  // the SSS boundary can never spawn a scoreable attempt.
+  // HAF is exempt: travelling on the ground is part of the game there.
+  const landingCutoffMs =
+    competitionType === 'XC'
+      ? findLandingCutoffMs(fixes.filter((f) => f.timestamp >= sssCrossings[0].crossingTime))
+      : null;
 
   // ── Step 2: For each SSS crossing, greedily match remaining TPs ────────────
   const attempts: AttemptTrace[] = [];
+  // §12.1: the XC flight ended at the landing, so an SSS crossing at/after
+  // the cutoff is on the ground and can never start a valid attempt. The
+  // suppressed crossing itself passed the movement gate, so the suppression
+  // voids an otherwise-valid crossing — flag the surviving attempts (⚑) so
+  // the truncation is visible for review.
+  let suppressedAttempt = false;
 
   for (let ai = 0; ai < sssCrossings.length; ai++) {
     const sssCross = sssCrossings[ai];
+    if (landingCutoffMs !== null && sssCross.crossingTime >= landingCutoffMs) {
+      suppressedAttempt = true;
+      continue;
+    }
 
     const sssCrossing: CylinderCrossing = {
       turnpointId: sss.id,
@@ -341,6 +404,14 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
     let reachedGoal = false;
     let essCrossing: CylinderCrossing | null = null;
     let goalCrossing: CylinderCrossing | null = null;
+
+    // §9.2.1.2a: each crossing must be recorded strictly after the previous
+    // cylinder's crossing (and hence after the start itself).
+    let lastCrossingTimeMs = sssCrossing.crossingTime;
+
+    // Set when the landing cutoff voids an otherwise-valid crossing for
+    // this attempt — surfaces as ⚑ instead of a silent rescore.
+    let truncationVoidedCrossing = false;
 
     // Pre-compute goal line bearing once per attempt (avoid re-running optimiseRoute per segment)
     const goalTp = task.turnpoints[task.turnpoints.length - 1];
@@ -367,7 +438,10 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
       }
     }
 
-    // Use while loop so we can re-check the same fix-pair after a TP is achieved
+    // Use while loop so we can re-check the same fix-pair after a TP is achieved.
+    // The scan deliberately continues PAST the landing cutoff: a would-be
+    // crossing found beyond it is voided (never recorded), but its existence
+    // flags the attempt so the truncation is visible for review.
     let fixI = sssCross.fixIndex;
     while (fixI < fixes.length - 1 && tpIdx < task.turnpoints.length) {
       const tp = task.turnpoints[tpIdx];
@@ -413,17 +487,62 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
       }
 
       if (crossed && crossT !== null) {
+        let crossingTime = interpolateCrossingTime(a, b, crossT);
+        // §9.2.1.2a: a crossing must be recorded strictly after the previous
+        // cylinder's crossing (and hence after the start itself) — same-
+        // segment re-checks and already-inside tags can otherwise stamp a
+        // time at or before the previous crossing, shortening (or negating)
+        // task time. A premature candidate does NOT abandon the segment:
+        // §6.2.1 makes every boundary root a crossing in its own right, so
+        // re-consult ALL of the segment's boundary roots and accept the
+        // earliest one that postdates the previous crossing. This covers a
+        // graze-through whose entry root is pre-start but whose exit root is
+        // valid, and an already-inside segment-start fix where the pilot
+        // exits the zone before the next fix. Only when no root on the
+        // segment qualifies do we advance to the next fix (a pilot still
+        // inside the cylinder then picks the tag up at the first fix that
+        // postdates the previous crossing). GOAL_LINE candidates come from
+        // chord/arc geometry rather than a cylinder boundary, so they have
+        // no extra roots to retry.
+        if (crossingTime <= lastCrossingTimeMs) {
+          let retriedTime: number | null = null;
+          if (tp.type !== 'GOAL_LINE') {
+            for (const t of segmentCircleBoundaryCrossings(aLocal, bLocal, effectiveR)) {
+              const candidateTime = interpolateCrossingTime(a, b, t);
+              if (candidateTime > lastCrossingTimeMs) {
+                retriedTime = candidateTime;
+                break;
+              }
+            }
+          }
+          if (retriedTime === null) {
+            fixI++;
+            continue;
+          }
+          crossingTime = retriedTime;
+        }
+
+        // §9.3/§12.1: a crossing at/after the landing cutoff is on the
+        // ground. It is otherwise valid (in order, past the gate), so void
+        // it, flag the attempt for review, and stop — everything beyond the
+        // landing is dead for scoring.
+        if (landingCutoffMs !== null && crossingTime >= landingCutoffMs) {
+          truncationVoidedCrossing = true;
+          break;
+        }
+
         const groundCheckRequired = tp.forceGround === true;
         const crossing: CylinderCrossing = {
           turnpointId: tp.id,
           sequenceIndex: tp.sequenceIndex,
-          crossingTime: interpolateCrossingTime(a, b, crossT),
+          crossingTime,
           segmentStartFix: a,
           segmentEndFix: b,
           groundCheckRequired,
           detectedMaxSpeedKmh: null,
           groundConfirmed: !groundCheckRequired,
         };
+        lastCrossingTimeMs = crossingTime;
 
         turnpointCrossings.push(crossing);
 
@@ -451,7 +570,9 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
     const taskTimeS = timingCrossing !== null ? (timingCrossing.crossingTime - sssCrossing.crossingTime) / 1000 : null;
 
     attempts.push({
-      attemptIndex: ai,
+      // attempts.length, not the crossing index: suppressed crossings leave
+      // gaps in `ai`, and attemptIndex must stay contiguous for persistence.
+      attemptIndex: attempts.length,
       sssCrossing,
       essCrossing,
       goalCrossing,
@@ -460,7 +581,24 @@ export function detectAttempts(fixes: Fix[], task: TaskDefinition): Result<Attem
       lastTurnpointIndex,
       taskTimeS,
       distanceFlownKm: 0, // populated by calculateDistances
+      landingCutoffMs,
+      truncationVoidedCrossing,
     });
+  }
+
+  if (attempts.length === 0) {
+    // Every gate-passing SSS crossing postdated the landing — degenerate,
+    // but surface the same explicit error a crossing-free track gets.
+    return err({
+      code: 'NO_SSS_CROSSING',
+      message: 'No SSS cylinder crossing was detected before the landing',
+    });
+  }
+
+  if (suppressedAttempt) {
+    // A whole attempt was voided by the landing cutoff — make the
+    // suppression visible on everything that survives.
+    for (const attempt of attempts) attempt.truncationVoidedCrossing = true;
   }
 
   return ok(attempts);
@@ -513,6 +651,27 @@ export function segmentIntersectsCircle(a: Point2D, b: Point2D, r: number): numb
   if (t1 >= 0 && t1 <= 1) return t1;
   if (t2 >= 0 && t2 <= 1) return t2;
   return null;
+}
+
+/**
+ * Every parameter t ∈ [0,1] at which segment A→B crosses the boundary of a
+ * circle of radius r centred at origin, in ascending order (0, 1, or 2
+ * entries). Unlike `segmentIntersectsCircle`, this reports both legs of a
+ * graze-through (both endpoints outside, segment clipping the circle) — each
+ * root is a boundary crossing in its own right. A tangent touch (zero
+ * discriminant) is not a crossing and yields no entries.
+ */
+export function segmentCircleBoundaryCrossings(a: Point2D, b: Point2D, r: number): number[] {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const qa = dx * dx + dy * dy;
+  if (qa === 0) return [];
+  const qb = 2 * (a.x * dx + a.y * dy);
+  const qc = a.x * a.x + a.y * a.y - r * r;
+  const disc = qb * qb - 4 * qa * qc;
+  if (disc <= 0) return [];
+  const sqrtDisc = Math.sqrt(disc);
+  return [(-qb - sqrtDisc) / (2 * qa), (-qb + sqrtDisc) / (2 * qa)].filter((t) => t >= 0 && t <= 1);
 }
 
 /**
@@ -733,6 +892,17 @@ export function geodesicDistanceM(lat1: number, lng1: number, lat2: number, lng2
 
 const SUSTAINED_STILLNESS_WINDOW_S = 20;
 const SUSTAINED_STILLNESS_SPEED_KMH = 5;
+// XC landing detection (Stage 3). Deliberately stricter than HAF ground
+// confirmation: a HAF false negative merely flags a crossing for review,
+// whereas an XC landing false positive silently discards flight. The longer
+// window plus altitude flatness keeps a glider parked in ridge lift (steady
+// 0–4 km/h ground speed but bobbing in lift) from reading as landed.
+const LANDING_STILLNESS_WINDOW_S = 30;
+const LANDING_MAX_ALT_RANGE_M = 15;
+// Stage 3 movement gate: minimum endpoint ground speed for an SSS boundary
+// crossing to spawn an attempt. Walking pace is ~4–6 km/h; slow flight in
+// wind stays comfortably above this.
+const SSS_CROSSING_MIN_SPEED_KMH = 8;
 const EARTH_RADIUS_M = 6_371_000;
 const DEG_RAD = Math.PI / 180;
 
@@ -748,23 +918,96 @@ function fixDistanceToTpM(fix: Fix, tp: TurnpointDef): number {
 }
 
 /**
- * Does the fix sequence contain a continuous run of at least
- * SUSTAINED_STILLNESS_WINDOW_S seconds where every fix has ground speed
- * below SUSTAINED_STILLNESS_SPEED_KMH? Expects fixes in ascending time order.
+ * Start timestamp of the first continuous run of at least
+ * SUSTAINED_STILLNESS_WINDOW_S seconds in which every fix has ground speed
+ * below SUSTAINED_STILLNESS_SPEED_KMH, or null if the fixes contain no such
+ * run. Expects fixes in ascending time order.
+ *
+ * Stage 4 uses this to confirm a HAF touch-down inside a force-ground
+ * cylinder. Stage 3's XC landing detection uses the stricter
+ * `findLandingCutoffMs` instead — see the constants above for why the two
+ * signatures differ.
  */
-function hasSustainedStillness(fixes: Fix[]): boolean {
+function findSustainedStillnessStartMs(fixes: Fix[]): number | null {
   const windowMs = SUSTAINED_STILLNESS_WINDOW_S * 1000;
   let runStart: number | null = null;
   for (const f of fixes) {
     const speed = f.derivedSpeedKmh ?? Number.POSITIVE_INFINITY;
     if (speed < SUSTAINED_STILLNESS_SPEED_KMH) {
       if (runStart === null) runStart = f.timestamp;
-      else if (f.timestamp - runStart >= windowMs) return true;
+      else if (f.timestamp - runStart >= windowMs) return runStart;
     } else {
       runStart = null;
     }
   }
-  return false;
+  return null;
+}
+
+/**
+ * Does the fix sequence contain a continuous run of at least
+ * SUSTAINED_STILLNESS_WINDOW_S seconds where every fix has ground speed
+ * below SUSTAINED_STILLNESS_SPEED_KMH? Expects fixes in ascending time order.
+ */
+function hasSustainedStillness(fixes: Fix[]): boolean {
+  return findSustainedStillnessStartMs(fixes) !== null;
+}
+
+/**
+ * XC landing detection: start timestamp of the first landing-stillness
+ * window in the fix sequence, or null when the pilot never landed on camera.
+ *
+ * A landing-stillness window is ≥ LANDING_STILLNESS_WINDOW_S seconds in
+ * which EVERY fix has ground speed below SUSTAINED_STILLNESS_SPEED_KMH AND
+ * the gpsAlt spread across the window is under LANDING_MAX_ALT_RANGE_M.
+ * Speed alone false-positives on a glider parked in strong laminar wind
+ * (steady 0–4 km/h over the ground); the altitude-flatness requirement
+ * breaks that case, because a parked glider rides the lift band up and down
+ * while a landed pilot's GPS altitude is flat within receiver noise.
+ *
+ * The caller pre-filters the fixes to those at/after the first valid SSS
+ * crossing, so a window straddling that boundary only counts from its
+ * post-crossing portion. Expects fixes in ascending time order.
+ */
+function findLandingCutoffMs(fixes: Fix[]): number | null {
+  const windowMs = LANDING_STILLNESS_WINDOW_S * 1000;
+
+  // Walk the low-speed runs; within each, look for the earliest sub-window
+  // that satisfies both the duration and the altitude-flatness constraints.
+  let runStartIdx: number | null = null;
+  for (let i = 0; i <= fixes.length; i++) {
+    const isStill =
+      i < fixes.length && (fixes[i].derivedSpeedKmh ?? Number.POSITIVE_INFINITY) < SUSTAINED_STILLNESS_SPEED_KMH;
+    if (isStill) {
+      if (runStartIdx === null) runStartIdx = i;
+      continue;
+    }
+    if (runStartIdx !== null) {
+      const start = earliestFlatWindowStartMs(fixes, runStartIdx, i - 1, windowMs);
+      if (start !== null) return start;
+      runStartIdx = null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Earliest window start within fixes[lo..hi] (an all-below-stillness-speed
+ * run) whose duration reaches windowMs while the gpsAlt spread stays under
+ * LANDING_MAX_ALT_RANGE_M, or null. O(run × window) — runs are seconds-to-
+ * minutes of 1 Hz fixes, so this is cheap.
+ */
+function earliestFlatWindowStartMs(fixes: Fix[], lo: number, hi: number, windowMs: number): number | null {
+  for (let i = lo; i <= hi; i++) {
+    let minAlt = fixes[i].gpsAlt;
+    let maxAlt = fixes[i].gpsAlt;
+    for (let j = i + 1; j <= hi; j++) {
+      minAlt = Math.min(minAlt, fixes[j].gpsAlt);
+      maxAlt = Math.max(maxAlt, fixes[j].gpsAlt);
+      if (maxAlt - minAlt >= LANDING_MAX_ALT_RANGE_M) break; // this start can't flatten out again
+      if (fixes[j].timestamp - fixes[i].timestamp >= windowMs) return fixes[i].timestamp;
+    }
+  }
+  return null;
 }
 
 /**
@@ -865,8 +1108,13 @@ export function calculateDistances(attempts: AttemptTrace[], fixes: Fix[], task:
     }
 
     const sssTime = attempt.sssCrossing.crossingTime;
+    // §9.3 sweeps only points "where the pilot is still flying": lower-bound
+    // the scan at this attempt's start and upper-bound it at the landing
+    // cutoff detectAttempts found (null for HAF and for pilots who never went
+    // still), so retrieve fixes can't shrink the remaining distance.
+    const cutoffMs = attempt.landingCutoffMs ?? null;
     const pilotFixes = fixes
-      .filter((f) => f.timestamp >= sssTime)
+      .filter((f) => f.timestamp >= sssTime && (cutoffMs === null || f.timestamp < cutoffMs))
       .map((f) => ({ lat: f.lat, lng: f.lng, timestamp: f.timestamp }));
 
     // FAI §9.3: feed the ordered (sequenceIndex, crossingTime) pairs so the
@@ -929,7 +1177,11 @@ export function scoreAttempts(
       distancePoints,
       timePoints,
       totalPoints: distancePoints + timePoints,
-      hasFlaggedCrossings: attempt.turnpointCrossings.some((c) => c.groundCheckRequired && !c.groundConfirmed),
+      // ⚑ for review: a HAF ground check failed, or the XC landing cutoff
+      // voided an otherwise-valid crossing (truncation must not be silent).
+      hasFlaggedCrossings:
+        attempt.turnpointCrossings.some((c) => c.groundCheckRequired && !c.groundConfirmed) ||
+        attempt.truncationVoidedCrossing === true,
     };
   });
 }
@@ -1037,7 +1289,7 @@ export async function runPipelineFromParsed(
   if (!dateResult.ok) return err({ stage: 'DATE', error: dateResult.error });
 
   // Stage 3: Attempt detection
-  const detectionResult = detectAttempts(track.fixes, input.task);
+  const detectionResult = detectAttempts(track.fixes, input.task, input.competitionType);
   if (!detectionResult.ok) return err({ stage: 'DETECTION', error: detectionResult.error });
   let attempts = detectionResult.value;
 

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -275,19 +275,39 @@ export interface AttemptTrace {
   distanceFlownKm: number; // populated by calculateDistances (initialised to 0 here)
   // XC only: the GLOBAL landing cutoff for the whole track — the start of the
   // first landing-stillness window (≥ 30 s of every fix below 5 km/h with a
-  // gpsAlt range under 15 m) that begins at/after the track's first valid SSS
-  // crossing. A §12.1 XC flight ends at the first landing, so the same cutoff
-  // applies to every attempt: fixes and crossings from this timestamp onward
-  // are post-landing and dead, and attempts whose SSS crossing postdates the
+  // gpsAlt range under 15 m) at/after the accepted anchor SSS crossing. The
+  // anchor is self-correcting: a stillness window with no flight evidence in
+  // front of it (no course progress) is pre-flight ground time, not a
+  // landing, and the scan re-anchors past it — see detectAttempts Step 3.
+  // A §12.1 XC flight ends at the first landing, so the same cutoff applies
+  // to every attempt: fixes and crossings from this timestamp onward are
+  // post-landing and dead, and attempts whose SSS crossing postdates the
   // cutoff are suppressed before they exist. null when the pilot never went
   // still, or for HAF where ground travel is legitimate.
   landingCutoffMs?: number | null;
   // Set when the landing cutoff voided at least one otherwise-valid crossing
-  // (a turnpoint/goal crossing past the cutoff, or a whole suppressed
-  // attempt). Surfaces as hasFlaggedCrossings (⚑) so admins can review the
-  // truncation instead of it failing silently. Distance-only truncation
-  // (no voided crossing) does not set it.
+  // this attempt could have counted: a turnpoint/goal crossing past the
+  // cutoff found by the attempt's own scan, or — for attempts that did NOT
+  // reach goal — a whole suppressed post-landing attempt (the suppressed
+  // crossing might have been their real flight). Attempts that reached goal
+  // are not flagged by suppression alone: a post-landing SSS re-cross cannot
+  // have affected a score that was sealed at the goal crossing. Surfaces as
+  // hasFlaggedCrossings (⚑) so admins can review the truncation instead of
+  // it failing silently. Distance-only truncation (no voided crossing) does
+  // not set it.
   truncationVoidedCrossing?: boolean;
+}
+
+/** detectAttempts-internal: one greedy TP-matcher run from a single SSS crossing. */
+interface AttemptScan {
+  sssCrossing: CylinderCrossing;
+  essCrossing: CylinderCrossing | null;
+  goalCrossing: CylinderCrossing | null;
+  turnpointCrossings: CylinderCrossing[];
+  reachedGoal: boolean;
+  lastTurnpointIndex: number;
+  taskTimeS: number | null;
+  truncationVoidedCrossing: boolean;
 }
 
 /**
@@ -297,6 +317,9 @@ export interface AttemptTrace {
  * crossing direction irrelevant, so entry-style starts work too):
  *   - Greedily match remaining TPs forward using segment-circle intersection
  *   - Build an AttemptTrace per SSS crossing
+ *
+ * XC only: a self-correcting landing anchor (Step 3) decides which crossings
+ * were flight and where the §12.1 landing falls — see the comments there.
  */
 export function detectAttempts(
   fixes: Fix[],
@@ -320,20 +343,21 @@ export function detectAttempts(
   // or both legs of a graze-through — spawns an attempt; Stage 7 picks the
   // best, so extra attempts are harmless.
   //
-  // Movement gate (XC only): an XC start is flown, not walked. A boundary
-  // crossing only spawns an attempt when the crossing segment shows movement
-  // — the faster of its two endpoint fixes is at least
-  // SSS_CROSSING_MIN_SPEED_KMH. This ignores on-foot crossings (~4–6 km/h
-  // walk-in to an entry-style start) and parked-drift crossings, which
-  // previously anchored the landing scan at launch prep and silently zeroed
-  // the whole flight; a walk-in track now gets the explicit NO_SSS_CROSSING
-  // error again. Accepted edge: a pilot parked exactly on the boundary in
-  // strong wind loses that particular crossing and starts on a later one. A
-  // fix with an unknown speed passes the gate (benefit of the doubt). HAF is
-  // exempt — travelling on foot is the point of the game there.
+  // Drift gate (XC only): an SSS boundary crossing is ignored only when BOTH
+  // endpoint fixes of the crossing segment are below the stillness threshold
+  // (SUSTAINED_STILLNESS_SPEED_KMH) — the GPS-noise drift of a parked pilot,
+  // not travel. Anything faster passes: walking, driving and slow flight all
+  // look alike at the boundary — a paraglider penetrating a strong headwind
+  // routinely crosses at single-digit ground speed, so no speed floor can
+  // separate flight from ground travel here. The landing-anchor loop in
+  // Step 3 decides what was actually flight. Accepted edge: a pilot parked
+  // exactly on the boundary in still-drift loses that particular crossing
+  // and starts on a later one. A fix with an unknown speed passes the gate
+  // (benefit of the doubt). HAF is exempt — travelling on foot is the point
+  // of the game there.
   const sssCrossings: Array<{ fixIndex: number; t: number; crossingTime: number }> = [];
   const sssEffectiveR = sss.radiusM + tagToleranceM(sss.radiusM);
-  const applyMovementGate = competitionType === 'XC';
+  const applyDriftGate = competitionType === 'XC';
 
   for (let i = 0; i < fixes.length - 1; i++) {
     const a = fixes[i];
@@ -342,7 +366,7 @@ export function detectAttempts(
       a.derivedSpeedKmh ?? Number.POSITIVE_INFINITY,
       b.derivedSpeedKmh ?? Number.POSITIVE_INFINITY,
     );
-    if (applyMovementGate && segmentMaxSpeed < SSS_CROSSING_MIN_SPEED_KMH) continue;
+    if (applyDriftGate && segmentMaxSpeed < SUSTAINED_STILLNESS_SPEED_KMH) continue;
     const aLocal = projectToLocal(a.lat, a.lng, sss.lat, sss.lng);
     const bLocal = projectToLocal(b.lat, b.lng, sss.lat, sss.lng);
 
@@ -355,39 +379,38 @@ export function detectAttempts(
     return err({ code: 'NO_SSS_CROSSING', message: 'No SSS cylinder crossing was detected in the track' });
   }
 
-  // XC: a landed pilot's later fixes (packing up, walking, car retrieve)
-  // must not earn crossings or distance — §9.3 counts only points "where
-  // the pilot is still flying", §12.1 only "up until the pilot landed".
-  // The landing is GLOBAL to the track: the start of the first
-  // landing-stillness window (≥ 30 s in which every fix is below 5 km/h
-  // AND the gpsAlt range stays under 15 m — a glider parked in ridge lift
-  // bobs in altitude; a landed pilot's GPS alt is flat within noise) that
-  // begins at/after the FIRST valid SSS crossing. Anchoring at the first
-  // crossing keeps pre-launch rigging stillness out of scope; using one
-  // cutoff for every attempt means a post-landing retrieve that re-crosses
-  // the SSS boundary can never spawn a scoreable attempt.
-  // HAF is exempt: travelling on the ground is part of the game there.
-  const landingCutoffMs =
-    competitionType === 'XC'
-      ? findLandingCutoffMs(fixes.filter((f) => f.timestamp >= sssCrossings[0].crossingTime))
-      : null;
+  // ── Step 2: greedy TP matcher — one run per SSS crossing ───────────────────
 
-  // ── Step 2: For each SSS crossing, greedily match remaining TPs ────────────
-  const attempts: AttemptTrace[] = [];
-  // §12.1: the XC flight ended at the landing, so an SSS crossing at/after
-  // the cutoff is on the ground and can never start a valid attempt. The
-  // suppressed crossing itself passed the movement gate, so the suppression
-  // voids an otherwise-valid crossing — flag the surviving attempts (⚑) so
-  // the truncation is visible for review.
-  let suppressedAttempt = false;
-
-  for (let ai = 0; ai < sssCrossings.length; ai++) {
-    const sssCross = sssCrossings[ai];
-    if (landingCutoffMs !== null && sssCross.crossingTime >= landingCutoffMs) {
-      suppressedAttempt = true;
-      continue;
+  // Pre-compute goal line bearing once per task (avoid re-running
+  // optimiseRoute per attempt/segment).
+  const goalTp = task.turnpoints[task.turnpoints.length - 1];
+  let cachedGoalBearing: number | undefined;
+  if (goalTp?.type === 'GOAL_LINE') {
+    cachedGoalBearing = goalTp.goalLineBearingDeg ?? undefined;
+    if (cachedGoalBearing == null) {
+      try {
+        const cyls: Cylinder[] = task.turnpoints.map((t) => ({
+          lat: t.lat,
+          lng: t.lng,
+          radiusM: t.radiusM,
+          type: t.type,
+        }));
+        cachedGoalBearing = optimiseRoute(cyls).goalLineBearingDeg;
+      } catch {
+        const prevTp = task.turnpoints[task.turnpoints.length - 2];
+        if (prevTp) {
+          const prevLocal = projectToLocal(prevTp.lat, prevTp.lng, goalTp.lat, goalTp.lng);
+          const inboundAngle = (Math.atan2(-prevLocal.x, -prevLocal.y) * 180) / Math.PI;
+          cachedGoalBearing = (inboundAngle + 90 + 360) % 360;
+        }
+      }
     }
+  }
 
+  const scanFromCrossing = (
+    sssCross: { fixIndex: number; t: number; crossingTime: number },
+    landingCutoffMs: number | null,
+  ): AttemptScan => {
     const sssCrossing: CylinderCrossing = {
       turnpointId: sss.id,
       sequenceIndex: sss.sequenceIndex,
@@ -412,31 +435,6 @@ export function detectAttempts(
     // Set when the landing cutoff voids an otherwise-valid crossing for
     // this attempt — surfaces as ⚑ instead of a silent rescore.
     let truncationVoidedCrossing = false;
-
-    // Pre-compute goal line bearing once per attempt (avoid re-running optimiseRoute per segment)
-    const goalTp = task.turnpoints[task.turnpoints.length - 1];
-    let cachedGoalBearing: number | undefined;
-    if (goalTp?.type === 'GOAL_LINE') {
-      cachedGoalBearing = goalTp.goalLineBearingDeg ?? undefined;
-      if (cachedGoalBearing == null) {
-        try {
-          const cyls: Cylinder[] = task.turnpoints.map((t) => ({
-            lat: t.lat,
-            lng: t.lng,
-            radiusM: t.radiusM,
-            type: t.type,
-          }));
-          cachedGoalBearing = optimiseRoute(cyls).goalLineBearingDeg;
-        } catch {
-          const prevTp = task.turnpoints[task.turnpoints.length - 2];
-          if (prevTp) {
-            const prevLocal = projectToLocal(prevTp.lat, prevTp.lng, goalTp.lat, goalTp.lng);
-            const inboundAngle = (Math.atan2(-prevLocal.x, -prevLocal.y) * 180) / Math.PI;
-            cachedGoalBearing = (inboundAngle + 90 + 360) % 360;
-          }
-        }
-      }
-    }
 
     // Use while loop so we can re-check the same fix-pair after a TP is achieved.
     // The scan deliberately continues PAST the landing cutoff: a would-be
@@ -569,10 +567,7 @@ export function detectAttempts(
     const timingCrossing = essCrossing ?? goalCrossing;
     const taskTimeS = timingCrossing !== null ? (timingCrossing.crossingTime - sssCrossing.crossingTime) / 1000 : null;
 
-    attempts.push({
-      // attempts.length, not the crossing index: suppressed crossings leave
-      // gaps in `ai`, and attemptIndex must stay contiguous for persistence.
-      attemptIndex: attempts.length,
+    return {
       sssCrossing,
       essCrossing,
       goalCrossing,
@@ -580,25 +575,148 @@ export function detectAttempts(
       reachedGoal,
       lastTurnpointIndex,
       taskTimeS,
-      distanceFlownKm: 0, // populated by calculateDistances
-      landingCutoffMs,
       truncationVoidedCrossing,
-    });
+    };
+  };
+
+  // ── Step 3: XC landing anchor ───────────────────────────────────────────────
+  // A landed pilot's later fixes (packing up, walking, car retrieve) must not
+  // earn crossings or distance — §9.3 counts only points "where the pilot is
+  // still flying", §12.1 only "up until the pilot landed". The landing is
+  // GLOBAL to the track: the start of the first landing-stillness window
+  // (≥ 30 s in which every fix is below 5 km/h AND the gpsAlt range stays
+  // under 15 m — a glider parked in ridge lift bobs in altitude; a landed
+  // pilot's GPS alt is flat within noise) at/after the anchor SSS crossing.
+  //
+  // The anchor is SELF-CORRECTING. Stillness alone cannot tell a landing
+  // from launch-prep rigging, and the drift gate deliberately lets walking
+  // and driving crossings through (no speed floor separates them from slow
+  // flight in wind). So each candidate anchor is tested for FLIGHT EVIDENCE:
+  // do the attempts spawned from crossings in [anchor, cutoff) make any
+  // course progress before the cutoff — a turnpoint crossing beyond the SSS,
+  // or at least FLIGHT_EVIDENCE_MIN_PROGRESS_KM of §9.3 partial distance?
+  //   - Evidence found: the cutoff is THE landing for the whole track. Later
+  //     SSS crossings are post-landing and suppressed — a retrieve car that
+  //     re-crosses the start boundary can never spawn a scoreable attempt.
+  //   - No evidence, later crossings exist: the anchor was pre-flight ground
+  //     movement (car up the hill, hike-in); its crossings are discarded
+  //     (they spawn no attempts) and the scan re-anchors at the first
+  //     crossing past the window. Anchors strictly advance, so this
+  //     terminates.
+  //   - No evidence, no later crossings: explicit NO_SSS_CROSSING — a
+  //     walk-in/drive-in track must never silently persist a truncated
+  //     pre-flight attempt.
+  // HAF is exempt: travelling on the ground is part of the game there.
+  let landingCutoffMs: number | null = null;
+  let suppressedPostLandingCrossing = false;
+  let scans: AttemptScan[] = [];
+
+  if (competitionType !== 'XC') {
+    scans = sssCrossings.map((c) => scanFromCrossing(c, null));
+  } else {
+    // Route/cylinders for the flight-evidence probe. On degenerate geometry
+    // (optimiseRoute throws) distance evidence is unavailable — but so is
+    // all distance credit (calculateDistances zeroes it), so TP-crossing
+    // evidence alone deciding is consistent.
+    const probeCylinders: Cylinder[] = task.turnpoints.map((tp) => ({
+      lat: tp.lat,
+      lng: tp.lng,
+      radiusM: tp.radiusM,
+      type: tp.type,
+      forceGround: tp.forceGround,
+      goalLineBearingDeg: tp.goalLineBearingDeg,
+    }));
+    let probeRoute: OptimisedRoute | null = null;
+    try {
+      probeRoute = optimiseRoute(probeCylinders);
+    } catch {
+      probeRoute = null;
+    }
+
+    const courseProgressKm = (scan: AttemptScan, cutoffMs: number): number => {
+      if (probeRoute === null) return 0;
+      const pilotFixes = fixes
+        .filter((f) => f.timestamp >= scan.sssCrossing.crossingTime && f.timestamp < cutoffMs)
+        .map((f) => ({ lat: f.lat, lng: f.lng, timestamp: f.timestamp }));
+      const crossings = scan.turnpointCrossings.map((c) => ({
+        sequenceIndex: c.sequenceIndex,
+        crossingTime: c.crossingTime,
+      }));
+      return computePartialDistanceKm(probeRoute, probeCylinders, crossings, pilotFixes);
+    };
+
+    let anchorIdx = 0;
+    for (;;) {
+      const anchor = sssCrossings[anchorIdx];
+      const cutoff = findLandingCutoffMs(fixes.filter((f) => f.timestamp >= anchor.crossingTime));
+
+      if (cutoff === null) {
+        // No stillness after this anchor — the pilot flew until the track
+        // ends. Every remaining crossing spawns an attempt; nothing is dead.
+        scans = sssCrossings.slice(anchorIdx).map((c) => scanFromCrossing(c, null));
+        landingCutoffMs = null;
+        break;
+      }
+
+      // Crossings in [anchor, cutoff) are this anchor's attempt candidates.
+      let firstPostCutoffIdx = sssCrossings.length;
+      for (let i = anchorIdx; i < sssCrossings.length; i++) {
+        if (sssCrossings[i].crossingTime >= cutoff) {
+          firstPostCutoffIdx = i;
+          break;
+        }
+      }
+      const candidateScans = sssCrossings.slice(anchorIdx, firstPostCutoffIdx).map((c) => scanFromCrossing(c, cutoff));
+
+      const hasFlightEvidence =
+        candidateScans.some((s) => s.turnpointCrossings.length > 1) ||
+        candidateScans.some((s) => courseProgressKm(s, cutoff) >= FLIGHT_EVIDENCE_MIN_PROGRESS_KM);
+
+      if (hasFlightEvidence) {
+        scans = candidateScans;
+        landingCutoffMs = cutoff;
+        // §12.1: an SSS crossing at/after the landing is on the ground and
+        // can never start a valid attempt. It passed the drift gate, so the
+        // suppression voids an otherwise-valid crossing — remembered here
+        // and surfaced as ⚑ on the surviving non-goal attempts below.
+        suppressedPostLandingCrossing = firstPostCutoffIdx < sssCrossings.length;
+        break;
+      }
+
+      // No flight evidence: the stillness was pre-flight ground time (car up
+      // the hill, hike-in), not a landing. These crossings spawn no attempts.
+      const nextAnchorIdx = Math.max(firstPostCutoffIdx, anchorIdx + 1);
+      if (nextAnchorIdx >= sssCrossings.length) {
+        return err({
+          code: 'NO_SSS_CROSSING',
+          message:
+            'No flown SSS cylinder crossing was detected — the only start-boundary crossings were pre-flight ground movement',
+        });
+      }
+      anchorIdx = nextAnchorIdx;
+    }
   }
 
-  if (attempts.length === 0) {
-    // Every gate-passing SSS crossing postdated the landing — degenerate,
-    // but surface the same explicit error a crossing-free track gets.
-    return err({
-      code: 'NO_SSS_CROSSING',
-      message: 'No SSS cylinder crossing was detected before the landing',
-    });
-  }
+  // ── Step 4: materialise attempts ────────────────────────────────────────────
+  const attempts: AttemptTrace[] = scans.map((scan, i) => ({
+    // Index over the surviving scans — discarded/suppressed crossings leave
+    // no gaps, and attemptIndex must stay contiguous for persistence.
+    attemptIndex: i,
+    ...scan,
+    distanceFlownKm: 0, // populated by calculateDistances
+    landingCutoffMs,
+  }));
 
-  if (suppressedAttempt) {
-    // A whole attempt was voided by the landing cutoff — make the
-    // suppression visible on everything that survives.
-    for (const attempt of attempts) attempt.truncationVoidedCrossing = true;
+  if (suppressedPostLandingCrossing) {
+    // Scope the ⚑: a post-landing SSS re-cross cannot have affected an
+    // attempt that already reached goal (its scan sealed at the goal
+    // crossing, before the landing), so goal attempts stay clean — flagging
+    // them would bury the flags that actually need review. Partial attempts
+    // keep the flag: the suppressed crossing might have been their real
+    // flight.
+    for (const attempt of attempts) {
+      if (!attempt.reachedGoal) attempt.truncationVoidedCrossing = true;
+    }
   }
 
   return ok(attempts);
@@ -899,10 +1017,26 @@ const SUSTAINED_STILLNESS_SPEED_KMH = 5;
 // 0–4 km/h ground speed but bobbing in lift) from reading as landed.
 const LANDING_STILLNESS_WINDOW_S = 30;
 const LANDING_MAX_ALT_RANGE_M = 15;
-// Stage 3 movement gate: minimum endpoint ground speed for an SSS boundary
-// crossing to spawn an attempt. Walking pace is ~4–6 km/h; slow flight in
-// wind stays comfortably above this.
-const SSS_CROSSING_MIN_SPEED_KMH = 8;
+// Stage 3 flight-evidence threshold: minimum §9.3 course progress (km) the
+// attempts in front of a candidate landing anchor must show for the anchor's
+// stillness window to be accepted as THE landing (see detectAttempts Step 3).
+// Must sit below the shortest genuine post-start flight the suppression
+// machinery protects (the sink-back bomb-out in the retrieve-car regression
+// makes ~0.7 km of course progress) and above the geometric slop of a
+// vehicle or walker crossing the start boundary near the optimised route
+// start point (~0.1 km).
+//
+// Accepted residual: a pre-flight vehicle that drives MORE than this
+// distance along the course line after crossing the SSS and then stops
+// (rigging stillness) defeats the no-progress test — launch-prep stillness
+// is then accepted as the landing and the genuine flight that follows is
+// suppressed-and-flagged (⚑, visible to admins) rather than scored. Inverse
+// residual: a genuine flight with LESS than this much course progress looks
+// like ground movement — with no later boundary crossing the upload gets the
+// explicit NO_SSS_CROSSING error rather than a silent truncation; with a
+// later crossing the scan re-anchors there. Both are the same
+// flight-vs-drive limitation class as the stillness signature itself.
+const FLIGHT_EVIDENCE_MIN_PROGRESS_KM = 0.5;
 const EARTH_RADIUS_M = 6_371_000;
 const DEG_RAD = Math.PI / 180;
 

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -308,9 +308,16 @@ export function computePartialDistanceKm(
     // route from the 0-radius anchor to the goal-boundary touch point on the
     // near side and report a small positive remaining distance — under-
     // crediting the pilot. Treat this case as 0 remaining explicitly.
+    //
+    // GOAL_LINE is excluded: §9.3 defines line-goal remaining distance as the
+    // optimised distance to the goal *point* with no radius term, and for a
+    // line radiusM holds the half line-length — proximity to the goal centre
+    // says nothing about having crossed the line (a fix 150 m short on the
+    // near side is within radiusM but has 150 m still to fly). The unguarded
+    // optimiser path below already computes exactly the §9.3 line formula.
     if (reachedIdx === n - 2) {
       const goal = cylinders[n - 1];
-      if (haversineKm(f.lat, f.lng, goal.lat, goal.lng) * 1000 <= goal.radiusM) {
+      if (goal.type !== 'GOAL_LINE' && haversineKm(f.lat, f.lng, goal.lat, goal.lng) * 1000 <= goal.radiusM) {
         minRemainingKm = 0;
         break;
       }
@@ -345,11 +352,15 @@ export const MAX_POINTS = 1000;
  * Distance points for one pilot.
  *   Goal:     MAX_POINTS
  *   Non-goal: MAX_POINTS * sqrt(dist / bestDist)
+ *
+ * Returns full precision — rounding to one decimal happens exactly once, on
+ * the final persisted value after task-level normalisation
+ * (rebuildTaskResults in src/job-queue.ts), per the S7F round-once principle.
  */
 export function computeDistancePoints(distKm: number, bestDistKm: number, reachedGoal: boolean): number {
   if (reachedGoal) return MAX_POINTS;
   if (bestDistKm <= 0) return 0;
-  return Math.round(MAX_POINTS * Math.sqrt(distKm / bestDistKm) * 10) / 10;
+  return MAX_POINTS * Math.sqrt(distKm / bestDistKm);
 }
 
 /**
@@ -363,6 +374,9 @@ export function computeDistancePoints(distKm: number, bestDistKm: number, reache
  * or beyond BestTime + sqrt(BestTime) — an absolute cutoff anchored to the
  * winner's time, not to the slowest finisher.
  *
+ * Returns full precision — see computeDistancePoints for where rounding
+ * happens.
+ *
  * @param taskTimeS      This pilot's task time in seconds
  * @param allGoalTimesS  All goal pilots' task times including this one
  */
@@ -372,5 +386,5 @@ export function computeTimePoints(taskTimeS: number, allGoalTimesS: number[]): n
   if (bestTimeH <= 0) return taskTimeS <= 0 ? MAX_POINTS : 0;
   const excessH = Math.max(0, taskTimeS / 3600 - bestTimeH);
   const speedFraction = Math.max(0, 1 - (excessH / Math.sqrt(bestTimeH)) ** (5 / 6));
-  return Math.round(MAX_POINTS * speedFraction * 10) / 10;
+  return MAX_POINTS * speedFraction;
 }

--- a/tests/crossing-order.test.ts
+++ b/tests/crossing-order.test.ts
@@ -1,0 +1,272 @@
+// =============================================================================
+// Crossing order — FAI §9.2.1.2
+//
+// A valid crossing must be recorded "a. after the valid crossing of the
+// previous cylinder in the task definition, b. not earlier than the start
+// time". The greedy scan re-checks the same fix segment after tagging a
+// turnpoint, and its already-inside shortcut (crossT = 0 → segment-START
+// timestamp) could previously stamp a crossing at or before the previous
+// crossing — before the start itself on the SSS exit segment — producing
+// non-monotonic crossing sequences and negative task times that poisoned
+// BestTime for every other pilot on the task.
+//
+// Crossing timestamps within an attempt must now be strictly increasing; a
+// premature candidate does NOT abandon its segment — §6.2.1 makes every
+// boundary root a crossing in its own right, so the scan re-consults ALL of
+// the segment's boundary roots and accepts the earliest one that postdates
+// the previous crossing (covering a graze-through whose entry root is
+// pre-start but whose exit root is valid, and an already-inside segment-start
+// fix where the pilot exits the zone before the next fix). Only when no root
+// on the segment qualifies does the scan move on; a pilot still inside the
+// cylinder then picks the tag up at the first fix that postdates the
+// previous crossing.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import { type AttemptTrace, detectAttempts, type Fix, type TaskDefinition } from '../src/shared/pipeline';
+
+function fx(tSec: number, lat: number, lng = -122.0, speedKmh = 35): Fix {
+  return {
+    timestamp: tSec * 1000,
+    lat,
+    lng,
+    gpsAlt: 500,
+    pressureAlt: 500,
+    valid: true,
+    gspKmh: null,
+    derivedSpeedKmh: speedKmh,
+  };
+}
+
+function expectStrictlyIncreasingCrossings(attempt: AttemptTrace) {
+  const times = attempt.turnpointCrossings.map((c) => c.crossingTime);
+  for (let i = 1; i < times.length; i++) {
+    expect(times[i]).toBeGreaterThan(times[i - 1]);
+  }
+}
+
+describe('goal cylinder overlapping the SSS exit (negative task time repro)', () => {
+  // 2-TP task whose goal cylinder overlaps the SSS exit point. On the SSS
+  // exit segment the goal boundary sits BEFORE the SSS boundary, so the old
+  // code tagged goal at ≈ t=44.8 s against an SSS crossing at ≈ t=48.6 s:
+  // taskTimeS ≈ −3.9 s, reachedGoal=true — and computeTimePoints' bestTime<=0
+  // branch then gave this attempt 1000 points and every honest finisher 0.
+  const task: TaskDefinition = {
+    id: 'task-overlap-goal',
+    turnpoints: [
+      { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+      { id: 'goal', sequenceIndex: 1, lat: 47.507, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+    ],
+  };
+  const fixes = [fx(0, 47.5), fx(60, 47.5045), fx(120, 47.5055), fx(180, 47.506)];
+
+  it('rejects the pre-start goal candidate and tags goal after the SSS crossing', () => {
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.value).toHaveLength(1);
+    const [attempt] = res.value;
+
+    // SSS exit interpolates to ≈ 48.6 s on the first segment.
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(40_000);
+    expect(attempt.sssCrossing.crossingTime).toBeLessThan(55_000);
+
+    // Goal still counts — the pilot genuinely flew into it — but at the
+    // first fix after the start (t=60 s), not at the segment start (t=0).
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.goalCrossing!.crossingTime).toBe(60_000);
+    expect(attempt.goalCrossing!.crossingTime).toBeGreaterThan(attempt.sssCrossing.crossingTime);
+
+    // The poison vector: task time can no longer be negative (or zero).
+    expect(attempt.taskTimeS).not.toBeNull();
+    expect(attempt.taskTimeS!).toBeGreaterThan(0);
+    expectStrictlyIncreasingCrossings(attempt);
+  });
+});
+
+describe('overlapping intermediate cylinders (same-segment re-check)', () => {
+  // TP2 (r=2000) contains fix a of the segment on which TP1 is crossed at an
+  // interpolated ≈ t=79 s. The old already-inside shortcut stamped TP2 at the
+  // segment START (t=60 s) — before TP1, violating §9.2.1.2a.
+  const task: TaskDefinition = {
+    id: 'task-overlap-tps',
+    turnpoints: [
+      { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+      { id: 'tp1', sequenceIndex: 1, lat: 47.53, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+      { id: 'tp2', sequenceIndex: 2, lat: 47.532, lng: -122.0, radiusM: 2000, type: 'CYLINDER' },
+      { id: 'goal', sequenceIndex: 3, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+    ],
+  };
+  const fixes = [fx(0, 47.5), fx(60, 47.52), fx(120, 47.54), fx(180, 47.56), fx(240, 47.58), fx(300, 47.6)];
+
+  it('defers the overlapped TP to the first fix after the previous crossing', () => {
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const [attempt] = res.value;
+    expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2, 3]);
+
+    const [, tp1, tp2] = attempt.turnpointCrossings;
+    // TP1 interpolates mid-segment (t=60 → t=120).
+    expect(tp1.crossingTime).toBeGreaterThan(60_000);
+    expect(tp1.crossingTime).toBeLessThan(120_000);
+    // TP2 previously stamped at 60_000 (the segment start, before TP1);
+    // now it lands on the next fix, after TP1.
+    expect(tp2.crossingTime).toBe(120_000);
+
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS!).toBeGreaterThan(0);
+    expectStrictlyIncreasingCrossings(attempt);
+  });
+});
+
+// 1° of latitude in the pipeline's local projection (R = 6 371 000 m).
+const M_PER_DEG_LAT = (6_371_000 * Math.PI) / 180;
+const latAtM = (m: number, originLat: number) => originLat + m / M_PER_DEG_LAT;
+
+describe('same-segment root retry — graze-through straddling the SSS boundary', () => {
+  // TP1 (r=200, effR 205) straddles the SSS boundary (r=3000, effR 3015).
+  // One 30 s segment (2700 m → 3300 m along the courseline) contains, in
+  // order: TP1's entry root (2805 m, ≈ t=105.3 s), the SSS exit crossing
+  // (3015 m, ≈ t=115.8 s), and TP1's exit root (3215 m, ≈ t=125.8 s). The
+  // entry root predates the start and is rejected (§9.2.1.2b) — but the
+  // exit root is a valid §9.2.1 crossing in its own right and the pilot
+  // must be tagged there, not forfeit TP1 (and everything downstream)
+  // because the first root happened to be premature.
+  const ORIGIN = 47.5;
+  const task: TaskDefinition = {
+    id: 'task-straddle-graze',
+    turnpoints: [
+      { id: 'sss', sequenceIndex: 0, lat: ORIGIN, lng: -122.0, radiusM: 3000, type: 'SSS' },
+      { id: 'tp1', sequenceIndex: 1, lat: latAtM(3010, ORIGIN), lng: -122.0, radiusM: 200, type: 'CYLINDER' },
+      { id: 'goal', sequenceIndex: 2, lat: latAtM(8000, ORIGIN), lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+    ],
+  };
+  const fixes = [
+    fx(0, latAtM(0, ORIGIN)),
+    fx(60, latAtM(1500, ORIGIN)),
+    fx(100, latAtM(2700, ORIGIN)),
+    fx(130, latAtM(3300, ORIGIN)), // the straddle segment
+    fx(190, latAtM(5000, ORIGIN)),
+    fx(250, latAtM(7000, ORIGIN)),
+    fx(310, latAtM(8200, ORIGIN)), // through goal (boundary at 7595 m)
+  ];
+
+  it('tags TP1 at the same-segment exit root and reaches goal', () => {
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.value).toHaveLength(1);
+    const [attempt] = res.value;
+
+    // SSS exit ≈ 115.8 s.
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(110_000);
+    expect(attempt.sssCrossing.crossingTime).toBeLessThan(120_000);
+
+    // TP1 tagged at the exit root (≈ 125.8 s) — within the same segment,
+    // strictly after the start.
+    expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+    const tp1 = attempt.turnpointCrossings[1];
+    expect(tp1.crossingTime).toBeGreaterThan(attempt.sssCrossing.crossingTime);
+    expect(tp1.crossingTime).toBeLessThan(130_000);
+
+    // Downstream goal is reached with a positive task time.
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS).not.toBeNull();
+    expect(attempt.taskTimeS!).toBeGreaterThan(0);
+    expectStrictlyIncreasingCrossings(attempt);
+  });
+});
+
+describe('same-segment root retry — concentric SSS inside TP1, exit within one segment', () => {
+  // SSS (r=400) sits at the centre of TP1 (r=2000). On the very first
+  // segment the pilot crosses the SSS boundary at ≈ 11.5 s AND exits TP1 at
+  // ≈ 57.1 s. TP1's already-inside candidate (segment-start fix, t=0) is
+  // premature; the exit root — the pilot's genuine §9.2.1 boundary crossing,
+  // strictly after the start — must be accepted instead of TP1 (and the
+  // whole downstream course) being forfeited, since the next fix is already
+  // outside TP1 and the tag can never be picked up later.
+  const task: TaskDefinition = {
+    id: 'task-concentric',
+    turnpoints: [
+      { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+      { id: 'tp1', sequenceIndex: 1, lat: 47.5, lng: -122.0, radiusM: 2000, type: 'CYLINDER' },
+      { id: 'goal', sequenceIndex: 2, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+    ],
+  };
+  const fixes = [
+    fx(0, 47.5),
+    fx(60, 47.519), // SSS exit ≈ 11.5 s and TP1 exit ≈ 57.1 s, one segment
+    fx(120, 47.538),
+    fx(180, 47.557),
+    fx(240, 47.576),
+    fx(300, 47.595),
+    fx(360, 47.614), // through goal (boundary ≈ 47.5964)
+  ];
+
+  it('tags TP1 at the same-segment exit root and reaches goal', () => {
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.value).toHaveLength(1);
+    const [attempt] = res.value;
+
+    // SSS exit ≈ 11.5 s.
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(10_000);
+    expect(attempt.sssCrossing.crossingTime).toBeLessThan(13_000);
+
+    // TP1 tagged at its exit root ≈ 57.1 s — after the start, before the
+    // segment-end fix.
+    expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+    const tp1 = attempt.turnpointCrossings[1];
+    expect(tp1.crossingTime).toBeGreaterThan(attempt.sssCrossing.crossingTime);
+    expect(tp1.crossingTime).toBeLessThan(60_000);
+
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS!).toBeGreaterThan(0);
+    expectStrictlyIncreasingCrossings(attempt);
+  });
+});
+
+describe('equal-timestamp candidates and pre-start candidates', () => {
+  // TP1 and TP2 are both 2 km cylinders containing fix t=60. TP1's boundary
+  // intersection on the SSS exit segment (≈ t=11.5 s) precedes the SSS
+  // crossing (≈ t=21.9 s) and must be rejected (§9.2.1.2b: not earlier than
+  // the start). TP1 then tags already-inside at t=60; TP2's candidate at the
+  // same t=60 is equal, not after — it must wait for the next fix.
+  const task: TaskDefinition = {
+    id: 'task-equal-times',
+    turnpoints: [
+      { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+      { id: 'tp1', sequenceIndex: 1, lat: 47.52, lng: -122.0, radiusM: 2000, type: 'CYLINDER' },
+      { id: 'tp2', sequenceIndex: 2, lat: 47.523, lng: -122.0, radiusM: 2000, type: 'CYLINDER' },
+      { id: 'goal', sequenceIndex: 3, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+    ],
+  };
+  const fixes = [fx(0, 47.5), fx(60, 47.51), fx(120, 47.515), fx(180, 47.518)];
+
+  it('every crossing is strictly after the start and the previous crossing', () => {
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const [attempt] = res.value;
+    expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+
+    const [sss, tp1, tp2] = attempt.turnpointCrossings;
+    expect(sss.crossingTime).toBeGreaterThan(0);
+    expect(sss.crossingTime).toBeLessThan(60_000);
+    // TP1's pre-start boundary intersection (≈ 11.5 s) was rejected; the
+    // already-inside tag lands on the first fix after the start.
+    expect(tp1.crossingTime).toBe(60_000);
+    // TP2 may not share TP1's timestamp — strictly after means the next fix.
+    expect(tp2.crossingTime).toBe(120_000);
+
+    expect(attempt.lastTurnpointIndex).toBe(2);
+    expectStrictlyIncreasingCrossings(attempt);
+  });
+});

--- a/tests/landing-truncation.test.ts
+++ b/tests/landing-truncation.test.ts
@@ -5,20 +5,29 @@
 // §12.1: distance counts "up until the pilot landed or the task deadline was
 // reached". For XC seasons the pipeline finds the landing GLOBALLY, once per
 // track: the start of the first landing-stillness window — ≥ 30 s in which
-// every fix is below 5 km/h AND the gpsAlt spread stays under 15 m — that
-// begins at/after the track's first valid SSS crossing. Everything from that
-// timestamp onward is dead: no turnpoint or goal crossings, no distance
-// credit, and an SSS crossing at/after the cutoff can't even start an attempt
-// (a §12.1 XC flight ends at the first landing, so a retrieve car that
-// re-crosses the start boundary spawns nothing).
+// every fix is below 5 km/h AND the gpsAlt spread stays under 15 m — at/after
+// the accepted anchor SSS crossing. Everything from that timestamp onward is
+// dead: no turnpoint or goal crossings, no distance credit, and an SSS
+// crossing at/after the cutoff can't even start an attempt (a §12.1 XC flight
+// ends at the first landing, so a retrieve car that re-crosses the start
+// boundary spawns nothing).
+//
+// The anchor is SELF-CORRECTING: a stillness window is only accepted as THE
+// landing when the attempts in front of it show flight evidence — a turnpoint
+// crossing beyond the SSS, or ≥ 0.5 km of §9.3 course progress — before the
+// cutoff. A no-evidence window is pre-flight ground time (car up the hill,
+// hike-in); its crossings are discarded and the scan re-anchors at the first
+// crossing past the window, or errors NO_SSS_CROSSING when none exists.
 //
 // The altitude-flatness requirement keeps a glider parked in ridge lift
 // (steady 0–4 km/h over the ground but bobbing in the lift band) from being
 // read as landed; a landed pilot's GPS altitude is flat within noise.
 //
-// A truncation or suppression that voids at least one otherwise-valid
-// crossing raises the attempt's ⚑ (hasFlaggedCrossings) so it is visible for
-// review; distance-only truncation stays quiet.
+// A truncation that voids an otherwise-valid crossing of the attempt's own
+// scan raises the attempt's ⚑ (hasFlaggedCrossings); a suppressed
+// post-landing SSS crossing flags only the surviving attempts that did NOT
+// reach goal (a sealed goal score cannot have been affected by it).
+// Distance-only truncation stays quiet.
 //
 // HAF seasons are exempt from all of this — travelling on the ground is part
 // of the game.
@@ -389,6 +398,235 @@ describe('landing truncation — genuine slow flight is NOT a landing', () => {
     expect(attempt.truncationVoidedCrossing).toBe(true);
     const [scored] = scoreAttempts([attempt], [], TASK_KM);
     expect(scored.hasFlaggedCrossings).toBe(true);
+  });
+});
+
+describe('self-correcting anchor — pre-flight ground movement across the SSS (XC)', () => {
+  // Finding 1 regression: the logger is running before launch and the drive
+  // up the hill crosses the SSS cylinder at vehicle speed. Rigging stillness
+  // at launch must NOT be accepted as the landing — the drive shows no course
+  // progress, so the scan re-anchors at the first in-flight crossing and the
+  // genuine flight scores in full (it scored 0.0 before this fix).
+  function driveUpThenFlyTrack(): Fix[] {
+    const fixes: Fix[] = [
+      fx(0, 47.49, 30), // car driving up the hill, south of the SSS
+      fx(60, 47.4945, 30),
+      fx(120, 47.499, 30), // crossed the SSS boundary (≈ 47.4964) ≈ t=85 s
+    ];
+    for (let t = 125; t <= 200; t += 5) fixes.push(fx(t, 47.4995, 0.5)); // 75 s rigging, alt flat
+    fixes.push(fx(260, 47.505, 30)); // launches; exits the SSS in flight ≈ t=245 s
+    fixes.push(fx(320, 47.52, 50));
+    fixes.push(fx(380, 47.55, 55));
+    fixes.push(fx(440, 47.58, 55));
+    fixes.push(fx(500, 47.61, 55)); // TP1
+    fixes.push(fx(560, 47.64, 55));
+    fixes.push(fx(620, 47.67, 55));
+    fixes.push(fx(680, 47.7, 55)); // TP2
+    fixes.push(fx(740, 47.73, 55));
+    fixes.push(fx(800, 47.76, 55));
+    fixes.push(fx(860, 47.79, 55));
+    fixes.push(fx(920, 47.81, 55)); // goal
+    return fixes;
+  }
+
+  it('drive-up at 30 km/h through the SSS + rigging stillness: the flight still scores goal', () => {
+    const attempts = detect(driveUpThenFlyTrack(), 'XC');
+
+    // The car's crossing spawned nothing; only the in-flight exit survives.
+    expect(attempts).toHaveLength(1);
+    const [attempt] = attempts;
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(200_000);
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS).toBeGreaterThan(0);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+    // Re-anchored past the rigging window; no landing after launch.
+    expect(attempt.landingCutoffMs).toBeNull();
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(false);
+  });
+
+  it('HAF season is exempt: the driven crossing is a legitimate start', () => {
+    const attempts = detect(driveUpThenFlyTrack(), 'HIKE_AND_FLY');
+    expect(attempts).toHaveLength(2);
+    for (const attempt of attempts) {
+      expect(attempt.landingCutoffMs).toBeNull();
+      expect(attempt.reachedGoal).toBe(true);
+    }
+  });
+
+  it('hike-in whose walking crossing has a GPS-jitter fix above walking pace: same rescue', () => {
+    // The walk across the boundary is 4 km/h with one 9 km/h jitter endpoint
+    // on the crossing segment — fast enough to defeat any walking-pace speed
+    // gate (it defeated the old 8 km/h one). The walk itself then reads as a
+    // stillness window (< 5 km/h); with no course progress in front of it the
+    // scan re-anchors at the in-flight exit and the flight scores in full.
+    const fixes: Fix[] = [
+      fx(0, 47.495, 4), // walking north toward the boundary
+      fx(60, 47.4957, 4),
+      fx(120, 47.497, 9), // jitter endpoint; crossed ≈ 47.4964 ≈ t=92 s
+      fx(180, 47.4977, 4),
+      fx(240, 47.4984, 4),
+    ];
+    for (let t = 245; t <= 320; t += 5) fixes.push(fx(t, 47.4985, 0.4)); // 75 s rigging, alt flat
+    fixes.push(fx(380, 47.506, 30)); // launches; exits the SSS in flight ≈ t=361 s
+    fixes.push(fx(440, 47.52, 50));
+    fixes.push(fx(500, 47.55, 55));
+    fixes.push(fx(560, 47.58, 55));
+    fixes.push(fx(620, 47.61, 55)); // TP1
+    fixes.push(fx(680, 47.64, 55));
+    fixes.push(fx(740, 47.67, 55));
+    fixes.push(fx(800, 47.7, 55)); // TP2
+    fixes.push(fx(860, 47.73, 55));
+    fixes.push(fx(920, 47.76, 55));
+    fixes.push(fx(980, 47.79, 55));
+    fixes.push(fx(1040, 47.81, 55)); // goal
+    const attempts = detect(fixes, 'XC');
+
+    expect(attempts).toHaveLength(1);
+    const [attempt] = attempts;
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(320_000);
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+    expect(attempt.landingCutoffMs).toBeNull();
+
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(false);
+  });
+});
+
+describe('suppression flag scoping — post-landing SSS re-cross (XC)', () => {
+  it('a clean goal flight is NOT flagged when the retrieve re-crosses the SSS', () => {
+    // The most common clean profile at hill sites: fly the task to goal,
+    // land, go still, then the retrieve car drives home back through the
+    // start cylinder. The car crossing is suppressed, but the goal score was
+    // sealed at the goal crossing — flagging it would bury real flags.
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40), // launch at the SSS centre; exits ≈ t=22 s
+      fx(60, 47.52, 60),
+      fx(120, 47.55, 60),
+      fx(180, 47.58, 60),
+      fx(240, 47.61, 60), // TP1
+      fx(300, 47.64, 60),
+      fx(360, 47.67, 60),
+      fx(420, 47.7, 60), // TP2
+      fx(480, 47.73, 60),
+      fx(540, 47.76, 60),
+      fx(600, 47.79, 60),
+      fx(660, 47.8, 40), // goal crossed ≈ t=638 s, lands
+    ];
+    for (let t = 665; t <= 700; t += 5) fixes.push(fx(t, 47.8, 0.5)); // 35 s still, alt flat
+    fixes.push(fx(760, 47.7, 80)); // retrieve drives south
+    fixes.push(fx(820, 47.6, 80));
+    fixes.push(fx(880, 47.52, 80));
+    fixes.push(fx(940, 47.5, 80)); // car re-enters the SSS cylinder ≈ t=907 s
+
+    const attempts = detect(fixes, 'XC');
+
+    // Car crossing suppressed; only the flown attempt survives.
+    expect(attempts).toHaveLength(1);
+    const [attempt] = attempts;
+    expect(attempt.landingCutoffMs).toBe(665_000);
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS).toBeGreaterThan(0);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+    // Goal attempts are exempt from the suppression flag.
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(false);
+  });
+
+  it('a partial flight IS still flagged when a post-landing crossing is suppressed', () => {
+    // Lands mid-course (no TP beyond the SSS), retrieve re-crosses the SSS.
+    // The suppressed crossing might have been the real flight, so the ⚑
+    // stays on the partial attempt.
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40), // exits SSS ≈ t=11 s
+      fx(60, 47.52, 40),
+      fx(120, 47.55, 60),
+      fx(180, 47.56, 20), // touch-down short of TP1
+    ];
+    for (let t = 185; t <= 220; t += 5) fixes.push(fx(t, 47.56, 0.5)); // 35 s still, alt flat
+    fixes.push(fx(280, 47.53, 60)); // retrieve drives back south
+    fixes.push(fx(340, 47.5, 60)); // re-enters the SSS cylinder ≈ t=333 s
+
+    const attempts = detect(fixes, 'XC');
+
+    expect(attempts).toHaveLength(1);
+    const [attempt] = attempts;
+    expect(attempt.landingCutoffMs).toBe(185_000);
+    expect(attempt.reachedGoal).toBe(false);
+    expect(attempt.lastTurnpointIndex).toBe(0);
+    // ~6.3 km of genuine course progress (47.5036 → 47.56), then dead.
+    expect(attempt.distanceFlownKm).toBeCloseTo(6.27, 1);
+    // Suppression flags the non-goal survivor.
+    expect(attempt.truncationVoidedCrossing).toBe(true);
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(true);
+  });
+});
+
+describe('accepted residual — pre-flight vehicle making course progress (XC)', () => {
+  // Documented limitation, pinned so it stays deliberate: a pre-flight car
+  // that crosses the SSS and drives MORE than the 0.5 km flight-evidence
+  // epsilon ALONG the course line before stopping at launch defeats the
+  // no-progress test. The rigging stillness is then accepted as THE landing:
+  // the genuine flight (whose SSS exit postdates it) is suppressed and every
+  // surviving car attempt is truncated at the cutoff and flagged. The flight
+  // is lost — visibly (⚑ for admin review), never silently scored off the
+  // car's track.
+  function carAlongCourseThenFlyTrack(): Fix[] {
+    const fixes: Fix[] = [
+      fx(0, 47.49, 30), // car enters from the south, crossing ≈ t=73 s
+      fx(60, 47.4945, 30),
+      fx(120, 47.503, 30),
+      fx(180, 47.512, 30), // exits the far side ≈ t=124 s, driving up the course
+      fx(240, 47.5215, 30), // ≈ 2.0 km of course progress
+      fx(300, 47.512, 30), // drives back toward launch
+      fx(360, 47.503, 30), // re-enters ≈ t=356 s
+      fx(420, 47.4995, 10), // parks at launch inside the cylinder
+    ];
+    for (let t = 425; t <= 495; t += 5) fixes.push(fx(t, 47.4995, 0.5)); // 70 s rigging, alt flat
+    fixes.push(fx(555, 47.5045, 25)); // launches; SSS exit ≈ t=544 s — SUPPRESSED
+    fixes.push(fx(615, 47.52, 45));
+    fixes.push(fx(675, 47.55, 55));
+    fixes.push(fx(735, 47.58, 55));
+    fixes.push(fx(795, 47.61, 55)); // TP1 (voided — post-cutoff)
+    fixes.push(fx(855, 47.65, 55));
+    fixes.push(fx(915, 47.7, 55)); // TP2 (voided)
+    fixes.push(fx(975, 47.75, 55));
+    fixes.push(fx(1035, 47.81, 55)); // goal (voided)
+    return fixes;
+  }
+
+  it('the flight is suppressed-and-flagged, never scored as the car attempt reaching goal', () => {
+    const attempts = detect(carAlongCourseThenFlyTrack(), 'XC');
+
+    // The three pre-cutoff car crossings all spawn (truncated) attempts; the
+    // in-flight exit at ≈ 544 s postdates the rigging cutoff and spawns none.
+    expect(attempts).toHaveLength(3);
+    for (const attempt of attempts) {
+      expect(attempt.landingCutoffMs).toBe(425_000);
+      expect(attempt.sssCrossing.crossingTime).toBeLessThan(425_000);
+      // Nothing flown counts: no goal, no task time, no TPs beyond the SSS.
+      expect(attempt.reachedGoal).toBe(false);
+      expect(attempt.taskTimeS).toBeNull();
+      expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0]);
+      // Both the suppression and the voided TP/goal crossings raise the ⚑.
+      expect(attempt.truncationVoidedCrossing).toBe(true);
+    }
+
+    const scored = scoreAttempts(attempts, [], TASK_KM);
+    const best = scored[selectBestAttempt(scored)];
+    // The persisted best is the car's truncated course progress (~2 km) —
+    // NOT the full flown task — and it is flagged for review.
+    expect(best.reachedGoal).toBe(false);
+    expect(best.distanceFlownKm).toBeCloseTo(2.0, 1);
+    expect(best.distanceFlownKm).toBeLessThan(TASK_KM / 4);
+    expect(best.hasFlaggedCrossings).toBe(true);
+    // The t_best pool gets nothing from this upload.
+    expect(scored.every((a) => !a.reachedGoal && a.taskTimeS === null)).toBe(true);
   });
 });
 

--- a/tests/landing-truncation.test.ts
+++ b/tests/landing-truncation.test.ts
@@ -1,0 +1,460 @@
+// =============================================================================
+// Landing truncation — FAI §9.3 / §12.1
+//
+// §9.3: flown distance considers "each point where the pilot is still flying";
+// §12.1: distance counts "up until the pilot landed or the task deadline was
+// reached". For XC seasons the pipeline finds the landing GLOBALLY, once per
+// track: the start of the first landing-stillness window — ≥ 30 s in which
+// every fix is below 5 km/h AND the gpsAlt spread stays under 15 m — that
+// begins at/after the track's first valid SSS crossing. Everything from that
+// timestamp onward is dead: no turnpoint or goal crossings, no distance
+// credit, and an SSS crossing at/after the cutoff can't even start an attempt
+// (a §12.1 XC flight ends at the first landing, so a retrieve car that
+// re-crosses the start boundary spawns nothing).
+//
+// The altitude-flatness requirement keeps a glider parked in ridge lift
+// (steady 0–4 km/h over the ground but bobbing in the lift band) from being
+// read as landed; a landed pilot's GPS altitude is flat within noise.
+//
+// A truncation or suppression that voids at least one otherwise-valid
+// crossing raises the attempt's ⚑ (hasFlaggedCrossings) so it is visible for
+// review; distance-only truncation stays quiet.
+//
+// HAF seasons are exempt from all of this — travelling on the ground is part
+// of the game.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import {
+  calculateDistances,
+  detectAttempts,
+  type Fix,
+  runPipeline,
+  scoreAttempts,
+  selectBestAttempt,
+  type TaskDefinition,
+} from '../src/shared/pipeline';
+import { type Cylinder, optimiseRoute } from '../src/shared/task-engine';
+
+// ── Shared geometry ──────────────────────────────────────────────────────────
+// Four collinear cylinders along the −122° meridian, 0.1° (≈ 11.12 km) apart,
+// 400 m radius each (same shape as tests/partial-distance.test.ts).
+
+const TASK: TaskDefinition = {
+  id: 'task-landing',
+  turnpoints: [
+    { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+    { id: 'tp1', sequenceIndex: 1, lat: 47.6, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+    { id: 'tp2', sequenceIndex: 2, lat: 47.7, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+    { id: 'goal', sequenceIndex: 3, lat: 47.8, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+  ],
+};
+
+const CYLINDERS: Cylinder[] = TASK.turnpoints.map((tp) => ({
+  lat: tp.lat,
+  lng: tp.lng,
+  radiusM: tp.radiusM,
+  type: tp.type,
+}));
+const TASK_KM = optimiseRoute(CYLINDERS).totalDistanceKm; // ≈ 32.56
+
+function fx(tSec: number, lat: number, speedKmh: number, alt = 500, lng = -122.0): Fix {
+  return {
+    timestamp: tSec * 1000,
+    lat,
+    lng,
+    gpsAlt: alt,
+    pressureAlt: alt,
+    valid: true,
+    gspKmh: null,
+    derivedSpeedKmh: speedKmh,
+  };
+}
+
+function detect(fixes: Fix[], competitionType: 'XC' | 'HIKE_AND_FLY') {
+  const res = detectAttempts(fixes, TASK, competitionType);
+  expect(res.ok).toBe(true);
+  if (!res.ok) throw new Error('unreachable');
+  return calculateDistances(res.value, fixes, TASK);
+}
+
+// Pilot launches inside SSS, flies north, tags TP1, touches down at 47.65
+// (between TP1 and TP2), goes still for 30 s (flat altitude), then the
+// retrieve car drives north along the courseline straight through TP2 and
+// beyond.
+function retrieveAlongCourseTrack(): Fix[] {
+  const fixes: Fix[] = [
+    fx(0, 47.5, 40),
+    fx(60, 47.51, 40), // SSS exited ≈ t=22 s
+    fx(120, 47.53, 40),
+    fx(180, 47.55, 40),
+    fx(240, 47.57, 40),
+    fx(300, 47.59, 40),
+    fx(360, 47.6, 40), // TP1 tagged ≈ t=338 s
+    fx(420, 47.62, 40),
+    fx(480, 47.65, 40), // touch-down
+  ];
+  for (let t = 485; t <= 515; t += 5) fixes.push(fx(t, 47.65, 0.5)); // 30 s still, alt flat
+  fixes.push(fx(570, 47.66, 60));
+  fixes.push(fx(630, 47.67, 60));
+  fixes.push(fx(690, 47.69, 65));
+  fixes.push(fx(750, 47.71, 65)); // car crosses TP2 (boundary ≈ 47.6964)
+  fixes.push(fx(810, 47.73, 65));
+  fixes.push(fx(870, 47.75, 65));
+  return fixes;
+}
+
+describe('landing truncation — retrieve along the courseline (XC)', () => {
+  it('stops crossings and distance at the stillness-window start, and flags the voided TP', () => {
+    const [attempt] = detect(retrieveAlongCourseTrack(), 'XC');
+
+    // Landing = first still fix, not the end of the window.
+    expect(attempt.landingCutoffMs).toBe(485_000);
+
+    // TP2 was only "crossed" by the car — must not count.
+    expect(attempt.lastTurnpointIndex).toBe(1);
+    expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1]);
+    expect(attempt.reachedGoal).toBe(false);
+
+    // The truncation voided an otherwise-valid TP2 crossing — not silent.
+    expect(attempt.truncationVoidedCrossing).toBe(true);
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(true);
+
+    // Distance credit ends at the landing spot (47.65, halfway TP1→TP2):
+    // ≈ 16.28 km, not the ≈ 27.4 km the drive to 47.75 would give.
+    expect(attempt.distanceFlownKm).toBeCloseTo(16.28, 1);
+    expect(attempt.distanceFlownKm).toBeLessThan(20);
+  });
+
+  it('HAF season is exempt: the same track keeps its ground progress', () => {
+    const [attempt] = detect(retrieveAlongCourseTrack(), 'HIKE_AND_FLY');
+
+    expect(attempt.landingCutoffMs).toBeNull();
+    // Ground travel is legitimate: TP2 counts, and so does the distance.
+    expect(attempt.lastTurnpointIndex).toBe(2);
+    expect(attempt.distanceFlownKm).toBeCloseTo(27.4, 1);
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+  });
+});
+
+describe('landing truncation — retrieve car re-crossing the SSS boundary (XC)', () => {
+  // The poison-vector regression: pilot exits SSS, sinks back into the
+  // cylinder, lands and goes still ≥ 30 s; the retrieve car then drives OUT
+  // of the SSS cylinder (a boundary crossing that would previously spawn a
+  // fresh attempt whose per-attempt stillness scan started after the
+  // landing) and up the valley road through TP1, TP2 and goal. The global
+  // cutoff suppresses the car-spawned attempt entirely, so the car can
+  // never set reachedGoal or contribute a taskTimeS to the t_best pool.
+  function carRetrieveTrack(): Fix[] {
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40), // launch at the SSS centre
+      fx(60, 47.51, 40), // SSS exited ≈ t=21.9 s
+      fx(120, 47.502, 20), // sinks back INSIDE the cylinder ≈ t=107.7 s
+    ];
+    for (let t = 130; t <= 165; t += 5) fixes.push(fx(t, 47.502, 1)); // lands, 35 s still, alt flat
+    fixes.push(fx(225, 47.503, 10)); // retrieve car sets off
+    fixes.push(fx(285, 47.51, 45)); // car exits the SSS cylinder ≈ t=230 s
+    fixes.push(fx(345, 47.55, 80));
+    fixes.push(fx(405, 47.61, 80)); // car through TP1
+    fixes.push(fx(465, 47.66, 80));
+    fixes.push(fx(525, 47.71, 80)); // car through TP2
+    fixes.push(fx(585, 47.76, 80));
+    fixes.push(fx(645, 47.81, 80)); // car through goal
+    return fixes;
+  }
+
+  it('suppresses the car-spawned attempt; the genuine truncated flight is best; no car t_best', () => {
+    const attempts = detect(carRetrieveTrack(), 'XC');
+
+    // Only the two airborne SSS crossings (exit + sink-back re-entry) spawn
+    // attempts; the car's post-landing exit crossing is suppressed.
+    expect(attempts).toHaveLength(2);
+    expect(attempts.map((a) => a.attemptIndex)).toEqual([0, 1]);
+
+    for (const attempt of attempts) {
+      expect(attempt.landingCutoffMs).toBe(130_000);
+      expect(attempt.sssCrossing.crossingTime).toBeLessThan(130_000);
+      // Nothing the car did counts: no goal, no task time, no TPs.
+      expect(attempt.reachedGoal).toBe(false);
+      expect(attempt.taskTimeS).toBeNull();
+      expect(attempt.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0]);
+      // The suppression + the car's would-be TP crossings are visible.
+      expect(attempt.truncationVoidedCrossing).toBe(true);
+    }
+
+    const scored = scoreAttempts(attempts, [], TASK_KM);
+    const best = scored[selectBestAttempt(scored)];
+    expect(best.reachedGoal).toBe(false);
+    expect(best.taskTimeS).toBeNull();
+    expect(best.hasFlaggedCrossings).toBe(true);
+    // Genuine flight progress only reached 47.51 — a sliver of the course.
+    expect(best.distanceFlownKm).toBeLessThan(2);
+    // The t_best pool gets nothing from this upload.
+    expect(scored.every((a) => !a.reachedGoal && a.taskTimeS === null)).toBe(true);
+  });
+
+  it('HAF season is exempt: the car-exit crossing still spawns a scoreable attempt', () => {
+    const attempts = detect(carRetrieveTrack(), 'HIKE_AND_FLY');
+    expect(attempts).toHaveLength(3);
+    expect(attempts.some((a) => a.reachedGoal)).toBe(true);
+  });
+});
+
+describe('landing truncation — walking across goal (XC)', () => {
+  // Pilot lands ~500 m short of the goal centre (~100 m short of the tag
+  // boundary), packs up for 30 s, then walks across the goal cylinder.
+  function walkAcrossGoalTrack(): Fix[] {
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40),
+      fx(60, 47.52, 60),
+      fx(120, 47.55, 60),
+      fx(180, 47.58, 60),
+      fx(240, 47.61, 60), // TP1 tagged ≈ t=213 s
+      fx(300, 47.64, 60),
+      fx(360, 47.67, 60),
+      fx(420, 47.7, 60), // TP2 tagged ≈ t=413 s
+      fx(480, 47.73, 60),
+      fx(540, 47.76, 60),
+      fx(600, 47.79, 60),
+      fx(604, 47.7955, 15), // final glide, touch-down
+    ];
+    for (let t = 610; t <= 640; t += 5) fixes.push(fx(t, 47.7955, 0.6)); // 30 s still, alt flat
+    fixes.push(fx(700, 47.7965, 4)); // walks into the goal cylinder
+    fixes.push(fx(760, 47.798, 4));
+    fixes.push(fx(820, 47.8, 4));
+    return fixes;
+  }
+
+  it('the walked goal crossing is void, flagged, and distance stops at the landing', () => {
+    const [attempt] = detect(walkAcrossGoalTrack(), 'XC');
+
+    expect(attempt.landingCutoffMs).toBe(610_000);
+    expect(attempt.reachedGoal).toBe(false);
+    expect(attempt.goalCrossing).toBeNull();
+    expect(attempt.lastTurnpointIndex).toBe(2);
+
+    // Voiding the walked goal crossing must not be silent.
+    expect(attempt.truncationVoidedCrossing).toBe(true);
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(true);
+
+    // Credit up to the touch-down fix at 47.7955 — ~100 m of remaining
+    // distance to the goal boundary, not the full task distance.
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM - 0.1, 1);
+    expect(attempt.distanceFlownKm).toBeLessThan(TASK_KM - 0.05);
+  });
+});
+
+describe('landing truncation — distance-only truncation is not flagged', () => {
+  it('landing then a retrieve that never crosses anything truncates quietly', () => {
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40),
+      fx(60, 47.51, 40),
+      fx(120, 47.54, 60),
+      fx(180, 47.57, 60),
+      fx(240, 47.6, 60), // TP1 tagged
+      fx(300, 47.63, 60),
+      fx(360, 47.65, 40), // touch-down between TP1 and TP2
+    ];
+    for (let t = 365; t <= 400; t += 5) fixes.push(fx(t, 47.65, 0.5)); // 35 s still, alt flat
+    // Retrieve drives EAST, away from the courseline — no TP2, no goal.
+    fixes.push(fx(460, 47.65, 50, 500, -121.95));
+    fixes.push(fx(520, 47.65, 50, 500, -121.9));
+
+    const [attempt] = detect(fixes, 'XC');
+    expect(attempt.landingCutoffMs).toBe(365_000);
+    expect(attempt.lastTurnpointIndex).toBe(1);
+    expect(attempt.reachedGoal).toBe(false);
+    expect(attempt.distanceFlownKm).toBeCloseTo(16.28, 1);
+
+    // No otherwise-valid crossing was voided — no ⚑.
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(false);
+  });
+});
+
+describe('landing truncation — genuine slow flight is NOT a landing', () => {
+  it('15 s of near-zero ground speed (scratchy low save) does not truncate', () => {
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40),
+      fx(60, 47.51, 40),
+      fx(120, 47.54, 60),
+      fx(180, 47.57, 60),
+      // 15 s below the stillness speed — far shorter than the 30 s window
+      fx(240, 47.59, 3),
+      fx(245, 47.5901, 2),
+      fx(250, 47.5902, 2),
+      fx(255, 47.5903, 2),
+      // climbs away and finishes the task
+      fx(260, 47.591, 8),
+      fx(320, 47.6, 45),
+      fx(380, 47.63, 60),
+      fx(440, 47.67, 60),
+      fx(500, 47.71, 60),
+      fx(560, 47.75, 60),
+      fx(620, 47.79, 60),
+      fx(680, 47.81, 60),
+    ];
+    const [attempt] = detect(fixes, 'XC');
+
+    expect(attempt.landingCutoffMs).toBeNull();
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+  });
+
+  it('a noisy 3–7 km/h hover (headwind soaring) does not truncate', () => {
+    const hoverSpeeds = [3, 7, 4, 6, 3, 8, 4, 6, 2, 7]; // > 45 s, never 30 s below 5
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40),
+      fx(60, 47.51, 40),
+      fx(120, 47.54, 60),
+      fx(180, 47.57, 60),
+      ...hoverSpeeds.map((speed, i) => fx(240 + i * 5, 47.59 + i * 0.0001, speed)),
+      fx(300, 47.6, 45),
+      fx(360, 47.63, 60),
+      fx(420, 47.67, 60),
+      fx(480, 47.71, 60),
+      fx(540, 47.75, 60),
+      fx(600, 47.79, 60),
+      fx(660, 47.81, 60),
+    ];
+    const [attempt] = detect(fixes, 'XC');
+
+    expect(attempt.landingCutoffMs).toBeNull();
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+  });
+
+  it('parked ridge-soaring (30+ s at 2–4 km/h, gpsAlt bobbing > 15 m) does not truncate', () => {
+    // Steady laminar wind: ground speed sits at 2–4 km/h for 35 s straight —
+    // the speed signature alone reads as landed. The glider is riding the
+    // lift band though, so its GPS altitude bobs by ~20 m; the flatness
+    // requirement keeps the flight alive.
+    const parkedAlts = [595, 615, 595, 613, 597, 615, 596, 614];
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40, 500),
+      fx(60, 47.51, 40, 520),
+      fx(120, 47.54, 60, 560),
+      fx(180, 47.57, 60, 600),
+      ...parkedAlts.map((alt, i) => fx(240 + i * 5, 47.59 + i * 0.00001, 2 + (i % 3), alt)),
+      fx(280, 47.591, 10, 620), // pushes forward out of the park
+      fx(340, 47.6, 45, 700),
+      fx(400, 47.63, 60, 800),
+      fx(460, 47.67, 60, 900),
+      fx(520, 47.71, 60, 900),
+      fx(580, 47.75, 60, 800),
+      fx(640, 47.79, 60, 700),
+      fx(700, 47.81, 60, 600),
+    ];
+    const [attempt] = detect(fixes, 'XC');
+
+    expect(attempt.landingCutoffMs).toBeNull();
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.distanceFlownKm).toBeCloseTo(TASK_KM, 2);
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(false);
+  });
+
+  it('the identical stop with FLAT altitude is a landing: truncated AND flagged', () => {
+    // Same track shape as the ridge-soaring case, but the 35 s stop has a
+    // flat GPS altitude — a top-landing. The later "flight" (a relaunch the
+    // §12.1 flight model does not credit) is voided and flagged.
+    const fixes: Fix[] = [
+      fx(0, 47.5, 40, 500),
+      fx(60, 47.51, 40, 520),
+      fx(120, 47.54, 60, 560),
+      fx(180, 47.57, 60, 600),
+      ...Array.from({ length: 8 }, (_, i) => fx(240 + i * 5, 47.59 + i * 0.00001, 2 + (i % 3), 600)),
+      fx(280, 47.591, 10, 620),
+      fx(340, 47.6, 45, 700),
+      fx(400, 47.63, 60, 800),
+      fx(460, 47.67, 60, 900),
+      fx(520, 47.71, 60, 900),
+      fx(580, 47.75, 60, 800),
+      fx(640, 47.79, 60, 700),
+      fx(700, 47.81, 60, 600),
+    ];
+    const [attempt] = detect(fixes, 'XC');
+
+    expect(attempt.landingCutoffMs).toBe(240_000);
+    expect(attempt.reachedGoal).toBe(false);
+    // TP1 (boundary ≈ 47.5964) was never reached before the landing.
+    expect(attempt.lastTurnpointIndex).toBe(0);
+    expect(attempt.distanceFlownKm).toBeLessThan(TASK_KM / 2);
+
+    // The voided post-landing TP1 crossing surfaces as ⚑ for review.
+    expect(attempt.truncationVoidedCrossing).toBe(true);
+    const [scored] = scoreAttempts([attempt], [], TASK_KM);
+    expect(scored.hasFlaggedCrossings).toBe(true);
+  });
+});
+
+// ── End-to-end through runPipeline (IGC bytes → scored attempts) ─────────────
+// Pilot exits SSS, flies to 47.52, sits still for 35 s (identical B records →
+// derived ground speed 0, flat altitude), then the retrieve drives through
+// the goal cylinder.
+
+const LANDING_IGC = [
+  'AXLK00001',
+  'HFDTE230126',
+  'B1000004730000N12200000WA0050000500', // 47.500 — inside SSS
+  'B1001004730600N12200000WA0050000500', // 47.510 — SSS exited
+  'B1002004731200N12200000WA0050000500', // 47.520 — touch-down
+  'B1002054731200N12200000WA0050000500',
+  'B1002104731200N12200000WA0050000500',
+  'B1002154731200N12200000WA0050000500',
+  'B1002204731200N12200000WA0050000500',
+  'B1002254731200N12200000WA0050000500',
+  'B1002304731200N12200000WA0050000500',
+  'B1002354731200N12200000WA0050000500',
+  'B1002404731200N12200000WA0050000500', // 35 s stationary
+  'B1004004732400N12200000WA0050000500', // 47.540 — car through goal
+].join('\n');
+
+const SHORT_TASK: TaskDefinition = {
+  id: 'task-short',
+  turnpoints: [
+    { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+    { id: 'goal', sequenceIndex: 1, lat: 47.54, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+  ],
+};
+
+describe('landing truncation — end-to-end runPipeline', () => {
+  it('XC: the driven goal crossing is void, flagged, and distance stops at the landing', async () => {
+    const result = await runPipeline(
+      { igcText: LANDING_IGC, task: SHORT_TASK, existingGoalTimes: [], competitionType: 'XC' },
+      '2026-01-01',
+      '2026-01-31',
+      3.65,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const best = result.value.scoredAttempts[result.value.bestAttemptIndex];
+    expect(best.reachedGoal).toBe(false);
+    expect(best.goalCrossing).toBeNull();
+    // The voided goal crossing raises the review flag.
+    expect(best.hasFlaggedCrossings).toBe(true);
+    // Flown to 47.52: task ≈ 3.65 km minus ≈ 1.82 km remaining to goal.
+    expect(best.distanceFlownKm).toBeCloseTo(1.82, 1);
+  });
+
+  it('HAF: the identical track keeps its post-touch-down goal crossing', async () => {
+    const result = await runPipeline(
+      { igcText: LANDING_IGC, task: SHORT_TASK, existingGoalTimes: [], competitionType: 'HIKE_AND_FLY' },
+      '2026-01-01',
+      '2026-01-31',
+      3.65,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const best = result.value.scoredAttempts[result.value.bestAttemptIndex];
+    expect(best.reachedGoal).toBe(true);
+    expect(best.distanceFlownKm).toBeCloseTo(3.65, 1);
+    expect(best.hasFlaggedCrossings).toBe(false);
+  });
+});

--- a/tests/partial-distance.test.ts
+++ b/tests/partial-distance.test.ts
@@ -121,6 +121,76 @@ describe('computePartialDistanceKm — anchor points on the optimised line', () 
   });
 });
 
+// ── Goal LINE: §9.3 computes line-goal remaining distance with no radius ────
+
+describe('computePartialDistanceKm — GOAL_LINE (§9.3: no radius term)', () => {
+  // Same collinear geometry, but the task ends in a 400 m goal LINE
+  // (radiusM = 200 holds the half line-length). For a line the optimised
+  // route ends at the goal CENTRE, so only the SSS boundary offset is
+  // subtracted: 33.358 − 0.400 = 32.958 km.
+  const TASK_LINE: Cylinder[] = [
+    { lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+    { lat: 47.6, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+    { lat: 47.7, lng: -122.0, radiusM: 400, type: 'CYLINDER' },
+    { lat: 47.8, lng: -122.0, radiusM: 200, type: 'GOAL_LINE' },
+  ];
+  const ROUTE_LINE = optimiseRoute(TASK_LINE);
+  const TASK_LINE_KM = ROUTE_LINE.totalDistanceKm;
+
+  const crossings = [
+    { sequenceIndex: 0, crossingTime: 0 },
+    { sequenceIndex: 1, crossingTime: 100_000 },
+    { sequenceIndex: 2, crossingTime: 200_000 },
+  ];
+  const DEG_PER_M = 1 / 111_194; // latitude degrees per metre
+
+  it('line-goal task distance ends at the goal centre (≈ 32.96 km)', () => {
+    expect(TASK_LINE_KM).toBeCloseTo(32.958, 2);
+  });
+
+  it('fix 150 m short of the line on the near side yields taskKm − 0.15, not taskKm', () => {
+    // 150 m is within radiusM of the goal centre. The pre-fix guard applied
+    // cylinder semantics (inside radius ⇒ remaining = 0) and credited the
+    // full task distance to a pilot who never crossed the line; §9.3's line
+    // formula is the optimised distance to the goal point — 150 m left.
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.7, -122.0, 200_000),
+      fix(47.8 - 150 * DEG_PER_M, -122.0, 300_000), // 150 m before goal centre
+    ];
+    const d = computePartialDistanceKm(ROUTE_LINE, TASK_LINE, crossings, fixes);
+    expect(d).toBeCloseTo(TASK_LINE_KM - 0.15, 2);
+  });
+
+  it('un-tagged fix past the line (inside the D-zone) scores distance-to-goal-point', () => {
+    // A tagged goal crossing short-circuits upstream (full distance). If the
+    // tag is missing, §9.3's line formula still measures to the goal point —
+    // no radius credit in either direction.
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.7, -122.0, 200_000),
+      fix(47.8 + 100 * DEG_PER_M, -122.0, 300_000), // 100 m beyond goal centre
+    ];
+    const d = computePartialDistanceKm(ROUTE_LINE, TASK_LINE, crossings, fixes);
+    expect(d).toBeCloseTo(TASK_LINE_KM - 0.1, 2);
+  });
+
+  it('fix inside a GOAL_CYLINDER still zeroes remaining distance (guard retained)', () => {
+    // The cylinder branch of the guard must survive the goal-type split:
+    // 150 m from the centre of a 400 m goal cylinder IS inside goal.
+    const fixes = [
+      fix(47.503596, -122.0, 0),
+      fix(47.6, -122.0, 100_000),
+      fix(47.7, -122.0, 200_000),
+      fix(47.8 - 150 * DEG_PER_M, -122.0, 300_000),
+    ];
+    const d = computePartialDistanceKm(ROUTE, TASK, crossings, fixes);
+    expect(d).toBeCloseTo(TASK_KM, 1);
+  });
+});
+
 // ── The bug: tracks that diverge laterally must get DIFFERENT distances ─────
 
 describe('computePartialDistanceKm — lateral divergence (was: same score)', () => {

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -378,9 +378,7 @@ describe('rebuildTaskResults', () => {
     rebuildTaskResults(db, taskHalf.id);
 
     const rows = db
-      .prepare(
-        'SELECT user_id, distance_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank',
-      )
+      .prepare('SELECT user_id, distance_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank')
       .all(taskHalf.id) as any[];
     expect(rows).toHaveLength(2);
     expect(rows[0].user_id).toBe(pilot.id);

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -353,12 +353,50 @@ describe('rebuildTaskResults', () => {
     expect(rows[1].rank).toBe(2);
   });
 
+  // Regression for double rounding: components must be rounded to one decimal
+  // exactly once, AFTER the normalisation scale is applied. Rounding before
+  // scaling too (the old behavior) compounds two rounding errors — here raw
+  // dp = 866.0896... at scale 0.5 lands on 433.0 single-rounded but 433.1
+  // double-rounded (866.1 * 0.5 = 433.05 rounds up).
+  it('rounds components once, after normalisation scaling', () => {
+    const taskHalf = createTestTask(db, season.id, league.id, { name: 'Half-scale' });
+    db.prepare(`UPDATE tasks SET normalized_score = 500 WHERE id = ?`).run(taskHalf.id);
+
+    // Winner: non-goal at bestDist → raw dp = 1000 exactly, so scale = 0.5 exactly.
+    const sub1 = createTestSubmission(db, taskHalf.id, pilot.id, league.id);
+    createTestAttempt(db, sub1, taskHalf.id, pilot.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 80,
+    });
+    // Runner-up: raw dp = 1000 * sqrt(60.0089 / 80) = 866.089631...
+    const sub2 = createTestSubmission(db, taskHalf.id, pilot2.id, league.id);
+    createTestAttempt(db, sub2, taskHalf.id, pilot2.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 60.0089,
+    });
+
+    rebuildTaskResults(db, taskHalf.id);
+
+    const rows = db
+      .prepare(
+        'SELECT user_id, distance_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank',
+      )
+      .all(taskHalf.id) as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].user_id).toBe(pilot.id);
+    expect(rows[0].distance_points).toBe(500); // winner lands exactly on normalized_score
+    expect(rows[0].total_points).toBe(500);
+    expect(rows[1].user_id).toBe(pilot2.id);
+    expect(rows[1].distance_points).toBe(433); // 433.1 would mean a pre-scale rounding crept back in
+    expect(rows[1].total_points).toBe(433);
+  });
+
   // Regression for time-point staleness: when a new goal time enters the set,
   // every goal pilot's time_points must reflect the full updated range.
   it('rescores time_points across all goal pilots when the goal-times set changes', () => {
     // normalized_score=2000 matches the unscaled winner total
-    // (distance_points=1000 + time_points=1000 for the fastest pilot),
-    // so the post-rebuild values are the raw computeTimePoints outputs.
+    // (distance_points=1000 + time_points=1000 for the fastest pilot), so the
+    // post-rebuild values are the computeTimePoints outputs rounded to 0.1.
     const taskTime = createTestTask(db, season.id, league.id, { name: 'Time-points' });
     db.prepare(`UPDATE tasks SET normalized_score = 2000 WHERE id = ?`).run(taskTime.id);
 
@@ -451,5 +489,80 @@ describe('rebuildTaskResults', () => {
     // Pilot A's *best* is 3600 (slower 4200 is ignored) → 757.6.
     expect(byUser.get(pilot2.id).time_points).toBeCloseTo(1000, 0);
     expect(byUser.get(pilot.id).time_points).toBeCloseTo(757.6, 1);
+  });
+
+  // §13.1: the PG time-points parameter is 0% — a speed-section time earns
+  // nothing without reaching goal, including rank order. task_time_s is
+  // stored for any ESS crossing (even when the pilot lands short), so an
+  // ESS-but-no-goal time must not split equal-total pilots.
+  it('does not split equal-total non-goal pilots by an ESS-only task_time_s', () => {
+    const sub1 = createTestSubmission(db, task.id, pilot.id, league.id);
+    const sub2 = createTestSubmission(db, task.id, pilot2.id, league.id);
+    // Both land short at 40 km; pilot A crossed ESS (task_time_s set).
+    createTestAttempt(db, sub1, task.id, pilot.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 40,
+      taskTimeS: 4000,
+    });
+    createTestAttempt(db, sub2, task.id, pilot2.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 40,
+    });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, total_points, rank FROM task_results WHERE task_id = ?')
+      .all(task.id) as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].total_points).toBe(rows[1].total_points);
+    expect(rows[0].rank).toBe(1);
+    expect(rows[1].rank).toBe(1); // shared rank — the ESS time confers nothing
+  });
+
+  it('ranks a goal pilot above an equal-total non-goal pilot regardless of ESS times', () => {
+    // Under the §12.2 absolute cutoff a goal pilot slower than
+    // t_best + sqrt(t_best) scores 0 time points, so a non-goal pilot at
+    // bestDist can tie them on total_points. The goal pilot must still rank
+    // first — a fast ESS-only time must not flip the order.
+    const fast = createTestUser(db, { email: 'fast@test.com', displayName: 'Fast Finisher' });
+    addLeagueMember(db, league.id, fast.id, 'pilot');
+
+    // t_best = 3000 s (0.8333 h) → zero cutoff ≈ 3000 + 3286 = 6286 s.
+    const subFast = createTestSubmission(db, task.id, fast.id, league.id);
+    createTestAttempt(db, subFast, task.id, fast.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 3000,
+    });
+    // Goal pilot past the cutoff: full distance points + 0 time points.
+    const subSlow = createTestSubmission(db, task.id, pilot.id, league.id);
+    createTestAttempt(db, subSlow, task.id, pilot.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 7000,
+    });
+    // Non-goal pilot at bestDist with a fast ESS crossing.
+    const subEss = createTestSubmission(db, task.id, pilot2.id, league.id);
+    createTestAttempt(db, subEss, task.id, pilot2.id, league.id, {
+      reachedGoal: false,
+      distanceFlownKm: 50,
+      taskTimeS: 3100,
+    });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, reached_goal, total_points, rank FROM task_results WHERE task_id = ? ORDER BY rank')
+      .all(task.id) as any[];
+    expect(rows).toHaveLength(3);
+    expect(rows[0].user_id).toBe(fast.id);
+    // Slow goal pilot and non-goal pilot tie on points…
+    expect(rows[1].total_points).toBe(rows[2].total_points);
+    // …but the goal pilot ranks above; the non-goal ESS time earns nothing.
+    expect(rows[1].user_id).toBe(pilot.id);
+    expect(rows[1].reached_goal).toBe(1);
+    expect(rows[2].user_id).toBe(pilot2.id);
+    expect(rows[2].rank).toBe(3);
   });
 });

--- a/tests/routes/tasks.test.ts
+++ b/tests/routes/tasks.test.ts
@@ -805,6 +805,82 @@ describe('Task lifecycle — POST publish + closed-task edit guard', () => {
       expect(row.open_date).toBe(newOpen);
     });
   });
+
+  // task_results rows store points pre-scaled by normalized_score, so a PUT
+  // that changes taskValue must rescale them in the same request — previously
+  // the cache stayed on the old scale until an unrelated trigger (upload,
+  // submission delete, restart) fired a rebuild.
+  describe('taskValue edit rebuilds task_results', () => {
+    const openIso = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
+    const closeIso = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    /** Task with two scored non-goal pilots: 80 km winner + 20 km (sqrt(20/80) = 0.5). */
+    function seedScoredTask() {
+      const task = createTestTask(db, testSeason.id, testLeague.id, { openDate: openIso, closeDate: closeIso });
+      const subA = createTestSubmission(db, task.id, adminUser.id, testLeague.id);
+      createTestAttempt(db, subA, task.id, adminUser.id, testLeague.id, { reachedGoal: false, distanceFlownKm: 80 });
+      const subB = createTestSubmission(db, task.id, pilotUser.id, testLeague.id);
+      createTestAttempt(db, subB, task.id, pilotUser.id, testLeague.id, { reachedGoal: false, distanceFlownKm: 20 });
+      rebuildTaskResults(db, task.id);
+      return task;
+    }
+
+    const points = (taskId: string) =>
+      new Map(
+        (db.prepare('SELECT user_id, total_points FROM task_results WHERE task_id = ?').all(taskId) as any[]).map(
+          (r) => [r.user_id, r.total_points],
+        ),
+      );
+
+    const putTask = (taskId: string, payload: object) =>
+      app.inject({
+        method: 'PUT',
+        url: `/leagues/${testLeague.slug}/seasons/${testSeason.id}/tasks/${taskId}`,
+        headers: { 'x-test-user-id': adminUser.id, 'content-type': 'application/json' },
+        payload: JSON.stringify(payload),
+      });
+
+    it('rescales existing task_results when taskValue changes, without a new upload', async () => {
+      const task = seedScoredTask();
+      // Default scale (normalized_score NULL → 1000): winner 1000, other 500.
+      expect(points(task.id).get(adminUser.id)).toBe(1000);
+      expect(points(task.id).get(pilotUser.id)).toBe(500);
+
+      const res = await putTask(task.id, { taskValue: 500 });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).task.taskValue).toBe(500);
+      // Rescaled in the same request — no upload needed.
+      expect(points(task.id).get(adminUser.id)).toBe(500);
+      expect(points(task.id).get(pilotUser.id)).toBe(250);
+    });
+
+    it('clearing taskValue (null) rescales back to the default 1000', async () => {
+      const task = seedScoredTask();
+      db.prepare(`UPDATE tasks SET normalized_score = 500 WHERE id = ?`).run(task.id);
+      rebuildTaskResults(db, task.id);
+      expect(points(task.id).get(adminUser.id)).toBe(500);
+
+      const res = await putTask(task.id, { taskValue: null });
+
+      expect(res.statusCode).toBe(200);
+      expect(points(task.id).get(adminUser.id)).toBe(1000);
+      expect(points(task.id).get(pilotUser.id)).toBe(500);
+    });
+
+    it('does not rebuild when taskValue is absent or unchanged', async () => {
+      const task = seedScoredTask();
+      // Sentinel a rebuild would overwrite.
+      db.prepare(`UPDATE task_results SET total_points = 123.4 WHERE task_id = ?`).run(task.id);
+
+      // Name-only edit, then a no-op taskValue (null → stored NULL).
+      for (const payload of [{ name: 'Renamed, no taskValue' }, { taskValue: null }]) {
+        const res = await putTask(task.id, payload);
+        expect(res.statusCode).toBe(200);
+        expect(points(task.id).get(adminUser.id)).toBe(123.4); // sentinel survived — no rebuild
+      }
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/sss-direction.test.ts
+++ b/tests/sss-direction.test.ts
@@ -11,14 +11,19 @@
 // (start cylinder that does not contain launch) previously produced zero SSS
 // crossings and rejected the whole upload with NO_SSS_CROSSING.
 //
-// XC movement gate: an XC start is flown, not walked. A boundary crossing
-// only spawns an attempt when the crossing segment shows movement — the
-// faster of its two endpoint fixes is ≥ 8 km/h. A pilot who walks across an
-// entry-style start boundary (~4–6 km/h) before launching gets the explicit
-// NO_SSS_CROSSING error, not a silently zeroed flight anchored at their
-// launch-prep stillness. Accepted edge: a pilot parked exactly on the
-// boundary in strong wind loses that particular crossing and starts on a
-// later one. HAF is exempt — walking is the point of the game there.
+// XC drift gate: a boundary crossing is ignored only when BOTH endpoint
+// fixes of the crossing segment are below the stillness threshold (5 km/h) —
+// the GPS drift of a parked pilot. No higher speed floor is possible: a
+// paraglider penetrating a strong headwind crosses at single-digit ground
+// speed, indistinguishable from walking by speed alone. Walking and driving
+// crossings therefore pass the gate, and the SELF-CORRECTING landing anchor
+// in detectAttempts decides what was flight: an anchor whose stillness
+// window has no course progress in front of it is pre-flight ground
+// movement — its crossings are discarded and the scan re-anchors past the
+// window, or errors NO_SSS_CROSSING when no later crossing exists. Accepted
+// edge: a pilot parked exactly on the boundary loses that drift crossing and
+// starts on a later one. HAF is exempt — walking is the point of the game
+// there.
 //
 // The greedy multi-attempt model is preserved: extra crossings mean extra
 // attempts, and Stage 7 best-attempt selection picks the right one.
@@ -100,14 +105,15 @@ describe('entry-style SSS (launch outside the start cylinder)', () => {
   });
 });
 
-describe('XC movement gate on SSS crossings', () => {
+describe('XC drift gate and pre-flight anchor rejection on SSS crossings', () => {
   it('walk-in to an entry-style start, rig, fly inside: NO_SSS_CROSSING, not a silent 0 km', () => {
     // Pilot parks outside the 5 km entry SSS (boundary ≈ 47.5548), walks
     // north across it at 4 km/h, stands still 60 s rigging, then flies the
     // entire in-cylinder course through goal without ever re-crossing the
-    // SSS boundary. The walked crossing is the ONLY boundary crossing in
-    // the track; it must not spawn an attempt whose landing scan anchors at
-    // the rigging stillness and silently zeroes the flight.
+    // SSS boundary. Both endpoints of the walked crossing segment sit below
+    // the 5 km/h stillness threshold, so the drift gate drops it — and it is
+    // the ONLY boundary crossing in the track, so the upload gets the
+    // explicit error, not a flight silently zeroed at the rigging stillness.
     const fixes: Fix[] = [
       fx(0, 47.554, -122.0, 0), // parked
       fx(60, 47.5546, -122.0, 4), // walking
@@ -134,9 +140,10 @@ describe('XC movement gate on SSS crossings', () => {
   });
 
   it('parked-drift across the boundary is ignored; the flight starts on a later crossing', () => {
-    // Accepted edge of the gate: a pilot parked on the SSS boundary in
-    // strong wind drifts across it at ~3 km/h — that crossing is lost. The
-    // subsequent flown crossings still spawn attempts.
+    // Accepted edge of the drift gate: a pilot parked on the SSS boundary in
+    // strong wind drifts across it at ~3 km/h — BOTH endpoint fixes of the
+    // crossing segment are below the 5 km/h stillness threshold, so that
+    // crossing is lost. The subsequent flown crossings still spawn attempts.
     const task: TaskDefinition = {
       id: 'task-drift',
       turnpoints: [
@@ -164,6 +171,79 @@ describe('XC movement gate on SSS crossings', () => {
       expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(100_000);
       expect(attempt.reachedGoal).toBe(true);
     }
+  });
+
+  it('a slow-wind boundary penetration at ~6 km/h — the only crossing — still scores goal', () => {
+    // Routine strong-ridge-day physics for a paraglider: trim ~38–40 km/h
+    // minus ~33 km/h headwind ≈ 6 km/h ground speed while pushing out
+    // through the start boundary. Both endpoint fixes of the crossing
+    // segment are below 8 km/h — the old walking-pace gate dropped this
+    // crossing and, with no other boundary crossing in the track, rejected a
+    // legitimate goal flight with NO_SSS_CROSSING. The drift gate (5 km/h)
+    // lets it through, and no stillness follows, so the attempt stands.
+    const task: TaskDefinition = {
+      id: 'task-slow-wind',
+      turnpoints: [
+        { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+        { id: 'goal', sequenceIndex: 1, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+      ],
+    };
+    const fixes: Fix[] = [
+      fx(0, 47.5, -122.0, 6), // soaring inside the cylinder, pushing north
+      fx(60, 47.501, -122.0, 6),
+      fx(120, 47.502, -122.0, 6),
+      fx(180, 47.503, -122.0, 6),
+      fx(240, 47.504, -122.0, 6), // penetrates the boundary (≈ 47.5036) ≈ t=216 s
+      fx(300, 47.507, -122.0, 12), // climbs away
+      fx(360, 47.52, -122.0, 40),
+      fx(420, 47.55, -122.0, 55),
+      fx(480, 47.58, -122.0, 55),
+      fx(540, 47.61, -122.0, 55), // goal (boundary ≈ 47.5964), never re-enters SSS
+    ];
+
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true); // was: NO_SSS_CROSSING
+    if (!res.ok) return;
+
+    expect(res.value).toHaveLength(1);
+    const [attempt] = res.value;
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(180_000);
+    expect(attempt.sssCrossing.crossingTime).toBeLessThan(240_000);
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.taskTimeS).toBeGreaterThan(0);
+    expect(attempt.landingCutoffMs).toBeNull();
+    expect(attempt.truncationVoidedCrossing).toBeFalsy();
+  });
+
+  it('a walk-in crossing ABOVE the drift gate still errors when the whole flight stays inside', () => {
+    // Same walk-in shape as above but at 6 km/h — fast enough to pass the
+    // drift gate, so the crossing reaches the anchor logic. The rigging
+    // stillness in front of it shows no course progress (pre-flight ground
+    // time) and the flight never re-crosses the 5 km SSS boundary, so there
+    // is no crossing to re-anchor on: the upload gets the same explicit
+    // NO_SSS_CROSSING error, never a silently truncated pre-flight attempt.
+    const fixes: Fix[] = [
+      fx(0, 47.554, -122.0, 6), // walking north toward the boundary
+      fx(60, 47.5546, -122.0, 6),
+      fx(120, 47.5552, -122.0, 6), // walked across the boundary ≈ t=80 s
+      ...Array.from({ length: 15 }, (_, i) => fx(130 + i * 5, 47.5553, -122.0, 0.5)), // 70 s rigging
+      fx(260, 47.56, -122.0, 30), // launches
+      fx(320, 47.575, -122.0, 45),
+      fx(380, 47.59, -122.0, 45),
+      fx(440, 47.605, -122.0, 45),
+      fx(500, 47.617, -122.0, 45), // goal reached, still inside SSS
+    ];
+
+    const res = detectAttempts(fixes, ENTRY_TASK, 'XC');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('NO_SSS_CROSSING');
+
+    // HAF is exempt: the walked crossing is a legitimate start there.
+    const hafRes = detectAttempts(fixes, ENTRY_TASK, 'HIKE_AND_FLY');
+    expect(hafRes.ok).toBe(true);
+    if (!hafRes.ok) return;
+    expect(hafRes.value[0].reachedGoal).toBe(true);
   });
 });
 

--- a/tests/sss-direction.test.ts
+++ b/tests/sss-direction.test.ts
@@ -1,0 +1,224 @@
+// =============================================================================
+// SSS crossing direction — FAI §6.2.1 / §9.2.1
+//
+// §6.2.1: "The direction in which such a crossing occurs is irrelevant."
+// §9.2.1: a valid crossing is "a crossing into or out of the turnpoint's
+// tolerance zone, in any direction."
+//
+// Attempt detection must therefore spawn an attempt for EVERY boundary
+// crossing of the SSS cylinder — entries, exits, and both legs of a
+// graze-through — not just inside→outside transitions. Entry-style starts
+// (start cylinder that does not contain launch) previously produced zero SSS
+// crossings and rejected the whole upload with NO_SSS_CROSSING.
+//
+// XC movement gate: an XC start is flown, not walked. A boundary crossing
+// only spawns an attempt when the crossing segment shows movement — the
+// faster of its two endpoint fixes is ≥ 8 km/h. A pilot who walks across an
+// entry-style start boundary (~4–6 km/h) before launching gets the explicit
+// NO_SSS_CROSSING error, not a silently zeroed flight anchored at their
+// launch-prep stillness. Accepted edge: a pilot parked exactly on the
+// boundary in strong wind loses that particular crossing and starts on a
+// later one. HAF is exempt — walking is the point of the game there.
+//
+// The greedy multi-attempt model is preserved: extra crossings mean extra
+// attempts, and Stage 7 best-attempt selection picks the right one.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest';
+import { calculateDistances, detectAttempts, type Fix, runPipeline, type TaskDefinition } from '../src/shared/pipeline';
+import {
+  FIXTURE_INPUT,
+  FIXTURE_TASK_BEST_DISTANCE_KM,
+  FIXTURE_TASK_CLOSE_DATE,
+  FIXTURE_TASK_OPEN_DATE,
+} from '../src/shared/pipeline-parity-fixture';
+
+function fx(tSec: number, lat: number, lng = -122.0, speedKmh = 45): Fix {
+  return {
+    timestamp: tSec * 1000,
+    lat,
+    lng,
+    gpsAlt: 500,
+    pressureAlt: 500,
+    valid: true,
+    gspKmh: null,
+    derivedSpeedKmh: speedKmh,
+  };
+}
+
+// Entry-style start: a 5 km SSS cylinder whose interior contains the goal.
+// Launch is outside; the normal flight profile enters and never exits.
+const ENTRY_TASK: TaskDefinition = {
+  id: 'task-entry-sss',
+  turnpoints: [
+    { id: 'sss', sequenceIndex: 0, lat: 47.6, lng: -122.0, radiusM: 5000, type: 'SSS' },
+    { id: 'goal', sequenceIndex: 1, lat: 47.62, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+  ],
+};
+
+describe('entry-style SSS (launch outside the start cylinder)', () => {
+  it('a pilot who flies in and reaches goal without ever exiting is scored', () => {
+    // Northbound track: enters the SSS boundary (≈ 47.5548) between t=120
+    // and t=180, crosses the goal boundary (≈ 47.6164) between t=360 and
+    // t=420, and ends still inside the SSS cylinder.
+    const fixes = [
+      fx(0, 47.5),
+      fx(60, 47.52),
+      fx(120, 47.54),
+      fx(180, 47.56), // SSS entered
+      fx(240, 47.58),
+      fx(300, 47.6),
+      fx(360, 47.615),
+      fx(420, 47.625), // goal reached, still inside SSS
+    ];
+
+    const res = detectAttempts(fixes, ENTRY_TASK, 'XC');
+    expect(res.ok).toBe(true); // was: NO_SSS_CROSSING
+    if (!res.ok) return;
+
+    expect(res.value).toHaveLength(1);
+    const [attempt] = res.value;
+    // Start anchored at the inward crossing, between the straddling fixes.
+    expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(120_000);
+    expect(attempt.sssCrossing.crossingTime).toBeLessThan(180_000);
+    expect(attempt.reachedGoal).toBe(true);
+    expect(attempt.goalCrossing!.crossingTime).toBeGreaterThan(attempt.sssCrossing.crossingTime);
+    expect(attempt.taskTimeS).toBeGreaterThan(0);
+  });
+
+  it('a pilot who enters and lands inside the cylinder gets partial distance', () => {
+    const fixes = [fx(0, 47.5), fx(60, 47.53), fx(120, 47.56), fx(180, 47.59), fx(240, 47.61)];
+
+    const res = detectAttempts(fixes, ENTRY_TASK, 'XC');
+    expect(res.ok).toBe(true); // was: NO_SSS_CROSSING → zero score
+    if (!res.ok) return;
+
+    const [attempt] = calculateDistances(res.value, fixes, ENTRY_TASK);
+    expect(attempt.reachedGoal).toBe(false);
+    expect(attempt.lastTurnpointIndex).toBe(0);
+    expect(attempt.distanceFlownKm).toBeGreaterThan(1);
+  });
+});
+
+describe('XC movement gate on SSS crossings', () => {
+  it('walk-in to an entry-style start, rig, fly inside: NO_SSS_CROSSING, not a silent 0 km', () => {
+    // Pilot parks outside the 5 km entry SSS (boundary ≈ 47.5548), walks
+    // north across it at 4 km/h, stands still 60 s rigging, then flies the
+    // entire in-cylinder course through goal without ever re-crossing the
+    // SSS boundary. The walked crossing is the ONLY boundary crossing in
+    // the track; it must not spawn an attempt whose landing scan anchors at
+    // the rigging stillness and silently zeroes the flight.
+    const fixes: Fix[] = [
+      fx(0, 47.554, -122.0, 0), // parked
+      fx(60, 47.5546, -122.0, 4), // walking
+      fx(120, 47.5552, -122.0, 4), // walked across the boundary ≈ t=81 s
+      ...Array.from({ length: 7 }, (_, i) => fx(180 + i * 10, 47.5553, -122.0, 0.5)), // 60 s rigging
+      fx(300, 47.56, -122.0, 30), // launches
+      fx(360, 47.575, -122.0, 45),
+      fx(420, 47.59, -122.0, 45),
+      fx(480, 47.605, -122.0, 45),
+      fx(540, 47.617, -122.0, 45), // goal reached, still inside SSS
+    ];
+
+    const res = detectAttempts(fixes, ENTRY_TASK, 'XC');
+    // Explicit, pilot-visible error — the pre-branch behaviour for walk-ins.
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('NO_SSS_CROSSING');
+
+    // HAF is exempt: the walked crossing is a legitimate start there.
+    const hafRes = detectAttempts(fixes, ENTRY_TASK, 'HIKE_AND_FLY');
+    expect(hafRes.ok).toBe(true);
+    if (!hafRes.ok) return;
+    expect(hafRes.value[0].reachedGoal).toBe(true);
+  });
+
+  it('parked-drift across the boundary is ignored; the flight starts on a later crossing', () => {
+    // Accepted edge of the gate: a pilot parked on the SSS boundary in
+    // strong wind drifts across it at ~3 km/h — that crossing is lost. The
+    // subsequent flown crossings still spawn attempts.
+    const task: TaskDefinition = {
+      id: 'task-drift',
+      turnpoints: [
+        { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+        { id: 'goal', sequenceIndex: 1, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+      ],
+    };
+    const fixes: Fix[] = [
+      fx(0, 47.503, -122.0, 3), // parked just inside the boundary (≈ 334 m)
+      fx(60, 47.504, -122.0, 3), // drifted outside (≈ 445 m) — crossing gated out
+      fx(120, 47.5035, -122.0, 25), // airborne now — flies back in ≈ t=103 s
+      fx(180, 47.52, -122.0, 60), // and out again ≈ t=121 s
+      fx(240, 47.55, -122.0, 60),
+      fx(300, 47.58, -122.0, 60),
+      fx(360, 47.61, -122.0, 60), // goal
+    ];
+
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // Two flown crossings spawn attempts; the ~44 s drift crossing does not.
+    expect(res.value).toHaveLength(2);
+    for (const attempt of res.value) {
+      expect(attempt.sssCrossing.crossingTime).toBeGreaterThan(100_000);
+      expect(attempt.reachedGoal).toBe(true);
+    }
+  });
+});
+
+describe('graze-through of the SSS cylinder (both fixes outside)', () => {
+  it('spawns an attempt for each boundary crossing of the clipped segment', () => {
+    const task: TaskDefinition = {
+      id: 'task-graze',
+      turnpoints: [
+        { id: 'sss', sequenceIndex: 0, lat: 47.5, lng: -122.0, radiusM: 400, type: 'SSS' },
+        { id: 'goal', sequenceIndex: 1, lat: 47.6, lng: -122.0, radiusM: 400, type: 'GOAL_CYLINDER' },
+      ],
+    };
+    // Segment t=0 → t=60 passes clean through the SSS cylinder: both
+    // endpoints are ≈ 1.1 km from the centre, well outside r+tol ≈ 405 m.
+    const fixes = [fx(0, 47.49), fx(60, 47.51), fx(120, 47.55), fx(180, 47.59), fx(240, 47.61)];
+
+    const res = detectAttempts(fixes, task, 'XC');
+    expect(res.ok).toBe(true); // was: NO_SSS_CROSSING
+    if (!res.ok) return;
+
+    // One attempt per boundary crossing: the entry leg and the exit leg.
+    expect(res.value).toHaveLength(2);
+    const [entry, exit] = res.value;
+    expect(entry.sssCrossing.crossingTime).toBeGreaterThan(0);
+    expect(exit.sssCrossing.crossingTime).toBeGreaterThan(entry.sssCrossing.crossingTime);
+    expect(exit.sssCrossing.crossingTime).toBeLessThan(60_000);
+    for (const attempt of res.value) expect(attempt.reachedGoal).toBe(true);
+  });
+});
+
+describe('exit-style SSS regression (parity fixture baseline)', () => {
+  it('keeps the pre-change best-attempt numbers; the new entry attempt loses on points', async () => {
+    const result = await runPipeline(
+      FIXTURE_INPUT,
+      FIXTURE_TASK_OPEN_DATE,
+      FIXTURE_TASK_CLOSE_DATE,
+      FIXTURE_TASK_BEST_DISTANCE_KM,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The fixture track enters then exits the SSS — two crossings, two
+    // attempts (previously only the exit spawned one).
+    expect(result.value.scoredAttempts).toHaveLength(2);
+
+    // Best attempt is still the exit-anchored one (later start → shorter
+    // task time → more time points), with the exact numbers the parity
+    // tests pin.
+    const best = result.value.scoredAttempts[result.value.bestAttemptIndex];
+    const other = result.value.scoredAttempts.find((a) => a !== best)!;
+    expect(best.sssCrossing.crossingTime).toBeGreaterThan(other.sssCrossing.crossingTime);
+    expect(best.reachedGoal).toBe(true);
+    expect(best.turnpointCrossings.map((c) => c.sequenceIndex)).toEqual([0, 1, 2]);
+    expect(best.distanceFlownKm).toBeCloseTo(3.65, 2);
+    expect(best.taskTimeS).toBeGreaterThan(0);
+    expect(best.taskTimeS).toBeLessThan(other.taskTimeS!);
+  });
+});

--- a/tests/time-points.test.ts
+++ b/tests/time-points.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeTimePoints, MAX_POINTS } from '../src/shared/task-engine';
+import { computeDistancePoints, computeTimePoints, MAX_POINTS } from '../src/shared/task-engine';
 
 const hms = (h: number, m: number, s: number) => h * 3600 + m * 60 + s;
 
@@ -53,5 +53,21 @@ describe('computeTimePoints (FAI S7F §12.2)', () => {
     // A pilot faster than the pool minimum (should not happen — the pool
     // includes the pilot) clamps to full points rather than NaN.
     expect(computeTimePoints(3000, [3600])).toBe(MAX_POINTS);
+  });
+});
+
+// Rounding to one decimal happens exactly once, on the persisted value after
+// normalisation (rebuildTaskResults) — the compute functions themselves must
+// return full precision, or the later scale-then-round compounds two rounding
+// errors (S7F round-once principle).
+describe('compute functions return unrounded values', () => {
+  it('computeTimePoints keeps full precision', () => {
+    // A 0.1-pre-rounded return would collapse this to exactly 686.3.
+    expect(computeTimePoints(3032, [2314, 3032])).toBeCloseTo(686.3155932494, 6);
+  });
+
+  it('computeDistancePoints keeps full precision', () => {
+    // 1000 * sqrt(60.0089 / 80) — a 0.1-pre-rounded return would give 866.1.
+    expect(computeDistancePoints(60.0089, 80, false)).toBeCloseTo(866.089631620192, 6);
   });
 });


### PR DESCRIPTION
Stacked on #64. Implements the nine **bug-class** findings from the S7F compliance audit, then closes six regressions found by an adversarial review of the first implementation (each confirmed with an executable repro before fixing).

## Pipeline — flight model

**Landing detection (XC only).** Post-landing fixes could earn distance, turnpoint crossings, and even goal (a pilot could land short and be *driven* across the goal line — §9.3 requires "still flying"). Now: a single per-track cutoff at the first sustained-stillness window (≥30 s, every fix < 5 km/h, gpsAlt range < 15 m) after the first valid SSS crossing.
- Attempts whose SSS crossing postdates the landing are suppressed — a retrieve car re-crossing the start cylinder can't spawn a fresh scoring attempt and poison `t_best` for the field.
- The altitude-flatness requirement protects parked ridge-soaring (near-zero ground speed in wind) from false positives; a truncation that voids crossings sets the existing ⚑ flag so admins see it rather than a silent rescore.
- HAF seasons are fully exempt (landing mid-task is legitimate there).

**Direction-agnostic SSS (§6.2.1).** Start crossings were exit-only; entry-style start cylinders rejected every flight with zero distance. Both directions now spawn attempts (greedy multi-attempt model preserved). An 8 km/h movement gate stops on-foot boundary crossings from starting the clock — a walk-in track again gets the explicit `NO_SSS_CROSSING` error.

**Strict crossing order (§9.2.1.2a).** Crossings could be stamped at or before the previous turnpoint's crossing (already-inside tagging), enabling shortened or even negative task times. Timestamps are now strictly increasing, and order-rejected candidates retry the remaining intersection roots on the same segment so graze-throughs and same-segment exits aren't forfeited.

## Scoring

- Rank tiebreak by task time now applies only to pilots who reached goal (§13.1: PG parameter is 0% — ESS-without-goal earns no time credit).
- Compute functions return full precision; rounding to one decimal happens **once**, after normalization scaling (was rounded twice, drifting up to 0.1 pt).
- Goal-line tasks no longer get a cylinder radius subtracted in the fix-inside-goal guard (§9.3 line-goal geometry).
- `PUT /tasks/:id` with a changed `taskValue` rebuilds `task_results` in the same transaction (previously stale until the next upload).

## Frontend

- The client preview now keeps the pilot's own leaderboard row in the `t_best`/`bestDist` pools — the server never discards prior attempts — and exposes `predicted` (which of existing-best vs preview survives, at post-upload scale). FlightPreviewPanel renders the comparison on one scale instead of mixing pre- and post-upload normalizations.
- UploadZone marks all score components provisional while the task is open, not just time points (distance can rescale too).

## Deploy note

`SCORER_VERSION` 1.2 → 1.3: the boot reprocess loop re-runs every stored IGC, so **existing results will change** — that's the point (retrieve-inflated distances shrink, out-of-order crossings void). Flagged rows (⚑) deserve a manual look after the first deploy.

## Verification

294 backend + 36 frontend tests pass (59 new), typecheck clean. New regression tests reconstruct each review repro: car-retrieve SSS re-crossing, walk-in entry start, same-segment graze root, concentric-cylinder exit, parked-soaring false positive, and the preview scale-mixing cases.

Known accepted limitations (documented in code): a pilot parked exactly on the SSS boundary loses that particular crossing (starts on a later one); flight-vs-drive classification relies on the landing-stillness signature rather than per-fix AGL (no DEM dependency, per CLAUDE.md).