### PR TITLE
Align scoring with FAI S7F: §11 weights, 0.1% tolerance, shared ranks

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -584,7 +584,7 @@ runPipeline result
 | `detectAttempts` | Quadratic formula (parameterised segment-circle intersection); linear time interpolation at parameter `t`; goal line via segment-segment intersection; multiple SSS crossings → multiple attempts | `NO_SSS_CROSSING` |
 | `classifyGroundState` | 30s sustained speed window classifies each fix `GROUND` / `AIRBORNE` / `UNKNOWN`; 60s window around `GROUND_ONLY` crossing stores `detectedMaxSpeedKmh` | (no error — informational only) |
 | `calculateDistances` | Vincenty geodesic (`geographiclib-geodesic`) for point-to-point legs; goal pilots get full `optimisedDistanceKm`; partial pilots get cumulative distance + closest approach to next TP | — |
-| `scoreAttempts` | **Distance:** `938 * sqrt(d_pilot / d_best)` (or 938 for goal). **Time (FAI S7F §12.2):** `938 * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best))^(5/6))`, times in hours — provisional until task closes | — |
+| `scoreAttempts` | Available pools split by goal ratio (FAI S7F §11): `availDist = DW * 1000`, `availTime = (1 - DW) * 1000`. **Distance:** `availDist * sqrt(d_pilot / d_best)` (or `availDist` for goal). **Time (§12.2):** `availTime * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best))^(5/6))`, times in hours — provisional until task closes | — |
 | `selectBestAttempt` | Priority: (1) reached goal, (2) highest total points, (3) lowest task time | — |
 
 **Rescoring:** When a new goal pilot is detected, `RESCORE_TASK` job calls `rescoreTimePoints` — the same GAP formula applied across all known goal times for that task. `task_results` and `season_standings` are updated atomically via follow-up jobs.

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -199,15 +199,14 @@ Handles `POST .../tasks/:taskId/submissions` and `GET .../submissions/:submissio
 6. Call `runPipeline` inline — result delivered in the HTTP response (design decision: synchronous scoring)
 7. On pipeline failure: 422 with human-readable error via `formatPipelineError`
 8. On success: atomic transaction inserting into `flight_submissions` + `turnpoint_crossings`
-9. If `reachedGoal`: enqueue `RESCORE_TASK` (time points are provisional)
-10. Return 201 with scored submission + `provisional: true` flag
+9. `rebuildTaskResults` runs synchronously in the same transaction — the whole task rescores
+10. Return 201 with scored submission + `timePointsProvisional: true` (any later upload can rescore everyone while the task is open)
 
 **Download handler (`handleIgcDownload`):**
 
-Serves raw IGC BLOB. Access control:
-- Own submission: always accessible
-- Other pilot's file: hidden (403) until `scores_frozen_at` is set
-- Frozen files: `Cache-Control: public, max-age=86400`
+Serves raw IGC BLOB. Access control: own submission or league membership. (The old
+`scores_frozen_at`-gated visibility rule was removed along with the freeze concept in
+migration 0013 — "closed" is derived from `close_date`.)
 
 ---
 
@@ -217,7 +216,7 @@ Handles `GET .../submissions/:submissionId/track`.
 
 **Design decision:** GPS fixes are **not stored** in the database. They are re-parsed from the raw IGC BLOB on every request (~10–30 ms). Storing ~10,000 fixes per submission at club scale (e.g. 200 submissions) would add ~50 MB of rarely-accessed data to SQLite. Turnpoint crossing events (computed at submission time) are loaded from the DB and overlaid on the re-parsed fixes.
 
-**Access control:** Own submission or league admin always has access. Other pilots' tracks are hidden (403) until `scores_frozen_at` — prevents live-tracking competitors during an open task.
+**Access control:** League-scoped (the resolve-league hook); the freeze-gated visibility rule went away with `scores_frozen_at` in migration 0013.
 
 **Response shape:** `{ submissionId, taskId, pilotId, pilotName, flightDate, fixes[], crossings[], bounds, meta }` — fixes are compact `{ t, lat, lng, alt }` tuples; `bounds` is a pre-computed bounding box with 5% padding.
 
@@ -320,7 +319,7 @@ Cannot reopen a closed season.
 ```
 draft ──publish──▶ published  (requires at least one turnpoint)
 published ──unpublish──▶ draft  (blocked if any submissions exist)
-published ──freeze──▶ published + scores_frozen_at set  (cannot unfreeze)
+(no freeze step: submissions stop at close_date; scores settle naturally — migration 0013)
 ```
 
 ---
@@ -346,7 +345,6 @@ leagues ────────────────────────
   │                      │ 1:N flight_attempts                      │
   │                              │ 1:N turnpoint_crossings          │
   │                                      │ 1:N turnpoint_overrides  │
-  │ 1:N season_standings ◀────────────────────────────── users      │
   │ 1:N task_results ◀────────────────────────────────── users      │
   │                                                                 │
 jobs (queue)                                                        │
@@ -382,7 +380,7 @@ admin_audit_log
 
 | Table | Key columns | Notes |
 |---|---|---|
-| `tasks` | `id`, `season_id`, `league_id` (denormalised), `name`, `task_type`, `open_date`, `close_date`, `scores_frozen_at`, `status` (`draft`\|`published`), `sss_turnpoint_id`, `ess_turnpoint_id`, `goal_turnpoint_id`, `optimised_distance_km`, `task_data_source`, `task_data_raw` | FK cycle on SSS/ESS/goal IDs enforced in application layer (SQLite deferred FK limitation) |
+| `tasks` | `id`, `season_id`, `league_id` (denormalised), `name`, `task_type`, `open_date`, `close_date`, `status` (`draft`\|`published`), `normalized_score`, `sss_turnpoint_id`, `ess_turnpoint_id`, `goal_turnpoint_id`, `task_data_source`, `task_data_raw` | FK cycle on SSS/ESS/goal IDs enforced in application layer (SQLite deferred FK limitation); `scores_frozen_at` dropped in migration 0013 |
 | `turnpoints` | `task_id`, `league_id` (denormalised), `sequence_index`, `name`, `latitude`, `longitude`, `radius_m`, `type`, `goal_line_bearing_deg` | `type` values: `CYLINDER`, `GROUND_ONLY`, `AIR_OR_GROUND`, `SSS`, `ESS`, `GOAL_CYLINDER`, `GOAL_LINE`; unique on `(task_id, sequence_index)` |
 
 #### Submission / Scoring
@@ -398,8 +396,7 @@ admin_audit_log
 
 | Table | Key columns | Notes |
 |---|---|---|
-| `season_standings` | `season_id`, `user_id`, `total_points`, `tasks_completed`, `rank` | Upserted by `REBUILD_STANDINGS` job; primary key `(season_id, user_id)` |
-| `task_results` | `task_id`, `user_id`, `total_points`, `distance_points`, `time_points`, `rank`, `best_attempt_id` | Upserted by `RESCORE_TASK` job |
+| `task_results` | `task_id`, `user_id`, `total_points`, `distance_points`, `time_points`, `rank`, `best_attempt_id` | Rebuilt synchronously by `rebuildTaskResults` on every upload/delete/`normalized_score` edit — the single source of truth for scoring. (`season_standings` was dropped in migration 0013; standings are a live SQL aggregate.) |
 
 #### Infrastructure
 
@@ -419,7 +416,6 @@ idx_submissions_user    ON flight_submissions (user_id)   WHERE deleted_at IS NU
 idx_submissions_dedup   ON flight_submissions (task_id, user_id, igc_sha256) UNIQUE WHERE deleted_at IS NULL
 idx_turnpoints_task     ON turnpoints (task_id)           WHERE deleted_at IS NULL
 idx_jobs_status         ON jobs (status, scheduled_at)    WHERE status IN ('PENDING', 'FAILED')
-idx_standings_season    ON season_standings (season_id, total_points DESC)
 idx_task_results_task   ON task_results (task_id, total_points DESC)
 ```
 
@@ -473,8 +469,8 @@ POST .../tasks/:taskId/submissions
       INSERT flight_submissions (status='PROCESSED', igc_data BLOB, scores)
       INSERT turnpoint_crossings (per crossing)
       UPDATE flight_submissions SET best_attempt_id = ?
-  → if reachedGoal: queue.enqueue('RESCORE_TASK')
-  → 201 { submission, provisional: reachedGoal }
+  → rebuildTaskResults(db, taskId)   (synchronous, same transaction)
+  → 201 { submission, timePointsProvisional: true }
 ```
 
 ### Background Job Lifecycle
@@ -587,7 +583,7 @@ runPipeline result
 | `scoreAttempts` | Available pools split by goal ratio (FAI S7F §11): `availDist = DW * 1000`, `availTime = (1 - DW) * 1000`. **Distance:** `availDist * sqrt(d_pilot / d_best)` (or `availDist` for goal). **Time (§12.2):** `availTime * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best))^(5/6))`, times in hours — provisional until task closes | — |
 | `selectBestAttempt` | Priority: (1) reached goal, (2) highest total points, (3) lowest task time | — |
 
-**Rescoring:** When a new goal pilot is detected, `RESCORE_TASK` job calls `rescoreTimePoints` — the same GAP formula applied across all known goal times for that task. `task_results` and `season_standings` are updated atomically via follow-up jobs.
+**Rescoring:** Every upload, submission delete, and `normalized_score` edit triggers a synchronous `rebuildTaskResults` (src/job-queue.ts) inside the same transaction. The rebuild re-derives everything for the whole task from stored attempts: `t_best`, best distance, the §11 goal-ratio distance/time split, and the normalization scale — any single upload can move every pilot's points. Season standings are a live SQL aggregate over `task_results`; there are no rescore jobs. (`rescoreTimePoints`/`RESCORE_TASK` were the pre-0013 job-based flow and no longer exist.)
 
 ---
 
@@ -623,24 +619,12 @@ runPipeline result
 
 ### Job Types
 
-| Type | Trigger | Action |
-|---|---|---|
-| `RESCORE_TASK` | New goal submission; task freeze | Recalculate time points for all goal attempts; upsert `task_results`; enqueue `REBUILD_STANDINGS` and optionally `NOTIFY_PILOTS` |
-| `FREEZE_TASK_SCORES` | Task creation (scheduled at `close_date`) | Set `scores_frozen_at`; enqueue final `RESCORE_TASK` |
-| `REBUILD_STANDINGS` | After any rescore | Aggregate `task_results` into `season_standings` with ranking |
-| `REPROCESS_ALL_SUBMISSIONS` | Admin edits turnpoints | Re-run full pipeline per submission sequentially; errors on individual submissions are caught and logged |
-| `NOTIFY_PILOTS` | After rescore with score changes | Bulk insert `notifications` rows for affected pilots |
-
-### Job Dependency Graph
-
-```
-New goal submission ──▶ RESCORE_TASK ──▶ REBUILD_STANDINGS
-                                     └──▶ NOTIFY_PILOTS
-
-Task created ──▶ FREEZE_TASK_SCORES (at close_date) ──▶ RESCORE_TASK (final)
-
-Admin edits TPs ──▶ REPROCESS_ALL_SUBMISSIONS ──▶ RESCORE_TASK ──▶ ...
-```
+**None are registered today.** Scoring became fully synchronous (migration 0013):
+`rebuildTaskResults` runs inline on the upload and delete paths, standings are a live SQL
+aggregate, and stale-track reprocessing runs at boot (`src/reprocess.ts`, keyed off
+`SCORER_VERSION`). The queue/worker infrastructure remains for future async work
+(notifications etc.); the server deletes jobs of removed types (`RESCORE_TASK`,
+`FREEZE_TASK_SCORES`, `REBUILD_STANDINGS`, …) at startup.
 
 ### Retry Policy
 
@@ -720,11 +704,11 @@ All major tables have `deleted_at TEXT NULL`. Queries use `WHERE deleted_at IS N
 
 ### Denormalised `league_id`
 
-`league_id` is stored directly on tasks, turnpoints, submissions, attempts, `task_results`, and `season_standings`. This avoids JOIN chains (e.g. `submission → task → season → league`) on every query and makes tenant-scoping straightforward.
+`league_id` is stored directly on tasks, turnpoints, submissions, attempts, and `task_results`. This avoids JOIN chains (e.g. `submission → task → season → league`) on every query and makes tenant-scoping straightforward.
 
-### Materialised caches for leaderboards
+### Materialised task results
 
-`season_standings` and `task_results` are pre-computed by background jobs rather than calculated on every request. The cost of slightly stale data (up to one job cycle behind) is outweighed by consistent O(1) leaderboard reads.
+`task_results` is rebuilt synchronously from `flight_attempts` on every scoring-relevant write, so leaderboard reads are O(1) and never stale. Season standings are aggregated live from `task_results` in SQL (small enough at club scale; `season_standings` was dropped in migration 0013).
 
 ---
 

--- a/frontend/src/components/TaskMap.tsx
+++ b/frontend/src/components/TaskMap.tsx
@@ -468,8 +468,8 @@ export default function TaskMap({ turnpoints, height = 300, track, tracks }: Tas
     // the role colour on every channel means a ground SSS still reads as
     // blue — you don't have to remember which earth-tone overlay belongs to
     // which role. Outside each strict ring we shade the annular band between
-    // r and r + tagToleranceM(r) (max(5 m, 0.5 % of r)) — the band the
-    // scoring pipeline actually accepts for tag detection.
+    // r and r + tagToleranceM(r) (§9.1.1: max(5 m, 0.1 % of r)) — the band
+    // the scoring pipeline actually accepts for tag detection.
     for (const group of groups) {
       for (const { radiusM, color, forceGround } of mergeCircles(group.entries.filter((e) => !e.isGoalLine))) {
         const { r } = projR(group.lng, group.lat, radiusM);
@@ -477,7 +477,7 @@ export default function TaskMap({ turnpoints, height = 300, track, tracks }: Tas
 
         // Annular tolerance band (donut between r and r + tolerance) drawn as
         // a single path with two subpaths and evenodd fill-rule. The buffer
-        // is small in absolute terms (5 m floor, then 0.5 % of r), so we
+        // is small in absolute terms (5 m floor, then 0.1 % of r), so we
         // shade the band rather than drawing a thin ring — much more
         // visible on big cylinders and still tolerable on small ones. No
         // `stroke` here on purpose: a stroke would paint both subpaths and

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -114,22 +114,23 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
 
     // previewSubmission also applies the same task-level normalisation that
     // rebuildTaskResults runs server-side. Fixture setup:
-    //   - prior finisher: goal at 120 s → raw 1000 dist + 1000 time = 2000
-    //   - preview: goal at ~147 s → raw 1000 dist + 929.6 time (§12.2,
-    //     anchored at t_best = 120 s)
-    //   - winner raw = 2000 → scale = 1000 / 2000 = 0.5
-    //   - preview normalised: 500 dist + 464.8 time = 964.8
+    //   - both pilots in goal → §11 goal ratio 1 → DW 0.361 / TW 0.639
+    //   - prior finisher: goal at 120 s → raw 361 dist + 639 time = 1000
+    //   - preview: goal at ~147 s → raw 361 dist + 594.0 time (§12.2,
+    //     anchored at t_best = 120 s, over the 639 pool)
+    //   - winner raw = 1000 → scale = 1000 / 1000 = 1
+    //   - preview normalised: 361 dist + 594.0 time = 955.0
     // If this assertion ever drifts, either the normalisation logic changed
     // or the underlying scoring formulas did — both cases want a closer look
     // because the backend's rebuildTaskResults would have followed suit.
-    expect(best.distancePoints).toBeCloseTo(500, 1);
-    expect(best.timePoints).toBeCloseTo(464.8, 1);
-    expect(best.totalPoints).toBeCloseTo(964.8, 1);
+    expect(best.distancePoints).toBeCloseTo(361, 1);
+    expect(best.timePoints).toBeCloseTo(594.0, 1);
+    expect(best.totalPoints).toBeCloseTo(955.0, 1);
 
     // First submission for 'new-pilot' — the preview itself is the pilot's
     // predicted leaderboard row.
     expect(res.value.predicted.source).toBe('preview');
-    expect(res.value.predicted.totalPoints).toBeCloseTo(964.8, 1);
+    expect(res.value.predicted.totalPoints).toBeCloseTo(955.0, 1);
 
     // Frontend-only: previewSubmission also surfaces fixes for the map. Each
     // B record should produce one fix.
@@ -140,13 +141,16 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
 
   it("keeps the current pilot's standing goal time in the t_best pool when they preview a slower flight", async () => {
     // Pilot 'me' holds t_best = 100 s and previews the fixture flight
-    // (goal at ~147.2 s). The server never discards the old attempt, so:
-    //   - goal-time pool stays {100, 120, 147.2} → preview raw time = 879.8
-    //   - me's existing attempt (raw 2000) stays their best AND the winner
-    //   - scale = 1000 / 2000 = 0.5 → preview shows 500 + 439.9 = 939.9
+    // (goal at ~147.2 s). Everyone is in goal → GR 1 → DW 0.361 / TW 0.639.
+    // The server never discards the old attempt, so:
+    //   - goal-time pool stays {100, 120, 147.2} → preview raw time = 562.2
+    //     (§12.2 SpeedFraction over the 639 pool)
+    //   - me's existing attempt (raw 361 + 639 = 1000) stays their best AND
+    //     the winner → scale = 1000 / 1000 = 1
+    //   - preview shows 361 + 562.2 = 923.2
     //   - predicted row = the existing attempt at the full 1000
-    // The pre-fix code dropped me's row, anchoring t_best at 120 s (preview
-    // time 464.8 normalised) and predicting the preview as me's new row.
+    // The pre-fix code dropped me's row, anchoring t_best at 120 s and
+    // predicting the preview as me's new row.
     const entries = [
       mkEntry({ pilotId: 'me', distanceFlownKm: 3.65, reachedGoal: true, taskTimeS: 100 }),
       mkEntry({ pilotId: 'other', distanceFlownKm: 3.65, reachedGoal: true, taskTimeS: 120 }),
@@ -157,14 +161,14 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
     if (!res.ok) return;
 
     const best = res.value.attempts[res.value.bestAttemptIndex];
-    expect(best.distancePoints).toBeCloseTo(500, 1);
-    expect(best.timePoints).toBeCloseTo(439.9, 1);
-    expect(best.totalPoints).toBeCloseTo(939.9, 1);
+    expect(best.distancePoints).toBeCloseTo(361, 1);
+    expect(best.timePoints).toBeCloseTo(562.2, 1);
+    expect(best.totalPoints).toBeCloseTo(923.2, 1);
 
     expect(res.value.predicted.source).toBe('existing');
     expect(res.value.predicted.taskTimeS).toBe(100);
-    expect(res.value.predicted.distancePoints).toBeCloseTo(500, 1);
-    expect(res.value.predicted.timePoints).toBeCloseTo(500, 1);
+    expect(res.value.predicted.distancePoints).toBeCloseTo(361, 1);
+    expect(res.value.predicted.timePoints).toBeCloseTo(639, 1);
     expect(res.value.predicted.totalPoints).toBeCloseTo(1000, 1);
   });
 });
@@ -172,11 +176,12 @@ describe('previewSubmission parity — frontend wraps runPipeline against shared
 describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () => {
   it('matches the server when the previewing pilot holds t_best (verifier worked example)', () => {
     // A holds t_best = 3600 s, B in goal at 4500 s, A previews 5400 s,
-    // taskValue 1000. Server truth: pool stays {3600, 4500, 5400}, A's best
-    // attempt remains the 3600 s one → A stays winner at 1000 and B keeps
-    // 685.0 raw time points. The preview's own §12.2 time points anchor at
-    // 3600 s → raw 438.8, scaled by 1000/2000 → 219.4 (NOT the 856.5 total
-    // the pre-fix pool {4500, 5400} produced).
+    // taskValue 1000. Both pilots in goal → GR 1 → DW 0.361 / TW 0.639.
+    // Server truth: pool stays {3600, 4500, 5400}, A's best attempt remains
+    // the 3600 s one → A stays winner at raw 361 + 639 = 1000 (scale 1) and
+    // B keeps 437.7 raw time points. The preview's own §12.2 time points
+    // anchor at 3600 s → 280.4 over the 639 pool (NOT the larger figure a
+    // pool without A's row, anchored at 4500 s, would produce).
     const entries = [
       mkEntry({ pilotId: 'A', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }),
       mkEntry({ pilotId: 'B', distanceFlownKm: 50, reachedGoal: true, taskTimeS: 4500 }),
@@ -188,9 +193,9 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       1000,
     );
 
-    expect(r.distancePoints).toBeCloseTo(500, 1);
-    expect(r.timePoints).toBeCloseTo(219.4, 1);
-    expect(r.totalPoints).toBeCloseTo(719.4, 1);
+    expect(r.distancePoints).toBeCloseTo(361, 1);
+    expect(r.timePoints).toBeCloseTo(280.4, 1);
+    expect(r.totalPoints).toBeCloseTo(641.4, 1);
 
     expect(r.predicted.source).toBe('existing');
     expect(r.predicted.taskTimeS).toBe(3600);
@@ -211,8 +216,9 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       1000,
     );
 
-    // Preview wins → winner raw = 1000 dist + 1000 time (sole goal time) =
-    // 2000, scale 0.5.
+    // Preview wins → GR = 1/2 (me in goal via the preview, other not) →
+    // DW 0.422375; winner raw = 422.375 dist + 577.625 time (sole goal
+    // time) = 1000, scale 1.
     expect(r.predicted.source).toBe('preview');
     expect(r.predicted.reachedGoal).toBe(true);
     expect(r.totalPoints).toBeCloseTo(1000, 1);
@@ -234,8 +240,8 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
       1000,
     );
 
-    // Preview raw: 1000 dist (full task distance in goal) + 1000 time (sole
-    // goal time) = 2000 → winner → scale 0.5 → normalized 1000.
+    // Sole pilot, now in goal → GR 1 → DW 0.361. Preview raw: 361 dist +
+    // 639 time (sole goal time) = 1000 → winner → scale 1 → normalized 1000.
     expect(r.totalPoints).toBeCloseTo(1000, 1);
     expect(r.predicted.source).toBe('preview');
     expect(r.predicted.reachedGoal).toBe(true);
@@ -246,7 +252,9 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
   it('keeps the existing further non-goal flight as the predicted row and in the bestDist pool', () => {
     // me's standing 30 km row stays in the bestDist pool (server pools
     // MAX(distance) over ALL attempts), so the 10 km preview scores
-    // sqrt(10/30) of 1000, and the standing row remains the winner.
+    // sqrt(10/30) of the winner's 1000, and the standing row remains the
+    // winner. (GR = 0 → the 0.9 distance weight scales winner and preview
+    // alike, so normalization washes it out of the ratio.)
     const entries = [mkEntry({ pilotId: 'me', distanceFlownKm: 30, reachedGoal: false })];
     const r = normalizePreviewPoints(
       att({ distanceFlownKm: 10, reachedGoal: false, taskTimeS: null }),
@@ -272,9 +280,32 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
     );
 
     expect(r.predicted.source).toBe('preview');
-    // bestDist = 40 → preview raw = 1000·sqrt(20/40) = 707.1; winner is
-    // 'other' at raw 1000 → scale 1.
+    // GR = 0 → pool 900. bestDist = 40 → preview raw = 900·√(20/40) =
+    // 636.4; winner is 'other' at raw 900 → scale 1000/900 → 707.1.
     expect(r.totalPoints).toBeCloseTo(707.1, 1);
+  });
+
+  it('a goal preview moves the goal ratio and reproduces the server rebuild exactly', () => {
+    // Companion to the standings.test.ts case "GR-changing upload parity":
+    // one non-goal pilot at 40 km is on the board (GR = 0); pilot 'me'
+    // previews a goal flight at 50 km / 3600 s. Post-upload the server field
+    // is 2 pilots with 1 in goal → GR = 0.5 → DW = 0.422375 / TW = 0.577625,
+    // and the rebuild persists 422.4 + 577.6 = 1000 for the goal pilot. The
+    // preview must show those exact numbers — a 50/50 (or GR = 0) split
+    // would not.
+    const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
+    const r = normalizePreviewPoints(
+      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 },
+      entries,
+      'me',
+      1000,
+    );
+
+    expect(r.distancePoints).toBeCloseTo(422.4, 1);
+    expect(r.timePoints).toBeCloseTo(577.6, 1);
+    expect(r.totalPoints).toBeCloseTo(1000, 1);
+    expect(r.predicted.source).toBe('preview');
+    expect(r.predicted.totalPoints).toBeCloseTo(1000, 1);
   });
 });
 

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -426,12 +426,14 @@ const MULTI_ATTEMPT_IGC = [
 
 describe('previewSubmission — every attempt shares the post-upload scale', () => {
   it('applies the single taskValue/winnerRaw scale to non-best attempts (no raw-1000-scale leftovers)', async () => {
-    // Prior finisher at 120 s holds the winner raw total (2000), so the
-    // normalisation scale is well below 1 — any attempt left on the raw
-    // pipeline scale would stick out.
+    // Under the §11 split a goal winner's raw total is exactly 1000
+    // (availDist + availTime), so a default task value of 1000 gives
+    // scale = 1 and this test would lose its teeth. taskValue 500 forces
+    // scale = 0.5 — any attempt left on the raw pipeline scale sticks out.
+    const scaledTask = { ...task, taskValue: 500 };
     const res = await previewSubmission(
       MULTI_ATTEMPT_IGC,
-      task,
+      scaledTask,
       { competitionType: 'XC' },
       leaderboardEntries,
       'new-pilot',
@@ -471,7 +473,7 @@ describe('previewSubmission — every attempt shares the post-upload scale', () 
       raw.value.scoredAttempts[bestIdx],
       leaderboardEntries,
       'new-pilot',
-      1000,
+      500,
     );
     expect(scale).toBeGreaterThan(0);
     expect(scale).toBeLessThan(1); // guard: the scale actually moves the numbers

--- a/frontend/src/lib/previewPipeline.test.ts
+++ b/frontend/src/lib/previewPipeline.test.ts
@@ -294,12 +294,7 @@ describe('normalizePreviewPoints — pool parity with rebuildTaskResults', () =>
     // preview must show those exact numbers — a 50/50 (or GR = 0) split
     // would not.
     const entries = [mkEntry({ pilotId: 'other', distanceFlownKm: 40, reachedGoal: false })];
-    const r = normalizePreviewPoints(
-      { distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 },
-      entries,
-      'me',
-      1000,
-    );
+    const r = normalizePreviewPoints({ distanceFlownKm: 50, reachedGoal: true, taskTimeS: 3600 }, entries, 'me', 1000);
 
     expect(r.distancePoints).toBeCloseTo(422.4, 1);
     expect(r.timePoints).toBeCloseTo(577.6, 1);

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -8,7 +8,7 @@
 
 import type { PipelineError, ScoredAttempt } from '../../../src/shared/pipeline';
 import { parseAndValidate, runPipelineFromParsed } from '../../../src/shared/pipeline';
-import { computeDistancePoints, computeTimePoints, MAX_POINTS } from '../../../src/shared/task-engine';
+import { computeDistancePoints, computeTimePoints, goalRatioWeights, MAX_POINTS } from '../../../src/shared/task-engine';
 import type { Season } from '../api/leagues';
 import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
 import type { ReplayFix } from '../api/track';
@@ -78,11 +78,12 @@ function turnpointToDef(tp: Turnpoint) {
 /**
  * Mirror the task-level normalisation that `rebuildTaskResults` runs server-
  * side after every upload (src/job-queue.ts). The pipeline returns raw GAP
- * points (max 1000 each for dist + time); the leaderboard shows those points
- * rescaled so the winner's total equals the task's `normalized_score` (1000
- * by default). Without applying the same scale here, the preview's "Total
- * pts" would be on a different scale from the comparison panel's "Previous
- * Best" — leading to nonsense like "less distance = more points" when the
+ * points split by the §11 goal-ratio weights (availableDistancePoints +
+ * availableTimePoints = 1000); the leaderboard shows those points rescaled
+ * so the winner's total equals the task's `normalized_score` (1000 by
+ * default). Without applying the same scale here, the preview's "Total pts"
+ * would be on a different scale from the comparison panel's "Previous Best"
+ * — leading to nonsense like "less distance = more points" when the
  * existing leaderboard has been heavily compressed.
  *
  * Approach: pool the preview alongside the FULL existing leaderboard —
@@ -93,10 +94,11 @@ function turnpointToDef(tp: Turnpoint) {
  * Dropping the pilot's row here would move t_best when they hold it —
  * e.g. pilot A holds t_best = 3600 s, B in goal at 4500 s, A previews a
  * 5400 s flight: the server keeps the pool at {3600, 4500, 5400} (A stays
- * winner at 1000, B keeps 685.0 raw time points), whereas a pool without
- * A's row would wrongly anchor t_best at 4500 s. The pilot's row and the
- * preview together contribute ONE winner-scale candidate: whichever of the
- * two the server would keep as their best attempt.
+ * winner at raw 1000, B keeps 437.7 raw time points over the GR=1 pool of
+ * 639), whereas a pool without A's row would wrongly anchor t_best at
+ * 4500 s. The pilot's row and the preview together contribute ONE
+ * winner-scale candidate: whichever of the two the server would keep as
+ * their best attempt.
  */
 function round1(n: number): number {
   return Math.round(n * 10) / 10;
@@ -141,9 +143,22 @@ export function normalizePreviewPoints(
     ...(preview.reachedGoal && preview.taskTimeS != null ? [preview.taskTimeS] : []),
   ];
 
+  // §11 goal-ratio weights, mirroring rebuildTaskResults: pilots flying =
+  // every leaderboard row (one row per pilot) plus the previewing pilot when
+  // they are not already on it; a pilot is "in goal" with any goal-reaching
+  // attempt — for the previewing pilot that's their existing row OR the
+  // preview (a non-goal→goal preview therefore moves the goal ratio and the
+  // weights, exactly as the server rebuild would after the upload).
+  const pilotsFlown = leaderboard.length + (existing ? 0 : 1);
+  const previewPilotInGoal = (existing?.reachedGoal ?? false) || preview.reachedGoal;
+  const pilotsInGoal = others.filter((e) => e.reachedGoal).length + (previewPilotInGoal ? 1 : 0);
+  const { distanceWeight, timeWeight } = goalRatioWeights(pilotsFlown > 0 ? pilotsInGoal / pilotsFlown : 0);
+  const availableDistancePoints = distanceWeight * MAX_POINTS;
+  const availableTimePoints = timeWeight * MAX_POINTS;
+
   const rawPoints = (d: number, reachedGoal: boolean, t: number | null) => {
-    const dp = computeDistancePoints(d, bestDist > 0 ? bestDist : 1, reachedGoal);
-    const tp = reachedGoal && t != null ? computeTimePoints(t, allGoalTimes) : 0;
+    const dp = computeDistancePoints(d, bestDist > 0 ? bestDist : 1, reachedGoal, availableDistancePoints);
+    const tp = reachedGoal && t != null ? computeTimePoints(t, allGoalTimes, availableTimePoints) : 0;
     return { dp, tp };
   };
   // rebuildTaskResults keeps raw totals at full precision (rounding to 0.1
@@ -264,6 +279,14 @@ export async function previewSubmission(
     .filter((e) => e.reachedGoal && e.taskTimeS != null)
     .map((e) => e.taskTimeS as number);
 
+  // §11 goal-ratio field counts, mirroring the server upload path: each
+  // leaderboard row is one pilot; a row's reachedGoal is a faithful "has a
+  // goal attempt" signal because best-attempt selection prefers goal
+  // attempts. The previewing pilot's own row is excluded — scoreAttempts
+  // folds them back in based on the previewed track.
+  const existingEntry = (currentUserId && leaderboardEntries.find((e) => e.pilotId === currentUserId)) || null;
+  const otherEntries = existingEntry ? leaderboardEntries.filter((e) => e !== existingEntry) : leaderboardEntries;
+
   const result = await runPipelineFromParsed(
     parsed.value,
     {
@@ -274,6 +297,11 @@ export async function previewSubmission(
       },
       existingGoalTimes,
       competitionType: season.competitionType,
+      fieldCounts: {
+        otherPilotsFlown: otherEntries.length,
+        otherPilotsInGoal: otherEntries.filter((e) => e.reachedGoal).length,
+        pilotAlreadyInGoal: existingEntry?.reachedGoal ?? false,
+      },
     },
     task.openDate,
     task.closeDate,

--- a/frontend/src/lib/previewPipeline.ts
+++ b/frontend/src/lib/previewPipeline.ts
@@ -8,7 +8,12 @@
 
 import type { PipelineError, ScoredAttempt } from '../../../src/shared/pipeline';
 import { parseAndValidate, runPipelineFromParsed } from '../../../src/shared/pipeline';
-import { computeDistancePoints, computeTimePoints, goalRatioWeights, MAX_POINTS } from '../../../src/shared/task-engine';
+import {
+  computeDistancePoints,
+  computeTimePoints,
+  goalRatioWeights,
+  MAX_POINTS,
+} from '../../../src/shared/task-engine';
 import type { Season } from '../api/leagues';
 import type { LeaderboardEntry, Task, Turnpoint } from '../api/tasks';
 import type { ReplayFix } from '../api/track';

--- a/src/job-queue.ts
+++ b/src/job-queue.ts
@@ -13,7 +13,7 @@
 
 import type { Database } from 'better-sqlite3';
 import { randomUUID } from 'crypto';
-import { computeDistancePoints, computeTimePoints } from './shared/task-engine';
+import { computeDistancePoints, computeTimePoints, goalRatioWeights, MAX_POINTS } from './shared/task-engine';
 
 // ── Minimal typed EventEmitter (no @types/node dependency) ───────────────────
 
@@ -267,14 +267,16 @@ function round1(n: number): number {
 // Goal first, then highest points, then fastest time (NULLs last).
 // Returns negative if a is the better attempt.
 //
-// Note: this priority order intentionally differs from the rank-sort below
-// (which is total_points → goal pilots' task_time_s → reached_goal). For the
-// *picker* goal-attempt > non-goal-attempt is meaningful even at equal
-// total_points because we want the goal-recording attempt's metadata
-// (task_time_s, crossings) preferred. In the *rank*, reached_goal is
-// load-bearing: under the §12.2 absolute cutoff a slow goal pilot scores 0
-// time points and can tie a bestDist non-goal pilot on total_points — the
-// goal pilot then ranks first via the reached_goal tier.
+// Note: this priority order intentionally differs from the row-order sort
+// below (total_points → goal pilots' task_time_s → reached_goal → user_id).
+// For the *picker* goal-attempt > non-goal-attempt is meaningful even at
+// equal total_points because we want the goal-recording attempt's metadata
+// (task_time_s, crossings) preferred. The *rank* value is competition
+// ranking on the rounded total alone (equal totals share a rank — S7F
+// treats the rounded TotalScore as the score); the sort keys below the
+// total only stabilise the render order within a shared rank, e.g. a goal
+// pilot who ties a bestDist non-goal pilot on points is listed first but
+// shares the rank number.
 function compareBestAttempt(a: ScoredAttemptRow, b: ScoredAttemptRow): number {
   if (a.reached_goal !== b.reached_goal) return b.reached_goal - a.reached_goal;
   if (a.total_points !== b.total_points) return b.total_points - a.total_points;
@@ -326,15 +328,32 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
   }
   const goalTimes = Array.from(fastestGoalTimeByPilot.values());
 
+  // FAI S7F §11: the distance/time split depends on the task's goal ratio —
+  // pilots with ≥ 1 goal-reaching attempt over pilots with ≥ 1 attempt.
+  // The weights set the MIX of a pilot's score; the normalisation below sets
+  // the SCALE (winner = normalized_score) exactly as before.
+  const pilotsFlown = new Set(attempts.map((a) => a.user_id)).size;
+  const pilotsInGoal = new Set(attempts.filter((a) => a.reached_goal === 1).map((a) => a.user_id)).size;
+  const { distanceWeight, timeWeight } = goalRatioWeights(pilotsInGoal / pilotsFlown);
+  const availableDistancePoints = distanceWeight * MAX_POINTS;
+  const availableTimePoints = timeWeight * MAX_POINTS;
+
   // Points stay at full precision here — best-attempt selection and the
   // normalisation scale both work on unrounded values so that rounding to
   // one decimal happens exactly once, on the persisted result (S7F
   // round-once principle; rounding before scaling compounds to ~0.2 pt of
   // error, enough to flip adjacent ranks).
   const scored: ScoredAttemptRow[] = attempts.map((a) => {
-    const distance_points = computeDistancePoints(a.distance_flown_km, bestDistKm, a.reached_goal === 1);
+    const distance_points = computeDistancePoints(
+      a.distance_flown_km,
+      bestDistKm,
+      a.reached_goal === 1,
+      availableDistancePoints,
+    );
     const time_points =
-      a.reached_goal === 1 && a.task_time_s !== null ? computeTimePoints(a.task_time_s, goalTimes) : 0;
+      a.reached_goal === 1 && a.task_time_s !== null
+        ? computeTimePoints(a.task_time_s, goalTimes, availableTimePoints)
+        : 0;
     const total_points = distance_points + time_points;
     return { ...a, distance_points, time_points, total_points };
   });
@@ -375,19 +394,27 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
     });
   }
 
-  // Rank by total_points DESC, task_time_s ASC (goal pilots only, NULLs last),
-  // reached_goal DESC. task_time_s is stored for any ESS crossing, including
-  // pilots who landed short of goal — but §13.1 sets the PG time-points
-  // parameter to 0%, so a speed-section time must earn nothing (not even rank
-  // order) without reaching goal. Treat non-goal times as absent.
-  // Ties share a rank (RANK semantics, matching the previous SQL window).
+  // Row ORDER: total_points DESC, then — for equal totals only, to keep the
+  // leaderboard render deterministic — task_time_s ASC (goal pilots only,
+  // NULLs last), reached_goal DESC, user_id ASC. task_time_s is stored for
+  // any ESS crossing, including pilots who landed short of goal — but §13.1
+  // sets the PG time-points parameter to 0%, so a speed-section time must
+  // earn nothing without reaching goal. Treat non-goal times as absent.
+  //
+  // The rank VALUE is standard competition ranking on the persisted
+  // (rounded) total_points alone (S7F §12/§14: the rounded one-decimal
+  // TotalScore IS the score; nothing in S7F splits equal scores by elapsed
+  // time). Equal totals share a rank; the next distinct total gets
+  // 1 + count of better pilots (1, 1, 3, ...). The order keys below the
+  // total are cosmetic and never influence the rank.
   const rankTimeS = (r: ScoredAttemptRow): number | null => (r.reached_goal === 1 ? r.task_time_s : null);
   bestList.sort((a, b) => {
     if (b.total_points !== a.total_points) return b.total_points - a.total_points;
     const at = rankTimeS(a) ?? Number.POSITIVE_INFINITY;
     const bt = rankTimeS(b) ?? Number.POSITIVE_INFINITY;
     if (at !== bt) return at - bt;
-    return b.reached_goal - a.reached_goal;
+    if (a.reached_goal !== b.reached_goal) return b.reached_goal - a.reached_goal;
+    return a.user_id < b.user_id ? -1 : a.user_id > b.user_id ? 1 : 0;
   });
 
   const now = new Date().toISOString();
@@ -400,13 +427,12 @@ function rebuildTaskResultsInner(db: Database, taskId: string): void {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
-  let prevKey: string | null = null;
+  let prevTotal: number | null = null;
   let prevRank = 0;
   for (let i = 0; i < bestList.length; i++) {
     const r = bestList[i];
-    const key = `${r.total_points}|${rankTimeS(r) ?? 'null'}|${r.reached_goal}`;
-    const rank = key === prevKey ? prevRank : i + 1;
-    prevKey = key;
+    const rank = r.total_points === prevTotal ? prevRank : i + 1;
+    prevTotal = r.total_points;
     prevRank = rank;
     ins.run(
       randomUUID(),

--- a/src/reprocess.ts
+++ b/src/reprocess.ts
@@ -87,6 +87,29 @@ export async function reprocessStaleSubmissions(db: Database): Promise<{ reproce
   return { reprocessed, failed };
 }
 
+// Drop task_results / turnpoint_crossings / flight_attempts rows for a single
+// submission, in FK-safe order. Shared by the successful-reprocess path
+// (which reinserts fresh rows right after) and the DETECTION-failure path
+// (which reinserts nothing — the flight simply no longer scores). Must run
+// inside a caller-owned transaction.
+function clearSubmissionAttempts(db: Database, submissionId: string): void {
+  // Drop only the task_results rows that point at this submission's
+  // attempts — the FK is task_results.best_attempt_id → flight_attempts(id),
+  // and we're about to delete those attempts. A full per-task DELETE +
+  // rebuild here would be O(N²) when many stale submissions share a task;
+  // the boot sweep in server.ts re-derives the whole table once afterward.
+  db.prepare(
+    `DELETE FROM task_results
+     WHERE best_attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
+  ).run(submissionId);
+
+  db.prepare(
+    `DELETE FROM turnpoint_crossings
+     WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
+  ).run(submissionId);
+  db.prepare(`DELETE FROM flight_attempts WHERE submission_id = ?`).run(submissionId);
+}
+
 async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
   const task = db
     .prepare(
@@ -167,10 +190,37 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
     taskBestDistanceKm,
   );
   if (!result.ok) {
-    // The original upload succeeded against the prior scorer; failure here
-    // means the IGC is somehow incompatible with the current code (e.g. a
-    // header parser tightened). Skip without modifying stored data so the
-    // pilot's existing flight_attempts stay intact.
+    if (result.error.stage === 'DETECTION') {
+      // The IGC parsed and date-validated fine, but under the CURRENT rules
+      // (e.g. the §9.1.3 tolerance tightening this reprocess run exists to
+      // apply) it produces zero valid attempts — most commonly NO_SSS_CROSSING
+      // for a submission whose only SSS tag fell in a tolerance band that has
+      // since been retired. This is a legitimate re-scoring outcome, not an
+      // incompatibility: the flight no longer scores under today's rules, so
+      // we clear its stored attempt data the same way a successful reprocess
+      // replaces it (just with nothing to insert afterward). Leaving the old
+      // 1.3-era rows in place would let the pilot keep points earned under a
+      // retired tolerance forever, and the staleness probe would re-select
+      // and re-fail this submission on every boot.
+      const code = (result.error.error as { code: string }).code;
+      console.log(
+        `[reprocess] submission ${sub.id} (task ${sub.task_id}, pilot ${sub.user_id}) no longer produces a ` +
+          `valid attempt under current rules (DETECTION/${code}) — clearing stored attempt data`,
+      );
+      db.transaction(() => {
+        clearSubmissionAttempts(db, sub.id);
+        db.prepare(`UPDATE flight_submissions SET best_attempt_id = NULL, updated_at = ? WHERE id = ?`).run(
+          new Date().toISOString(),
+          sub.id,
+        );
+      })();
+      return;
+    }
+    // PARSE/DATE-stage failures mean the IGC itself is incompatible with the
+    // current parser/date validation (e.g. a header parser tightened) rather
+    // than a legitimate re-scoring outcome. Skip without modifying stored
+    // data so the pilot's existing flight_attempts stay intact — these need
+    // manual reconciliation, not an automatic clear.
     throw new Error(`pipeline rejected IGC: ${result.error.stage}/${(result.error.error as { code: string }).code}`);
   }
 
@@ -180,27 +230,13 @@ async function reprocessOne(db: Database, sub: SubmissionRow): Promise<void> {
   const nowIso = new Date().toISOString();
 
   db.transaction(() => {
-    // Drop only the task_results rows that point at this submission's
-    // attempts — the FK is task_results.best_attempt_id → flight_attempts(id),
-    // and we're about to delete those attempts. A full per-task DELETE +
-    // rebuild here would be O(N²) when many stale submissions share a task;
-    // the boot sweep in server.ts re-derives the whole table once afterward.
-    db.prepare(
-      `DELETE FROM task_results
-       WHERE best_attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
-    ).run(sub.id);
-
     // Drop old attempt + crossing rows for this submission. Reprocess is
     // re-scoring the same IGC against a newer SCORER_VERSION, so we need
     // to replace the existing rows wholesale; soft-delete would leave the
     // stale attempts visible alongside the freshly-scored ones, so hard-
     // delete is the right call. turnpoint_crossings has no soft-delete
     // column either, so the same delete-and-reinsert applies.
-    db.prepare(
-      `DELETE FROM turnpoint_crossings
-       WHERE attempt_id IN (SELECT id FROM flight_attempts WHERE submission_id = ?)`,
-    ).run(sub.id);
-    db.prepare(`DELETE FROM flight_attempts WHERE submission_id = ?`).run(sub.id);
+    clearSubmissionAttempts(db, sub.id);
 
     for (let i = 0; i < scoredAttempts.length; i++) {
       const attempt = scoredAttempts[i];

--- a/src/routes/leagues.ts
+++ b/src/routes/leagues.ts
@@ -264,7 +264,14 @@ export async function registerLeagueRoutes(fastify: FastifyInstance, opts: Leagu
          JOIN users u ON u.id = tr.user_id
          LEFT JOIN flight_attempts fa ON fa.id = tr.best_attempt_id
          WHERE tr.task_id = ?
-         ORDER BY tr.rank ASC`,
+         ORDER BY tr.rank ASC,
+                  -- Equal totals share a rank (S7F competition ranking);
+                  -- mirror rebuildTaskResults' deterministic render order
+                  -- within a shared rank: goal-gated task time, goal flag,
+                  -- then pilot id.
+                  COALESCE(CASE WHEN tr.reached_goal = 1 THEN tr.task_time_s END, 1e15) ASC,
+                  tr.reached_goal DESC,
+                  tr.user_id ASC`,
         )
         .all(taskId) as any[];
 

--- a/src/shared/SCORING.md
+++ b/src/shared/SCORING.md
@@ -21,7 +21,7 @@ availableDistancePoints = DistanceWeight × 1000
 availableTimePoints     = TimeWeight × 1000
 ```
 
-Full FAI PG carves a LeadingTimeRatio share (default 26%) plus arrival points out of the `1 − DistanceWeight` remainder; because leading and arrival points are deliberately dropped here, **time absorbs the full remainder**. Reference points: GR = 0 → 900/100, GR = 0.5 → 422.375/577.625, GR = 1 → 361/639.
+Full FAI PG carves only a LeadingTimeRatio share (default 26%) out of the `1 − DistanceWeight` remainder — arrival points are always 0 for paragliding, and at GR = 0 FAI gives leading the *entire* remainder (FAI PG time weight is 0 there). Because leading points are deliberately dropped here, **time absorbs the full remainder**, which makes this deviation largest at low goal ratios. Reference points: GR = 0 → 900/100, GR = 0.5 → 422.375/577.625, GR = 1 → 361/639.
 
 ### Distance Points
 

--- a/src/shared/SCORING.md
+++ b/src/shared/SCORING.md
@@ -8,19 +8,38 @@ Scoring is based on a simplified GAP (Glide And Aim for Paragliding) model with 
 
 ## Components
 
+### Distance/Time Split (FAI S7F §11)
+
+The 1000 raw points available on a task are split between distance and time by the task's goal ratio:
+
+```
+GoalRatio      = pilots with ≥ 1 goal-reaching attempt / pilots with ≥ 1 attempt
+DistanceWeight = 0.9 − 1.665·GR + 1.713·GR² − 0.587·GR³
+TimeWeight     = 1 − DistanceWeight
+
+availableDistancePoints = DistanceWeight × 1000
+availableTimePoints     = TimeWeight × 1000
+```
+
+Full FAI PG carves a LeadingTimeRatio share (default 26%) plus arrival points out of the `1 − DistanceWeight` remainder; because leading and arrival points are deliberately dropped here, **time absorbs the full remainder**. Reference points: GR = 0 → 900/100, GR = 0.5 → 422.375/577.625, GR = 1 → 361/639.
+
 ### Distance Points
 
 Every pilot who crosses the SSS receives distance points.
 
 | Pilot | Formula |
 |---|---|
-| Reached goal | `1000` |
-| Did not reach goal | `1000 × √(dist / bestDist)` |
+| Reached goal | `availableDistancePoints` |
+| Did not reach goal | `availableDistancePoints × √(dist / bestDist)` |
 
 - `dist` — the pilot's best distance along the optimal route from SSS to goal
 - `bestDist` — the furthest distance flown by any pilot on the task (= task distance if anyone reached goal)
 
-The square root curve rewards pilots who fly further but does not linearly scale, providing some separation among non-goal pilots.
+The square root curve is a **deliberate departure from FAI S7F §12.1**, which prescribes purely
+linear distance points for paragliding (`dist / bestDist`). The sqrt curve compresses the top and
+stretches the bottom, giving meaningful separation among non-goal pilots in the small async fields
+this league flies — a 30 km flight against a 60 km best scores 70.7% of the distance pool here
+versus 50% under FAI linear.
 
 ### Time Points
 
@@ -28,7 +47,7 @@ Only goal pilots receive time points. The curve is the FAI Sporting Code S7F §1
 
 ```
 SpeedFraction = max(0, 1 - ((t − t_best) / √t_best)^(5/6))
-timePoints    = 1000 × SpeedFraction
+timePoints    = availableTimePoints × SpeedFraction
 ```
 
 - `t` — this pilot's task time **in hours** (ESS crossing if the task has an ESS, else goal crossing, measured from the SSS crossing)
@@ -36,7 +55,11 @@ timePoints    = 1000 × SpeedFraction
 
 The cutoff is absolute, anchored to the winner: a pilot scores zero time points only when
 their time is at or beyond `t_best + √t_best` (e.g. best time 1h → zero at 2h; best time
-4h → zero at 6h). A sole finisher is their own `t_best` and scores the full 1000.
+4h → zero at 6h). A sole finisher is their own `t_best` and scores the full available time pool.
+
+Because this is an **async league**, `t_best` pools task times across different flying days and
+conditions — FAI GAP assumes a single race day. This is inherent to the format: the fastest time
+flown at any point in the task window anchors everyone's time points.
 
 Non-goal pilots receive **0 time points**.
 
@@ -46,25 +69,32 @@ Non-goal pilots receive **0 time points**.
 totalPoints = distancePoints + timePoints
 ```
 
-For the fastest goal pilot this is `1000 + 1000 = 2000` before normalization.
+For the fastest goal pilot this is `availableDistancePoints + availableTimePoints = 1000` before normalization.
 
 ---
 
 ## Normalization
 
-After scoring, all scores are scaled so the highest-scoring pilot gets exactly **1000 points**:
+After scoring, all scores are scaled so the highest-scoring pilot gets exactly **1000 points**.
+Rounding to one decimal happens exactly once, on the scaled values:
 
 ```
-scale = 1000 / winnerTotal
-finalPoints = round(rawPoints × scale)
+scale           = 1000 / winnerRawTotal        (raw totals kept at full precision)
+distancePoints  = round1(rawDistance × scale)
+timePoints      = round1(rawTime × scale)
+totalPoints     = round1(distancePoints + timePoints)
 ```
 
 This means:
 - The winner always scores 1000 regardless of how many pilots flew or whether anyone reached goal.
 - Relative gaps between pilots are preserved.
-- Tasks with only distance scoring (no goal finishers) and tasks with both distance + time scoring are comparable on the same 0–1000 scale.
+- **Caveat (deliberate, non-FAI):** normalization erases absolute task quality. A 5 km scratch-fest
+  where nobody leaves the hill and a 100 km epic both award the winner 1000. FAI task validity
+  (chapter 10) would scale these differently; this league drops validity and instead lets admins
+  weight tasks manually via `normalized_score`.
 
-A custom `normalized_score` can be set per task to override the default 1000 cap.
+A custom `normalized_score` can be set per task to override the default 1000 cap. Editing it
+rebuilds the task's results immediately.
 
 ---
 
@@ -72,7 +102,9 @@ A custom `normalized_score` can be set per task to override the default 1000 cap
 
 If no pilot crosses the ESS/goal:
 - All pilots receive distance points only (no time points).
-- The furthest pilot gets `1000 × √(bestDist/bestDist) = 1000` before normalization, which normalizes to **1000**.
+- The goal ratio is 0, so the distance pool is `0.9 × 1000 = 900` raw points.
+- The furthest pilot gets `900 × √(bestDist/bestDist) = 900` before normalization, which
+  normalizes to **1000**.
 - Everyone else scales down from there.
 
 ---
@@ -81,10 +113,24 @@ If no pilot crosses the ESS/goal:
 
 The season standings sum each pilot's best result per task. If a pilot has multiple submissions for the same task (re-flies), only the highest-scoring attempt counts.
 
-Pilots are ranked by total points descending. Tie-breaking is not currently implemented.
+Pilots are ranked by total points descending. Within a task, pilots with equal (rounded) totals
+share a rank (competition ranking: 1, 1, 3); season standings have no tie-break.
 
 ---
 
 ## Rescoring
 
-Time points are recalculated every time a new result is submitted while a task is open. Because the §12.2 formula depends only on the fastest goal time, a pilot's time points change only when someone submits a *faster* goal time (shifting `t_best`); slower finishers arriving later never affect existing scores. Scores are finalized when an admin freezes the task.
+The entire task rescores every time a result is submitted or deleted while the task is open —
+`task_results` is rebuilt from scratch from the stored attempts. A new submission can move any of
+the shared inputs, and with them everyone's points:
+
+- `t_best` — someone submits a faster goal time → every goal pilot's time points drop.
+- `bestDist` — someone flies further → every non-goal pilot's distance points shrink.
+- The goal ratio — a new pilot in goal (or a new non-goal pilot) shifts the §11 distance/time
+  split for the whole field.
+- The normalization scale — any change to the winner's raw total rescales everyone.
+
+There is no separate freeze step: submissions are only accepted while `now < close_date`, so
+scores settle naturally once the task closes. (An earlier `scores_frozen_at` mechanism was removed
+in migration 0013.) Scores can still change after close if an admin deletes a submission or edits
+the task's `normalized_score` — both trigger a rebuild.

--- a/src/shared/pipeline-parity-fixture.ts
+++ b/src/shared/pipeline-parity-fixture.ts
@@ -63,6 +63,10 @@ export const FIXTURE_INPUT: PipelineInput = {
   task: { id: 'fixture-task', turnpoints: FIXTURE_TURNPOINTS },
   existingGoalTimes: [120], // one prior finisher in 2 minutes — gives this attempt provisional time points
   competitionType: 'XC',
+  // §11 field counts matching existingGoalTimes: one other pilot, in goal.
+  // With this submission also reaching goal the goal ratio is 2/2 = 1 →
+  // DistanceWeight 0.361, TimeWeight 0.639.
+  fieldCounts: { otherPilotsFlown: 1, otherPilotsInGoal: 1, pilotAlreadyInGoal: false },
 };
 
 export const FIXTURE_TASK_OPEN_DATE = '2026-01-01';

--- a/src/shared/pipeline.test.ts
+++ b/src/shared/pipeline.test.ts
@@ -170,29 +170,34 @@ describe('classifyGroundState', () => {
 });
 
 // =============================================================================
-// FAI §9.1.3 tolerance: max(5 m, 0.5% × radius). Documents the contract that
-// the detection code in pipeline.ts depends on.
+// FAI §9.1.1 tolerance (S7F 2025): max(5 m absolute, 0.1% relative).
+// Documents the contract that the detection code in pipeline.ts depends on.
 // =============================================================================
 
 describe('tagToleranceM', () => {
-  it('floors at 5 m for small cylinders', () => {
+  it('floors at 5 m for small and mid-size cylinders', () => {
     expect(tagToleranceM(200)).toBe(5);
     expect(tagToleranceM(500)).toBe(5);
-    expect(tagToleranceM(999)).toBe(5);
-    // 1000 m × 0.5% = 5 m exactly — still 5 m at the boundary
     expect(tagToleranceM(1000)).toBe(5);
+    // 4000 m × 0.1% = 4 m — still below the 5 m absolute floor
+    expect(tagToleranceM(4000)).toBe(5);
+    // 5000 m × 0.1% = 5 m exactly — still 5 m at the boundary
+    expect(tagToleranceM(5000)).toBe(5);
   });
 
-  it('uses 0.5% of radius once it exceeds the floor', () => {
-    expect(tagToleranceM(2000)).toBeCloseTo(10, 9);
-    expect(tagToleranceM(4000)).toBeCloseTo(20, 9);
-    expect(tagToleranceM(10000)).toBeCloseTo(50, 9);
+  it('uses 0.1% of radius once it exceeds the floor', () => {
+    expect(tagToleranceM(10000)).toBeCloseTo(10, 9);
+    expect(tagToleranceM(20000)).toBeCloseTo(20, 9);
+    expect(tagToleranceM(50000)).toBeCloseTo(50, 9);
   });
 });
 
 describe('SCORER_VERSION', () => {
   it('is set so the boot reprocess loop has a concrete current value to compare', () => {
     // If you bump the version intentionally, update this expectation.
-    expect(SCORER_VERSION).toBe('1.3');
+    // 1.4: §9.1.1 crossing tolerance tightened from 0.5% to the S7F 2025
+    // value of 0.1% (5 m absolute floor unchanged) — tolerance affects
+    // detection, so stored attempts must reprocess.
+    expect(SCORER_VERSION).toBe('1.4');
   });
 });

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -12,6 +12,8 @@ import {
   computeDistancePoints,
   computePartialDistanceKm,
   computeTimePoints,
+  goalRatioWeights,
+  MAX_POINTS,
   type OptimisedRoute,
   optimiseRoute,
   tagToleranceM,
@@ -25,7 +27,7 @@ import {
 // whose stored flight_attempts.scorer_version differs from this constant.
 // =============================================================================
 
-export const SCORER_VERSION = '1.3';
+export const SCORER_VERSION = '1.4';
 
 // Re-export so existing `import { tagToleranceM } from './shared/pipeline'`
 // paths keep working. The canonical helper lives in `./task-engine`.
@@ -97,6 +99,26 @@ export interface PipelineInput {
   existingGoalTimes: number[]; // task times (seconds) of all pilots who already reached goal
   // used to compute time points for this submission
   competitionType: 'XC' | 'HIKE_AND_FLY';
+  // §11 goal-ratio field counts for the provisional score — see
+  // TaskFieldCounts. Omitted → the submission is scored as a single-pilot
+  // field (goal ratio 0 or 1 from this track alone).
+  fieldCounts?: TaskFieldCounts;
+}
+
+/**
+ * FAI S7F §11 goal-ratio inputs: distinct-pilot counts over the task's
+ * stored attempts EXCLUDING the submitting pilot, plus whether the
+ * submitting pilot already has a stored goal-reaching attempt.
+ * scoreAttempts folds the submitting pilot in itself — they always count
+ * as flying, and count as in goal when `pilotAlreadyInGoal` is set or any
+ * attempt in this submission reaches goal — so the provisional weights
+ * match the goal ratio rebuildTaskResults derives once the submission's
+ * attempts are inserted in the same transaction.
+ */
+export interface TaskFieldCounts {
+  otherPilotsFlown: number; // distinct pilots with ≥ 1 attempt, excluding the submitter
+  otherPilotsInGoal: number; // distinct pilots with ≥ 1 goal attempt, excluding the submitter
+  pilotAlreadyInGoal: boolean; // submitter already has a stored goal attempt
 }
 
 export interface TaskDefinition {
@@ -1270,18 +1292,25 @@ export function calculateDistances(attempts: AttemptTrace[], fixes: Fix[], task:
 /**
  * Stage 6: scoreAttempts
  *
+ * §11 split: availableDistancePoints = DistanceWeight * 1000 and
+ * availableTimePoints = TimeWeight * 1000, where the weights depend on the
+ * task's goal ratio (goalRatioWeights). `fieldCounts` supplies the rest of
+ * the field; the submitting pilot is folded in here so the provisional
+ * numbers use the same weights the post-insert rebuild will derive.
+ *
  * Distance points:
- *   Goal: distancePoints = MAX_POINTS
- *   Else: distancePoints = MAX_POINTS * sqrt(dist / bestDist)
+ *   Goal: distancePoints = availableDistancePoints
+ *   Else: distancePoints = availableDistancePoints * sqrt(dist / bestDist)
  *
  * Time points (goal pilots only) — FAI S7F §12.2:
- *   timePoints = MAX_POINTS * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best)) ^ (5/6))
- *   (times in hours; t_best = fastest goal time; sole finisher gets MAX_POINTS)
+ *   timePoints = availableTimePoints * max(0, 1 - ((t_pilot - t_best) / sqrt(t_best)) ^ (5/6))
+ *   (times in hours; t_best = fastest goal time; sole finisher gets the full pool)
  */
 export function scoreAttempts(
   attempts: AttemptTrace[],
   existingGoalTimesS: number[],
   taskBestDistanceKm: number,
+  fieldCounts?: TaskFieldCounts,
 ): ScoredAttempt[] {
   // Collect goal task times including this submission's attempts
   const newGoalTimesS = attempts.filter((a) => a.reachedGoal && a.taskTimeS !== null).map((a) => a.taskTimeS!);
@@ -1290,13 +1319,26 @@ export function scoreAttempts(
   // Best distance across all pilots including this submission
   const thisBestDist = Math.max(taskBestDistanceKm, ...attempts.map((a) => a.distanceFlownKm));
 
+  // §11 goal ratio over the whole field, this pilot included. A pilot counts
+  // as "in goal" with a single goal-reaching attempt (best-attempt selection
+  // always prefers goal attempts, so this matches the leaderboard rows).
+  const counts = fieldCounts ?? { otherPilotsFlown: 0, otherPilotsInGoal: 0, pilotAlreadyInGoal: false };
+  const pilotInGoal = counts.pilotAlreadyInGoal || attempts.some((a) => a.reachedGoal);
+  const pilotsFlown = counts.otherPilotsFlown + 1;
+  const pilotsInGoal = counts.otherPilotsInGoal + (pilotInGoal ? 1 : 0);
+  const { distanceWeight, timeWeight } = goalRatioWeights(pilotsInGoal / pilotsFlown);
+  const availableDistancePoints = distanceWeight * MAX_POINTS;
+  const availableTimePoints = timeWeight * MAX_POINTS;
+
   return attempts.map((attempt) => {
     const dist = attempt.distanceFlownKm;
     const bestDist = Math.max(thisBestDist, dist);
 
-    const distancePoints = computeDistancePoints(dist, bestDist, attempt.reachedGoal);
+    const distancePoints = computeDistancePoints(dist, bestDist, attempt.reachedGoal, availableDistancePoints);
     const timePoints =
-      attempt.reachedGoal && attempt.taskTimeS !== null ? computeTimePoints(attempt.taskTimeS, allGoalTimesS) : 0;
+      attempt.reachedGoal && attempt.taskTimeS !== null
+        ? computeTimePoints(attempt.taskTimeS, allGoalTimesS, availableTimePoints)
+        : 0;
 
     return {
       attemptIndex: attempt.attemptIndex,
@@ -1322,6 +1364,11 @@ export function scoreAttempts(
 
 /**
  * Rescore: recalculate time points for all goal attempts on a task.
+ *
+ * NOTE: legacy entry point with no production callers — rebuildTaskResults
+ * (src/job-queue.ts) is the authoritative rescore path and applies the §11
+ * goal-ratio weights there. This helper recomputes over the raw MAX_POINTS
+ * pool only.
  */
 export function rescoreTimePoints(allTaskAttempts: ScoredAttempt[]): ScoredAttempt[] {
   const goalTimes = allTaskAttempts.filter((a) => a.reachedGoal && a.taskTimeS !== null).map((a) => a.taskTimeS!);
@@ -1434,7 +1481,7 @@ export async function runPipelineFromParsed(
   attempts = calculateDistances(attempts, track.fixes, input.task);
 
   // Stage 6: Scoring
-  const scoredAttempts = scoreAttempts(attempts, input.existingGoalTimes, taskBestDistanceKm);
+  const scoredAttempts = scoreAttempts(attempts, input.existingGoalTimes, taskBestDistanceKm, input.fieldCounts);
 
   // Stage 7: Select best
   const bestAttemptIndex = selectBestAttempt(scoredAttempts);

--- a/src/shared/pipeline.ts
+++ b/src/shared/pipeline.ts
@@ -1362,30 +1362,6 @@ export function scoreAttempts(
   });
 }
 
-/**
- * Rescore: recalculate time points for all goal attempts on a task.
- *
- * NOTE: legacy entry point with no production callers — rebuildTaskResults
- * (src/job-queue.ts) is the authoritative rescore path and applies the §11
- * goal-ratio weights there. This helper recomputes over the raw MAX_POINTS
- * pool only.
- */
-export function rescoreTimePoints(allTaskAttempts: ScoredAttempt[]): ScoredAttempt[] {
-  const goalTimes = allTaskAttempts.filter((a) => a.reachedGoal && a.taskTimeS !== null).map((a) => a.taskTimeS!);
-
-  return allTaskAttempts.map((attempt) => {
-    if (!attempt.reachedGoal || attempt.taskTimeS === null) {
-      return { ...attempt, timePoints: 0, totalPoints: attempt.distancePoints };
-    }
-    const timePoints = computeTimePoints(attempt.taskTimeS, goalTimes);
-    return {
-      ...attempt,
-      timePoints,
-      totalPoints: attempt.distancePoints + timePoints,
-    };
-  });
-}
-
 // =============================================================================
 // STAGE 7: SELECT BEST ATTEMPT
 // =============================================================================
@@ -1492,24 +1468,6 @@ export async function runPipelineFromParsed(
     flightDate: track.flightDate,
     gapCount: track.gapCount,
   });
-}
-
-// =============================================================================
-// RESCORE JOB ENTRY POINT
-// =============================================================================
-
-export interface RescoreInput {
-  taskId: string;
-  allAttemptsForTask: ScoredAttempt[];
-}
-
-export interface RescoreOutput {
-  updatedAttempts: ScoredAttempt[];
-}
-
-export function runRescore(input: RescoreInput): RescoreOutput {
-  const updatedAttempts = rescoreTimePoints(input.allAttemptsForTask);
-  return { updatedAttempts };
 }
 
 // =============================================================================

--- a/src/shared/task-engine.ts
+++ b/src/shared/task-engine.ts
@@ -7,18 +7,22 @@
 // =============================================================================
 
 // =============================================================================
-// FAI §9.1.3 cylinder tolerance
+// FAI §9.1.1 cylinder tolerance (S7F 2025)
 //
-// "Tolerance is applied separately to the straight portion and to the
-// semi-circle." Standard practice across FAI scoring tools is 0.5 % of the
-// radius with a minimum of 5 m. The boundary effectively shifts outward by
-// `tagToleranceM(r)` — a fix at distance ≤ r + tolerance is considered
-// inside. The optimised-route geometry continues to use the strict radius;
-// tolerance only governs whether a track tags the cylinder.
+//   relativeTolerance = 0.1 %   (from GAP 2026: 0.0 %)
+//   absoluteTolerance = 5 m
+//   outerRadius = max(radius * (1 + relativeTolerance), radius + absoluteTolerance)
+//
+// i.e. the tolerance is max(5 m, 0.1 % of the radius). §9.1.3 applies the
+// same tolerance separately to the goal-line chord and semi-circle. The
+// boundary effectively shifts outward by `tagToleranceM(r)` — a fix at
+// distance ≤ r + tolerance is considered inside. The optimised-route
+// geometry continues to use the strict radius; tolerance only governs
+// whether a track tags the cylinder.
 // =============================================================================
 
 export function tagToleranceM(radiusM: number): number {
-  return Math.max(5, radiusM * 0.005);
+  return Math.max(5, radiusM * 0.001);
 }
 
 // =============================================================================
@@ -349,42 +353,88 @@ export function computePartialDistanceKm(
 export const MAX_POINTS = 1000;
 
 /**
+ * FAI S7F §11 points allocation — goal-ratio-dependent distance/time split.
+ *
+ *   GoalRatio      = NumberOfPilotsInGoal / NumberOfPilotsFlying
+ *   DistanceWeight = 0.9 - 1.665*GR + 1.713*GR² - 0.587*GR³
+ *
+ * Full FAI PG then carves the (1 - DistanceWeight) remainder into leading
+ * (LeadingTimeRatio, default 26 %), arrival (0 for PG) and time weights:
+ *   TimeWeight = 1 - DistanceWeight - LeadingWeight - ArrivalWeight
+ *
+ * This league deliberately drops leading and arrival points (see
+ * src/shared/SCORING.md), so time absorbs the full remainder:
+ *   TimeWeight = 1 - DistanceWeight
+ *
+ * Available points are the weights * MAX_POINTS. §11 rounds the available
+ * pools to whole points; we keep full precision here because per-task
+ * normalisation (rebuildTaskResults) rescales everything afterwards and the
+ * S7F round-once principle puts the single rounding on the persisted value.
+ */
+export function goalRatioWeights(goalRatio: number): { distanceWeight: number; timeWeight: number } {
+  const gr = Math.min(1, Math.max(0, goalRatio));
+  const distanceWeight = 0.9 - 1.665 * gr + 1.713 * gr ** 2 - 0.587 * gr ** 3;
+  const timeWeight = 1 - distanceWeight;
+  return { distanceWeight, timeWeight };
+}
+
+/**
  * Distance points for one pilot.
- *   Goal:     MAX_POINTS
- *   Non-goal: MAX_POINTS * sqrt(dist / bestDist)
+ *   Goal:     availablePoints
+ *   Non-goal: availablePoints * sqrt(dist / bestDist)
+ *
+ * `availablePoints` is the §11 AvailableDistancePoints pool
+ * (DistanceWeight * 1000 — see goalRatioWeights). It defaults to MAX_POINTS
+ * for isolated unit-test use; every production call site passes the
+ * goal-ratio-weighted pool.
  *
  * Returns full precision — rounding to one decimal happens exactly once, on
  * the final persisted value after task-level normalisation
  * (rebuildTaskResults in src/job-queue.ts), per the S7F round-once principle.
  */
-export function computeDistancePoints(distKm: number, bestDistKm: number, reachedGoal: boolean): number {
-  if (reachedGoal) return MAX_POINTS;
+export function computeDistancePoints(
+  distKm: number,
+  bestDistKm: number,
+  reachedGoal: boolean,
+  availablePoints: number = MAX_POINTS,
+): number {
+  if (reachedGoal) return availablePoints;
   if (bestDistKm <= 0) return 0;
-  return MAX_POINTS * Math.sqrt(distKm / bestDistKm);
+  return availablePoints * Math.sqrt(distKm / bestDistKm);
 }
 
 /**
  * Time points for one goal pilot — FAI Sporting Code S7F §12.2.
  *
  *   SpeedFraction = max(0, 1 - ((T - BestTime) / sqrt(BestTime)) ^ (5/6))
- *   TimePoints    = SpeedFraction * MAX_POINTS
+ *   TimePoints    = SpeedFraction * availablePoints
  *
  * Times in the formula are in HOURS (per the spec). BestTime is the fastest
  * task time among goal pilots. A pilot scores zero only when their time is at
  * or beyond BestTime + sqrt(BestTime) — an absolute cutoff anchored to the
  * winner's time, not to the slowest finisher.
  *
+ * `availablePoints` is the §11 AvailableTimePoints pool
+ * (TimeWeight * 1000 — see goalRatioWeights). It defaults to MAX_POINTS for
+ * isolated unit-test use; every production call site passes the
+ * goal-ratio-weighted pool.
+ *
  * Returns full precision — see computeDistancePoints for where rounding
  * happens.
  *
- * @param taskTimeS      This pilot's task time in seconds
- * @param allGoalTimesS  All goal pilots' task times including this one
+ * @param taskTimeS       This pilot's task time in seconds
+ * @param allGoalTimesS   All goal pilots' task times including this one
+ * @param availablePoints AvailableTimePoints pool (defaults to MAX_POINTS)
  */
-export function computeTimePoints(taskTimeS: number, allGoalTimesS: number[]): number {
-  if (allGoalTimesS.length === 0) return MAX_POINTS;
+export function computeTimePoints(
+  taskTimeS: number,
+  allGoalTimesS: number[],
+  availablePoints: number = MAX_POINTS,
+): number {
+  if (allGoalTimesS.length === 0) return availablePoints;
   const bestTimeH = Math.min(...allGoalTimesS) / 3600;
-  if (bestTimeH <= 0) return taskTimeS <= 0 ? MAX_POINTS : 0;
+  if (bestTimeH <= 0) return taskTimeS <= 0 ? availablePoints : 0;
   const excessH = Math.max(0, taskTimeS / 3600 - bestTimeH);
   const speedFraction = Math.max(0, 1 - (excessH / Math.sqrt(bestTimeH)) ** (5 / 6));
-  return MAX_POINTS * speedFraction;
+  return availablePoints * speedFraction;
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -235,6 +235,22 @@ export async function handleIgcUpload(
     .get(taskId) as { best: number | null };
   const taskBestDistanceKm = bestDistRow.best ?? 0;
 
+  // ── §11 goal-ratio field counts ────────────────────────────────────────────
+  // Distinct-pilot counts excluding the uploader (scoreAttempts folds the
+  // uploader back in once it knows whether this submission reaches goal), so
+  // the provisional weights equal the ones rebuildTaskResults derives from
+  // the post-insert attempt set in the same transaction below.
+  const fieldRow = db
+    .prepare(
+      `SELECT
+         COUNT(DISTINCT CASE WHEN user_id != ? THEN user_id END) AS othersFlown,
+         COUNT(DISTINCT CASE WHEN user_id != ? AND reached_goal = 1 THEN user_id END) AS othersInGoal,
+         MAX(CASE WHEN user_id = ? AND reached_goal = 1 THEN 1 ELSE 0 END) AS pilotInGoal
+       FROM flight_attempts
+       WHERE task_id = ? AND deleted_at IS NULL`,
+    )
+    .get(userId, userId, userId, taskId) as { othersFlown: number; othersInGoal: number; pilotInGoal: number | null };
+
   // ── Build pipeline input ───────────────────────────────────────────────────
   const pipelineInput: PipelineInput = {
     igcText: fileBuffer.toString('utf8'),
@@ -244,6 +260,11 @@ export async function handleIgcUpload(
     },
     existingGoalTimes: existingGoalTimesS,
     competitionType: task.competition_type === 'HIKE_AND_FLY' ? 'HIKE_AND_FLY' : 'XC',
+    fieldCounts: {
+      otherPilotsFlown: fieldRow.othersFlown,
+      otherPilotsInGoal: fieldRow.othersInGoal,
+      pilotAlreadyInGoal: fieldRow.pilotInGoal === 1,
+    },
   };
 
   // ── Run pipeline ───────────────────────────────────────────────────────────

--- a/tests/goal-line.test.ts
+++ b/tests/goal-line.test.ts
@@ -207,7 +207,7 @@ describe('goal D-shape: chord + semi-circle together', () => {
 describe('segmentNearGoalLine', () => {
   // East-west chord at origin, half-length 100 m, bearing 90°. The chord is
   // sized off a 100 m goal cylinder, so tolerance = tagToleranceM(100) = 5 m
-  // (the 5 m floor; 0.5 % of 100 m is 0.5 m, below the floor).
+  // (the 5 m floor; 0.1 % of 100 m is 0.1 m, below the floor).
   const R = 100;
   const BRG = 90;
   const TOL = 5;
@@ -280,7 +280,7 @@ describe('segmentNearGoalLine', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('cylinder tolerance boundary (segmentIntersectsCircle + tagToleranceM)', () => {
-  // A 400 m cylinder gets a 5 m tolerance (the floor — 0.5% of 400 is 2 m)
+  // A 400 m cylinder gets a 5 m tolerance (the floor — 0.1% of 400 is 0.4 m)
   it('tags an inbound segment ending 4 m short of a 400 m cylinder', () => {
     const r = 400;
     const effectiveR = r + tagToleranceM(r); // 405
@@ -296,12 +296,14 @@ describe('cylinder tolerance boundary (segmentIntersectsCircle + tagToleranceM)'
     expect(t).toBeNull();
   });
 
-  it('uses the 0.5% rule above the floor (4000 m → 20 m tolerance)', () => {
-    const r = 4000;
-    const effectiveR = r + tagToleranceM(r); // 4020 — 0.5 % of 4000 = 20 m, above the 5 m floor
-    // 15 m short of the strict edge — within 20 m tolerance
-    const t = segmentIntersectsCircle({ x: 5000, y: 0 }, { x: 4015, y: 0 }, effectiveR);
-    expect(t).not.toBeNull();
+  it('uses the 0.1% rule above the floor (10000 m → 10 m tolerance)', () => {
+    const r = 10000;
+    const effectiveR = r + tagToleranceM(r); // 10010 — 0.1 % of 10000 = 10 m, above the 5 m floor
+    // 5 m short of the strict edge — within the 10 m tolerance
+    expect(segmentIntersectsCircle({ x: 11000, y: 0 }, { x: 10005, y: 0 }, effectiveR)).not.toBeNull();
+    // 15 m short of the strict edge — outside the 10 m tolerance (the old
+    // 0.5% band would have taken this; S7F 2025 §9.1.1 does not)
+    expect(segmentIntersectsCircle({ x: 11000, y: 0 }, { x: 10015, y: 0 }, effectiveR)).toBeNull();
   });
 });
 

--- a/tests/reprocess.test.ts
+++ b/tests/reprocess.test.ts
@@ -1,0 +1,201 @@
+// =============================================================================
+// reprocessStaleSubmissions — boot-time IGC reprocess against SCORER_VERSION
+// =============================================================================
+//
+// The reprocess loop distinguishes two pipeline failure classes:
+//
+//  - DETECTION-stage failures (IGC parsed fine, but the current rules find
+//    no valid attempt — e.g. NO_SSS_CROSSING for a submission whose only
+//    SSS tag fell in a tolerance band that has since been retired) are a
+//    legitimate re-scoring outcome: the stored attempt/crossing/task_results
+//    rows are cleared so the pilot drops off the leaderboard and the
+//    staleness probe stops re-selecting the submission on every boot.
+//  - PARSE/DATE-stage failures (genuine incompatibility, e.g. a corrupt or
+//    unparseable IGC blob) are conservatively skipped — stored rows are
+//    left untouched pending manual reconciliation.
+// =============================================================================
+
+import { randomUUID } from 'crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { rebuildTaskResults } from '../src/job-queue';
+import { reprocessStaleSubmissions } from '../src/reprocess';
+import { SCORER_VERSION } from '../src/shared/pipeline';
+import { FIXTURE_IGC, FIXTURE_TURNPOINTS } from '../src/shared/pipeline-parity-fixture';
+import {
+  createTestAttempt,
+  createTestLeague,
+  createTestSeason,
+  createTestSubmission,
+  createTestTask,
+  createTestTaskResult,
+  createTestUser,
+  setupTestDatabase,
+} from './helpers';
+import { getTestDb, resetTestDb } from './setup';
+
+// A track that stays ~6.6 km south of every FIXTURE_TURNPOINTS cylinder the
+// whole flight (cylinders sit at 47.50 / 47.52 / 47.54, radius 400 m) — it
+// never crosses the SSS boundary at all, so runPipeline rejects it with
+// DETECTION/NO_SSS_CROSSING regardless of exactly how wide the cylinder
+// tolerance is. Same IGC shape as FIXTURE_IGC (5 fixes, 1/min, same date),
+// just shifted south.
+const NO_SSS_IGC = [
+  'AXLK00001',
+  'HFDTE230126',
+  'B1000004723700N12200000WA0050000500',
+  'B1001004724000N12200000WA0050000500',
+  'B1002004724600N12200000WA0050000500',
+  'B1003004725200N12200000WA0050000500',
+  'B1004004726400N12200000WA0050000500',
+].join('\n');
+
+const TASK_OPEN_DATE = '2026-01-01T00:00:00Z';
+const TASK_CLOSE_DATE = '2026-01-31T23:59:59Z';
+
+function insertFixtureTurnpoints(db: ReturnType<typeof getTestDb>, taskId: string) {
+  const now = new Date().toISOString();
+  for (const tp of FIXTURE_TURNPOINTS) {
+    db.prepare(
+      `INSERT INTO turnpoints (
+         id, task_id, sequence_index, name, latitude, longitude, radius_m, type,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(randomUUID(), taskId, tp.sequenceIndex, tp.id, tp.lat, tp.lng, tp.radiusM, tp.type, now, now);
+  }
+}
+
+function setSubmissionIgc(db: ReturnType<typeof getTestDb>, submissionId: string, igcText: string) {
+  db.prepare(`UPDATE flight_submissions SET igc_data = ? WHERE id = ?`).run(Buffer.from(igcText, 'utf8'), submissionId);
+}
+
+describe('reprocessStaleSubmissions', () => {
+  let db: ReturnType<typeof getTestDb>;
+  let leagueId: string;
+  let seasonId: string;
+
+  beforeEach(() => {
+    resetTestDb();
+    db = getTestDb();
+    setupTestDatabase(db);
+
+    const league = createTestLeague(db);
+    leagueId = league.id;
+    seasonId = createTestSeason(db, leagueId).id;
+  });
+
+  it('clears attempts/crossings/task_results for a stale submission that no longer produces a valid attempt (DETECTION), and the leaderboard drops the pilot', async () => {
+    const user = createTestUser(db);
+    const task = createTestTask(db, seasonId, leagueId, { openDate: TASK_OPEN_DATE, closeDate: TASK_CLOSE_DATE });
+    insertFixtureTurnpoints(db, task.id);
+
+    const submissionId = createTestSubmission(db, task.id, user.id, leagueId);
+    setSubmissionIgc(db, submissionId, NO_SSS_IGC);
+
+    // Stale 1.x-era attempt + the task_results row it backs — as if this
+    // pilot scored under a since-retired tolerance.
+    const staleAttemptId = createTestAttempt(db, submissionId, task.id, user.id, leagueId, {
+      distanceFlownKm: 5,
+      reachedGoal: false,
+    });
+    createTestTaskResult(db, task.id, user.id, leagueId, staleAttemptId, { distanceFlownKm: 5 });
+
+    const before = db.prepare(`SELECT scorer_version FROM flight_attempts WHERE id = ?`).get(staleAttemptId) as {
+      scorer_version: string;
+    };
+    expect(before.scorer_version).not.toBe(SCORER_VERSION);
+
+    const result = await reprocessStaleSubmissions(db);
+    expect(result).toEqual({ reprocessed: 1, failed: 0 });
+
+    // Stored attempt/crossing rows for this submission are gone.
+    const attempts = db.prepare(`SELECT * FROM flight_attempts WHERE submission_id = ?`).all(submissionId);
+    expect(attempts).toHaveLength(0);
+    const crossings = db.prepare(`SELECT * FROM turnpoint_crossings WHERE attempt_id = ?`).all(staleAttemptId);
+    expect(crossings).toHaveLength(0);
+
+    // The task_results row tied to the deleted attempt is gone directly...
+    const taskResults = db.prepare(`SELECT * FROM task_results WHERE task_id = ?`).all(task.id);
+    expect(taskResults).toHaveLength(0);
+
+    // ...and stays gone after the boot-time rebuild sweep server.ts runs
+    // immediately after reprocessStaleSubmissions (the single point that
+    // re-derives task_results from the full attempt set).
+    rebuildTaskResults(db, task.id);
+    const afterRebuild = db.prepare(`SELECT * FROM task_results WHERE task_id = ?`).all(task.id);
+    expect(afterRebuild).toHaveLength(0);
+
+    // The submission no longer points at a deleted attempt.
+    const submission = db.prepare(`SELECT best_attempt_id FROM flight_submissions WHERE id = ?`).get(submissionId) as {
+      best_attempt_id: string | null;
+    };
+    expect(submission.best_attempt_id).toBeNull();
+
+    // The staleness probe's EXISTS subquery has nothing left to match —
+    // a second run selects and reprocesses nothing. The loop is over.
+    const second = await reprocessStaleSubmissions(db);
+    expect(second).toEqual({ reprocessed: 0, failed: 0 });
+  });
+
+  it('does not modify stored rows for a parse-level failure (corrupt IGC) — conservative skip', async () => {
+    const user = createTestUser(db);
+    const task = createTestTask(db, seasonId, leagueId, { openDate: TASK_OPEN_DATE, closeDate: TASK_CLOSE_DATE });
+    insertFixtureTurnpoints(db, task.id);
+
+    const submissionId = createTestSubmission(db, task.id, user.id, leagueId);
+    setSubmissionIgc(db, submissionId, 'this is not a valid IGC file\njust garbage text\n');
+
+    const attemptId = createTestAttempt(db, submissionId, task.id, user.id, leagueId, {
+      distanceFlownKm: 9,
+      reachedGoal: true,
+      taskTimeS: 1000,
+    });
+    createTestTaskResult(db, task.id, user.id, leagueId, attemptId, { distanceFlownKm: 9 });
+
+    const result = await reprocessStaleSubmissions(db);
+    expect(result).toEqual({ reprocessed: 0, failed: 1 });
+
+    const attemptAfter = db.prepare(`SELECT * FROM flight_attempts WHERE id = ?`).get(attemptId) as {
+      distance_flown_km: number;
+      reached_goal: number;
+      scorer_version: string;
+    };
+    expect(attemptAfter).toBeDefined();
+    expect(attemptAfter.distance_flown_km).toBe(9);
+    expect(attemptAfter.reached_goal).toBe(1);
+    expect(attemptAfter.scorer_version).not.toBe(SCORER_VERSION);
+
+    const taskResultAfter = db.prepare(`SELECT * FROM task_results WHERE task_id = ?`).all(task.id);
+    expect(taskResultAfter).toHaveLength(1);
+  });
+
+  it('reprocesses a healthy stale submission normally (regression guard on the happy path)', async () => {
+    const user = createTestUser(db);
+    const task = createTestTask(db, seasonId, leagueId, { openDate: TASK_OPEN_DATE, closeDate: TASK_CLOSE_DATE });
+    insertFixtureTurnpoints(db, task.id);
+
+    const submissionId = createTestSubmission(db, task.id, user.id, leagueId);
+    setSubmissionIgc(db, submissionId, FIXTURE_IGC);
+
+    createTestAttempt(db, submissionId, task.id, user.id, leagueId, { distanceFlownKm: 1, reachedGoal: false });
+
+    const result = await reprocessStaleSubmissions(db);
+    expect(result).toEqual({ reprocessed: 1, failed: 0 });
+
+    const attempts = db.prepare(`SELECT * FROM flight_attempts WHERE submission_id = ?`).all(submissionId) as Array<{
+      reached_goal: number;
+      scorer_version: string;
+      distance_flown_km: number;
+    }>;
+    expect(attempts.length).toBeGreaterThan(0);
+    for (const a of attempts) expect(a.scorer_version).toBe(SCORER_VERSION);
+    expect(attempts.some((a) => a.reached_goal === 1)).toBe(true);
+
+    rebuildTaskResults(db, task.id);
+    const taskResults = db.prepare(`SELECT * FROM task_results WHERE task_id = ?`).all(task.id);
+    expect(taskResults).toHaveLength(1);
+
+    // Fully re-scored — a second run finds nothing stale left.
+    const second = await reprocessStaleSubmissions(db);
+    expect(second).toEqual({ reprocessed: 0, failed: 0 });
+  });
+});

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -392,9 +392,10 @@ describe('rebuildTaskResults', () => {
   // Regression for time-point staleness: when a new goal time enters the set,
   // every goal pilot's time_points must reflect the full updated range.
   it('rescores time_points across all goal pilots when the goal-times set changes', () => {
-    // normalized_score=2000 matches the unscaled winner total
-    // (distance_points=1000 + time_points=1000 for the fastest pilot), so the
-    // post-rebuild values are the computeTimePoints outputs rounded to 0.1.
+    // All four pilots reach goal → §11 goal ratio 1 → DistanceWeight 0.361,
+    // TimeWeight 0.639. The fastest pilot's raw total is exactly
+    // 361 + 639 = 1000, so normalized_score=2000 makes the scale exactly 2
+    // and every persisted value is the weighted raw doubled.
     const taskTime = createTestTask(db, season.id, league.id, { name: 'Time-points' });
     db.prepare(`UPDATE tasks SET normalized_score = 2000 WHERE id = ?`).run(taskTime.id);
 
@@ -433,14 +434,15 @@ describe('rebuildTaskResults', () => {
     expect(rows).toHaveLength(4);
 
     // FAI S7F §12.2: bestTime=3000s (0.8333h), cutoff at best + sqrt(best) ≈ 6286s.
-    // time_points = 1000 * max(0, 1 - ((t - best) / sqrt(best))^(5/6)), times in hours.
+    // time_points = 639 * max(0, 1 - ((t - best) / sqrt(best))^(5/6)) * 2 (scale),
+    // times in hours — i.e. SpeedFraction * 1278.
     const byUser = new Map(rows.map((r) => [r.user_id, r]));
-    expect(byUser.get(pilot4.id).time_points).toBeCloseTo(1000, 0); // fastest
-    expect(byUser.get(pilot.id).time_points).toBeCloseTo(757.6, 1); // 3600
-    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(568.1, 1); // 4200
-    expect(byUser.get(pilot3.id).time_points).toBeCloseTo(230.4, 1); // slowest, still inside cutoff
-    // distance_points are tied at 1000 (all four flew 50km of best=50km).
-    for (const r of rows) expect(r.distance_points).toBeCloseTo(1000, 0);
+    expect(byUser.get(pilot4.id).time_points).toBeCloseTo(1278, 0); // fastest
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(968.2, 1); // 3600 (SF 0.7576)
+    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(726.0, 1); // 4200 (SF 0.5681)
+    expect(byUser.get(pilot3.id).time_points).toBeCloseTo(294.5, 1); // slowest, still inside cutoff (SF 0.2304)
+    // distance_points are tied at 722 = 0.361 * 1000 * 2 (all four flew 50km of best=50km).
+    for (const r of rows) expect(r.distance_points).toBeCloseTo(722, 0);
   });
 
   // Regression: goalTimes is built per-pilot (fastest), not per-attempt.
@@ -483,10 +485,12 @@ describe('rebuildTaskResults', () => {
       .all(taskTime.id) as any[];
     expect(rows).toHaveLength(2);
     const byUser = new Map(rows.map((r) => [r.user_id, r]));
-    // §12.2 with t_best=3000s: pilot B at 3000 → 1000.
-    // Pilot A's *best* is 3600 (slower 4200 is ignored) → 757.6.
-    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(1000, 0);
-    expect(byUser.get(pilot.id).time_points).toBeCloseTo(757.6, 1);
+    // Both pilots in goal → GR=1 → TimeWeight 0.639; winner raw total is
+    // 361 + 639 = 1000, normalized_score 2000 → scale 2 (time pool 1278).
+    // §12.2 with t_best=3000s: pilot B at 3000 → 1278.
+    // Pilot A's *best* is 3600 (slower 4200 is ignored) → SF 0.7576 → 968.2.
+    expect(byUser.get(pilot2.id).time_points).toBeCloseTo(1278, 0);
+    expect(byUser.get(pilot.id).time_points).toBeCloseTo(968.2, 1);
   });
 
   // §13.1: the PG time-points parameter is 0% — a speed-section time earns
@@ -518,11 +522,13 @@ describe('rebuildTaskResults', () => {
     expect(rows[1].rank).toBe(1); // shared rank — the ESS time confers nothing
   });
 
-  it('ranks a goal pilot above an equal-total non-goal pilot regardless of ESS times', () => {
+  it('orders a goal pilot above an equal-total non-goal pilot but shares the rank value', () => {
     // Under the §12.2 absolute cutoff a goal pilot slower than
     // t_best + sqrt(t_best) scores 0 time points, so a non-goal pilot at
-    // bestDist can tie them on total_points. The goal pilot must still rank
-    // first — a fast ESS-only time must not flip the order.
+    // bestDist can tie them on total_points. S7F ranks on the rounded
+    // TotalScore alone, so the two SHARE a rank; the goal pilot is merely
+    // listed first (deterministic render order), and the fast ESS-only time
+    // earns the non-goal pilot nothing.
     const fast = createTestUser(db, { email: 'fast@test.com', displayName: 'Fast Finisher' });
     addLeagueMember(db, league.id, fast.id, 'pilot');
 
@@ -550,17 +556,158 @@ describe('rebuildTaskResults', () => {
 
     rebuildTaskResults(db, task.id);
 
+    // Mirror the leaderboard route's deterministic order within a shared
+    // rank: goal-gated task time, then goal flag, then pilot id.
     const rows = db
-      .prepare('SELECT user_id, reached_goal, total_points, rank FROM task_results WHERE task_id = ? ORDER BY rank')
+      .prepare(
+        `SELECT user_id, reached_goal, total_points, rank FROM task_results WHERE task_id = ?
+         ORDER BY rank,
+                  COALESCE(CASE WHEN reached_goal = 1 THEN task_time_s END, 1e15),
+                  reached_goal DESC, user_id`,
+      )
       .all(task.id) as any[];
     expect(rows).toHaveLength(3);
     expect(rows[0].user_id).toBe(fast.id);
+    expect(rows[0].rank).toBe(1);
     // Slow goal pilot and non-goal pilot tie on points…
     expect(rows[1].total_points).toBe(rows[2].total_points);
-    // …but the goal pilot ranks above; the non-goal ESS time earns nothing.
+    // …the goal pilot is listed first, but the rank VALUE is shared (1, 2, 2).
     expect(rows[1].user_id).toBe(pilot.id);
     expect(rows[1].reached_goal).toBe(1);
+    expect(rows[1].rank).toBe(2);
     expect(rows[2].user_id).toBe(pilot2.id);
+    expect(rows[2].rank).toBe(2);
+  });
+
+  it('resumes competition ranking after a shared rank (1, 1, 3)', () => {
+    // Two non-goal pilots tie at bestDist; a third lands shorter. The tied
+    // pair share rank 1 and the next distinct total gets rank 3
+    // (1 + count of strictly better pilots), not rank 2.
+    const pilot3 = createTestUser(db, { email: 'third@test.com', displayName: 'Third Pilot' });
+    addLeagueMember(db, league.id, pilot3.id, 'pilot');
+
+    for (const p of [pilot, pilot2]) {
+      const sub = createTestSubmission(db, task.id, p.id, league.id);
+      createTestAttempt(db, sub, task.id, p.id, league.id, { reachedGoal: false, distanceFlownKm: 50 });
+    }
+    const sub3 = createTestSubmission(db, task.id, pilot3.id, league.id);
+    createTestAttempt(db, sub3, task.id, pilot3.id, league.id, { reachedGoal: false, distanceFlownKm: 20 });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, total_points, rank FROM task_results WHERE task_id = ? ORDER BY rank, user_id')
+      .all(task.id) as any[];
+    expect(rows).toHaveLength(3);
+    expect(rows[0].rank).toBe(1);
+    expect(rows[1].rank).toBe(1);
+    expect(rows[0].total_points).toBe(rows[1].total_points);
+    expect(rows[2].user_id).toBe(pilot3.id);
     expect(rows[2].rank).toBe(3);
+  });
+
+  // ── FAI S7F §11 goal-ratio weighting ───────────────────────────────────────
+
+  it('GR = 0: distance pool is 900 raw, but normalization still lands the winner on 1000', () => {
+    // Nobody in goal → DistanceWeight 0.9 (TimeWeight 0.1 is moot — no time
+    // points without goal). Raw winner = 900; the per-task normalization
+    // rescales to normalized_score (default 1000), so relative spacing is
+    // all sqrt-of-distance: runner-up at a quarter distance = 500.
+    const sub1 = createTestSubmission(db, task.id, pilot.id, league.id);
+    createTestAttempt(db, sub1, task.id, pilot.id, league.id, { reachedGoal: false, distanceFlownKm: 80 });
+    const sub2 = createTestSubmission(db, task.id, pilot2.id, league.id);
+    createTestAttempt(db, sub2, task.id, pilot2.id, league.id, { reachedGoal: false, distanceFlownKm: 20 });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, distance_points, time_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank')
+      .all(task.id) as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].user_id).toBe(pilot.id);
+    expect(rows[0].total_points).toBe(1000);
+    expect(rows[0].time_points).toBe(0);
+    expect(rows[1].total_points).toBe(500); // 900·√(20/80) = 450 raw, × 1000/900
+  });
+
+  it('GR = 0.5 worked example: two of four in goal → DW 0.422375 / TW 0.577625 exactly', () => {
+    // A (goal, 3000 s), B (goal, 3600 s), C (25 km), D (12.5 km); task
+    // distance 50 km. GR = 2/4 = 0.5:
+    //   DW = 0.9 − 1.665·0.5 + 1.713·0.25 − 0.587·0.125 = 0.422375
+    //   TW = 1 − DW = 0.577625
+    // A's raw total = 422.375 + 577.625 = 1000 → scale is exactly 1 at the
+    // default normalized_score, so the persisted rows expose the weighted
+    // raw values directly:
+    //   A: 422.4 + 577.6 = 1000
+    //   B: 422.4 + 577.625·SF(3600 vs 3000 = 0.7576) = 437.6 → 860.0
+    //   C: 422.375·√(25/50)   = 298.7
+    //   D: 422.375·√(12.5/50) = 211.2
+    const pilotC = createTestUser(db, { email: 'cc@test.com', displayName: 'Pilot C' });
+    const pilotD = createTestUser(db, { email: 'dd@test.com', displayName: 'Pilot D' });
+    addLeagueMember(db, league.id, pilotC.id, 'pilot');
+    addLeagueMember(db, league.id, pilotD.id, 'pilot');
+
+    const seed = (p: { id: string }, opts: Parameters<typeof createTestAttempt>[5]) => {
+      const sub = createTestSubmission(db, task.id, p.id, league.id);
+      createTestAttempt(db, sub, task.id, p.id, league.id, opts);
+    };
+    seed(pilot, { reachedGoal: true, distanceFlownKm: 50, taskTimeS: 3000 });
+    seed(pilot2, { reachedGoal: true, distanceFlownKm: 50, taskTimeS: 3600 });
+    seed(pilotC, { reachedGoal: false, distanceFlownKm: 25 });
+    seed(pilotD, { reachedGoal: false, distanceFlownKm: 12.5 });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, distance_points, time_points, total_points, rank FROM task_results WHERE task_id = ?')
+      .all(task.id) as any[];
+    const byUser = new Map(rows.map((r) => [r.user_id, r]));
+
+    const a = byUser.get(pilot.id);
+    expect(a.distance_points).toBe(422.4); // DW · 1000, rounded once
+    expect(a.time_points).toBe(577.6); // TW · 1000, rounded once
+    expect(a.total_points).toBe(1000);
+    expect(a.rank).toBe(1);
+
+    const b = byUser.get(pilot2.id);
+    expect(b.distance_points).toBe(422.4);
+    expect(b.time_points).toBe(437.6);
+    expect(b.total_points).toBe(860);
+
+    expect(byUser.get(pilotC.id).total_points).toBe(298.7);
+    expect(byUser.get(pilotD.id).total_points).toBe(211.2);
+  });
+
+  it('GR-changing upload parity: server numbers the frontend preview must reproduce', () => {
+    // Companion to the previewPipeline.test.ts case "a goal preview moves
+    // the goal ratio": one stored non-goal pilot at 40 km, then a goal
+    // upload at 50 km / 3600 s arrives. GR moves 0 → 1/2 → DW 0.422375.
+    // The frontend preview of that second flight must show exactly the
+    // numbers this rebuild persists.
+    const sub1 = createTestSubmission(db, task.id, pilot.id, league.id);
+    createTestAttempt(db, sub1, task.id, pilot.id, league.id, { reachedGoal: false, distanceFlownKm: 40 });
+    const sub2 = createTestSubmission(db, task.id, pilot2.id, league.id);
+    createTestAttempt(db, sub2, task.id, pilot2.id, league.id, {
+      reachedGoal: true,
+      distanceFlownKm: 50,
+      taskTimeS: 3600,
+    });
+
+    rebuildTaskResults(db, task.id);
+
+    const rows = db
+      .prepare('SELECT user_id, distance_points, time_points, total_points FROM task_results WHERE task_id = ?')
+      .all(task.id) as any[];
+    const byUser = new Map(rows.map((r) => [r.user_id, r]));
+
+    const goal = byUser.get(pilot2.id);
+    expect(goal.distance_points).toBe(422.4);
+    expect(goal.time_points).toBe(577.6);
+    expect(goal.total_points).toBe(1000);
+
+    const short = byUser.get(pilot.id);
+    expect(short.distance_points).toBe(377.8); // 422.375·√(40/50)
+    expect(short.time_points).toBe(0);
+    expect(short.total_points).toBe(377.8);
   });
 });

--- a/tests/routes/standings.test.ts
+++ b/tests/routes/standings.test.ts
@@ -621,7 +621,9 @@ describe('rebuildTaskResults', () => {
     rebuildTaskResults(db, task.id);
 
     const rows = db
-      .prepare('SELECT user_id, distance_points, time_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank')
+      .prepare(
+        'SELECT user_id, distance_points, time_points, total_points FROM task_results WHERE task_id = ? ORDER BY rank',
+      )
       .all(task.id) as any[];
     expect(rows).toHaveLength(2);
     expect(rows[0].user_id).toBe(pilot.id);

--- a/tests/time-points.test.ts
+++ b/tests/time-points.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeDistancePoints, computeTimePoints, MAX_POINTS } from '../src/shared/task-engine';
+import { computeDistancePoints, computeTimePoints, goalRatioWeights, MAX_POINTS } from '../src/shared/task-engine';
 
 const hms = (h: number, m: number, s: number) => h * 3600 + m * 60 + s;
 
@@ -53,6 +53,61 @@ describe('computeTimePoints (FAI S7F §12.2)', () => {
     // A pilot faster than the pool minimum (should not happen — the pool
     // includes the pilot) clamps to full points rather than NaN.
     expect(computeTimePoints(3000, [3600])).toBe(MAX_POINTS);
+  });
+});
+
+// FAI S7F §11: the distance/time split depends on the goal ratio.
+//   DistanceWeight = 0.9 - 1.665*GR + 1.713*GR² - 0.587*GR³
+// Leading and arrival points are deliberately dropped in this league, so
+// TimeWeight absorbs the full remainder (1 - DistanceWeight).
+describe('goalRatioWeights (FAI S7F §11)', () => {
+  it('GR = 0 (nobody in goal): distance gets 90%, time the 10% remainder', () => {
+    const { distanceWeight, timeWeight } = goalRatioWeights(0);
+    expect(distanceWeight).toBeCloseTo(0.9, 12);
+    expect(timeWeight).toBeCloseTo(0.1, 12);
+  });
+
+  it('GR = 0.5: DW = 0.9 - 0.8325 + 0.42825 - 0.073375 = 0.422375 exactly', () => {
+    const { distanceWeight, timeWeight } = goalRatioWeights(0.5);
+    expect(distanceWeight).toBeCloseTo(0.422375, 12);
+    expect(timeWeight).toBeCloseTo(0.577625, 12);
+  });
+
+  it('GR = 1 (everyone in goal): DW = 0.9 - 1.665 + 1.713 - 0.587 = 0.361', () => {
+    const { distanceWeight, timeWeight } = goalRatioWeights(1);
+    expect(distanceWeight).toBeCloseTo(0.361, 12);
+    expect(timeWeight).toBeCloseTo(0.639, 12);
+  });
+
+  it('weights always sum to 1 and clamp out-of-range ratios', () => {
+    for (const gr of [0, 0.1, 0.25, 0.33, 0.5, 0.75, 0.9, 1]) {
+      const { distanceWeight, timeWeight } = goalRatioWeights(gr);
+      expect(distanceWeight + timeWeight).toBeCloseTo(1, 12);
+      expect(distanceWeight).toBeGreaterThan(0);
+      expect(distanceWeight).toBeLessThan(1);
+    }
+    expect(goalRatioWeights(-0.5)).toEqual(goalRatioWeights(0));
+    expect(goalRatioWeights(1.5)).toEqual(goalRatioWeights(1));
+  });
+});
+
+describe('availablePoints pools scale the compute functions linearly', () => {
+  it('computeDistancePoints returns the pool for goal pilots and scales sqrt for the rest', () => {
+    // GR = 0 → AvailableDistancePoints = 0.9 * 1000 = 900 raw.
+    expect(computeDistancePoints(50, 50, true, 900)).toBe(900);
+    expect(computeDistancePoints(25, 100, false, 900)).toBeCloseTo(450, 9);
+    // Default remains MAX_POINTS for isolated unit use.
+    expect(computeDistancePoints(50, 50, true)).toBe(MAX_POINTS);
+  });
+
+  it('computeTimePoints returns the pool for t_best and scales the fraction', () => {
+    expect(computeTimePoints(3000, [3000, 3600], 639)).toBe(639);
+    expect(computeTimePoints(3600, [3000, 3600], 639)).toBeCloseTo(
+      0.639 * computeTimePoints(3600, [3000, 3600]),
+      9,
+    );
+    // Sole/no finisher degenerate branch honours the pool too.
+    expect(computeTimePoints(5000, [], 639)).toBe(639);
   });
 });
 

--- a/tests/time-points.test.ts
+++ b/tests/time-points.test.ts
@@ -102,10 +102,7 @@ describe('availablePoints pools scale the compute functions linearly', () => {
 
   it('computeTimePoints returns the pool for t_best and scales the fraction', () => {
     expect(computeTimePoints(3000, [3000, 3600], 639)).toBe(639);
-    expect(computeTimePoints(3600, [3000, 3600], 639)).toBeCloseTo(
-      0.639 * computeTimePoints(3600, [3000, 3600]),
-      9,
-    );
+    expect(computeTimePoints(3600, [3000, 3600], 639)).toBeCloseTo(0.639 * computeTimePoints(3600, [3000, 3600]), 9);
     // Sole/no finisher degenerate branch honours the pool too.
     expect(computeTimePoints(5000, [], 639)).toBe(639);
   });


### PR DESCRIPTION
Stacked on #65 (which stacks on #64). Implements audit findings 10, 11, 13 and the documentation corrections 14–16. Finding 12 (minimum-distance floor) is deliberately deferred for discussion.

## §11 goal-ratio distance/time split (finding 11)

Distance and time each had a fixed 1000 available raw points, making time always 50% of a goal pilot's raw score. FAI §11 makes the split depend on the goal ratio:

```
GR = pilots in goal / pilots flown
DW = 0.9 − 1.665·GR + 1.713·GR² − 0.587·GR³
TW = 1 − DW            ← deliberate deviation: leading + arrival points are dropped,
                          so time absorbs the full remainder (full FAI PG carves out a 26% LTR share)
```

Reference points: GR=0 → 900/100, GR=0.5 → 422.4/577.6, GR=1 → 361/639. The practical effect: on a task where one pilot scrapes into goal and everyone else lands out, landing 100 m short no longer costs half your score. All three scoring paths — `rebuildTaskResults`, the upload-time provisional score, and the client preview — derive the same GR (each counts distinct pilots, submitter/previewer folded in); parity between server and preview is pinned by tests asserting identical numbers for the same field.

Normalization is unchanged: weights set the *mix*, `normalized_score` sets the *scale*.

## Crossing tolerance 0.1% (finding 10)

`tagToleranceM` used 0.5% of cylinder radius with a comment calling it "standard practice" — the 2025 spec explicitly sets 0.1% for all competitions (§9.1.1, `max(5 m, 0.1%·r)`). A 10 km start cylinder's tolerance band shrinks from 50 m to 10 m.

## Shared ranks on equal totals (finding 13)

Ranks now use competition ranking on the rounded persisted total: equal totals share a rank (1, 1, 3). S7F ranks on the one-decimal score and has no elapsed-time tie-split. Row *order* within a shared rank stays deterministic (goal-gated time, then pilot id) so leaderboards render stably. Season standings aggregation is unaffected (sums points, never reads task rank).

## SCORING.md corrections (findings 14–16)

- The sqrt distance curve is now explicitly labeled a deliberate departure from §12.1's linear PG formula, with the small-field rationale and a worked comparison.
- The stale "scores are finalized when an admin freezes the task" claim is gone (the freeze mechanism was removed in migration 0013); the Rescoring section now describes the real lifecycle — everything rescores on every submission while open (`t_best`, `bestDist`, goal ratio, and the normalization scale can all move), submissions stop at `close_date`, and post-close changes only happen via admin deletion or `normalized_score` edits.
- Normalization's task-quality caveat (a 5 km day and a 100 km epic both normalize the winner to 1000 — FAI validity would separate them) and the async `t_best`-pools-across-days caveat are documented.

## Deploy note

`SCORER_VERSION` 1.3 → 1.4: stored tracks reprocess at boot under the tighter tolerance; combined with the §11 weights, **all existing task results will change on deploy**.

## Verification

304 backend + 37 frontend tests pass (10 new), typecheck clean. Worked examples in tests were recomputed independently by script (GR=0.5 four-pilot field, GR=0 no-goal field, GR=1 with custom task value, and a GR-shifting preview/server parity pair).