### PR TITLE
Docs refresh: README, AGENTS.md, architecture doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,10 +395,14 @@ See `.env.example` for all required variables. Key ones:
 
 ### Current State / Known Issues
 
-- **Routes not implemented**: The `src/routes/` directory is empty. Route handlers are currently commented out in `server.ts`
-- **Job worker disabled**: `bootstrapWorker()` is commented out because `TaskRepository` is not yet implemented
-- **OAuth not configured**: Google OAuth requires real credentials; placeholder values in `.env` will not work for login
-- **No health endpoint**: The API doesn't have a `/health` route yet
+- **Fully implemented**: routes (`src/routes/`), IGC upload + scoring, task import/export,
+  and the boot-time reprocess/rebuild sweep are all live — see
+  `docs/backend-architecture.md` for the current shape
+- **Job queue is idle infrastructure**: `bootstrapWorker()` runs but no job types are
+  registered; scoring is synchronous (`rebuildTaskResults` inline)
+- **OAuth needs real credentials**: obtain them from admin@nwparagliding.com; placeholder
+  values in `.env` will not work for login (never commit real values)
+- **No health endpoint**: the API doesn't have a `/health` route yet
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ A fullstack TypeScript application for paragliding and hike & fly competition sc
 - **Frontend**: React + Vite + TypeScript (ESNext)
 - **Database**: SQLite with WAL mode, better-sqlite3
 - **Auth**: Google OAuth → JWT (RS256, HttpOnly cookies)
-- **Job Queue**: SQLite-backed queue with single-process worker
+- **Scoring**: FAI S7F-derived GAP model, fully synchronous — shared pipeline code runs on
+  both server (authoritative) and client (upload preview); see
+  [src/shared/SCORING.md](./src/shared/SCORING.md)
 
 ## Quick Start
 
 ### Prerequisites
 
-- Node.js >=20 (managed with `fnm`)
+- Node.js >=22 (managed with `fnm`)
 - Python 3.8+ (managed with `uv` for native module compilation)
 
 ### Setup
@@ -73,12 +75,12 @@ This project uses Google OAuth for authentication. The OAuth client is managed u
 
 **For Local Development:**
 
-1. **The OAuth client is already configured** with these credentials (managed by admin@nwparagliding.com):
-   - Client ID: `861900491662-msd4hraiu4dqre5f3ktgpopc4j1gc8pg.apps.googleusercontent.com`
-   - Client Secret: `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`
-   - Authorized redirect URI: `http://localhost:3000/api/v1/auth/oauth/google/callback`
+1. Obtain the local-dev OAuth client ID and secret from admin@nwparagliding.com — never
+   commit them (`.env` is gitignored; `.env.example` carries placeholders only). The
+   authorized redirect URI for local dev is
+   `http://localhost:3000/api/v1/auth/oauth/google/callback`.
 
-2. **These credentials are already in the project** - you just need to copy `.env.example` to `.env` (they're pre-filled)
+2. Put the values in `.env` as `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` (see `.env.example`).
 
 3. **To test login:**
    - Start the dev server: `npm run dev`
@@ -120,36 +122,45 @@ npm run typecheck    # Type check both projects
 ```
 /
 ├── src/                    # Backend TypeScript source
-│   ├── server.ts          # Fastify entry point
+│   ├── server.ts          # Fastify entry point (migrations + boot rescore sweep)
 │   ├── auth.ts            # JWT + OAuth middleware
-│   ├── pipeline.ts        # IGC processing pipeline
-│   ├── job-queue.ts       # Background job system
+│   ├── shared/            # Code shared with the frontend (preview parity)
+│   │   ├── pipeline.ts    # IGC processing pipeline
+│   │   ├── task-engine.ts # Geometry + GAP scoring formulas
+│   │   └── SCORING.md     # The league's scoring model
+│   ├── job-queue.ts       # Queue infra + rebuildTaskResults (scoring rebuild)
+│   ├── upload.ts          # IGC upload handler
+│   ├── reprocess.ts       # Boot-time reprocess of stale tracks (SCORER_VERSION)
+│   ├── task-parsers.ts    # .xctsk / .cup import
+│   ├── task-exporters.ts  # .xctsk / .cup export + QR codes
 │   ├── schema.sql         # Database schema
+│   ├── migrations/        # Numbered SQL migrations
 │   └── routes/            # API route handlers
 ├── frontend/              # React frontend
 │   ├── src/
 │   │   ├── main.tsx       # React entry point
 │   │   ├── App.tsx        # Root component
 │   │   ├── api/           # API client functions
+│   │   ├── lib/           # previewPipeline (client-side scoring preview)
 │   │   ├── hooks/         # React hooks
 │   │   └── pages/         # Page components
 │   └── vite.config.ts
+├── docs/                  # Architecture documentation
 └── AGENTS.md              # Coding agent guidelines
 
 ```
 
-## Current Status
+## Features
 
-🚧 **Early Development** 🚧
-
-- ✅ Database schema and migrations ready
-- ✅ Authentication architecture implemented
-- ✅ Frontend UI components complete
-- ✅ IGC processing pipeline designed
-- ✅ API route handlers (auth, leagues, tasks, submissions)
-- ✅ Google OAuth login working (localhost)
-- 🚧 Job worker (disabled until TaskRepository implemented)
-- 🚧 IGC upload and processing (route exists, needs implementation)
+- Multi-league / multi-season platform with Google OAuth and role-based admin
+- Task management: .xctsk / .cup import, export, and QR codes (XCTrack-compatible)
+- IGC upload with full GAP scoring: FAI S7F §12.2 time points, §11 goal-ratio
+  distance/time split, landing detection, direction-agnostic start crossings,
+  crossing-order enforcement (see [src/shared/SCORING.md](./src/shared/SCORING.md))
+- Client-side upload preview running the same shared pipeline the server scores with
+- Hike & fly seasons with ground-only turnpoints (`[GND]` prefix)
+- Live leaderboards and season standings; scores rebuild on every submission while a
+  task is open, tracks reprocess automatically when the scorer version changes
 
 ## Deployment
 
@@ -188,8 +199,11 @@ fly deploy --remote-only \
 
 ## Documentation
 
-- See [AGENTS.md](./AGENTS.md) for detailed coding guidelines and architecture notes
-- See [src/api-spec.ts](./src/api-spec.ts) for REST API specification
+- [src/shared/SCORING.md](./src/shared/SCORING.md) — the league's scoring model (formulas,
+  deliberate deviations from FAI S7F, rescoring lifecycle)
+- [docs/backend-architecture.md](./docs/backend-architecture.md) — backend architecture
+- [AGENTS.md](./AGENTS.md) — coding guidelines and architecture notes for agents
+- [src/api-spec.ts](./src/api-spec.ts) — REST API specification
 
 ## License
 

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -59,22 +59,27 @@ In production, Fastify also serves the Vite-built frontend from `dist/client/` a
 ├── src/                        # Backend TypeScript source
 │   ├── server.ts               # Entry point — plugin registration, startup
 │   ├── auth.ts                 # JWT, OAuth flow, request decoration, auth guards
-│   ├── pipeline.ts             # IGC processing pipeline (pure functions)
-│   ├── job-queue.ts            # SQLite-backed job queue + worker
-│   ├── upload.ts               # IGC upload and download handlers
-│   ├── track-replay.ts         # Track replay endpoint
+│   ├── shared/                 # Code shared with the frontend (client preview parity)
+│   │   ├── pipeline.ts         # IGC processing pipeline (pure functions)
+│   │   ├── task-engine.ts      # Geometry, route optimisation, GAP scoring formulas
+│   │   ├── pipeline-parity-fixture.ts  # Shared fixture pinning client/server parity
+│   │   └── SCORING.md          # The league's scoring model (FAI S7F-derived)
+│   ├── job-queue.ts            # Job-queue infra + rebuildTaskResults (scoring rebuild)
+│   ├── upload.ts               # IGC upload handler (runs the pipeline inline)
+│   ├── reprocess.ts            # Boot-time re-run of stale tracks (SCORER_VERSION)
 │   ├── task-parsers.ts         # .xctsk and .cup file parsers
 │   ├── task-exporters.ts       # .xctsk, .cup exporters + QR deep-link builder
-│   ├── migrate.ts              # Migration runner (standalone process)
+│   ├── migrate.ts              # Migration runner
+│   ├── migration-helpers.ts    # Shared migration utilities
 │   ├── schema.sql              # Base database schema (applied once by migration 0001)
 │   ├── api-spec.ts             # Inline API specification comments
-│   ├── optimiser.ts            # Route optimisation utilities
 │   ├── migrations/             # Numbered SQL migration files (0002, 0003, ...)
 │   └── routes/
 │       ├── auth.ts             # Fastify route wiring for auth endpoints
 │       ├── admin.ts            # Super-admin endpoints
 │       └── leagues.ts          # All league / season / task / submission endpoints
 ├── frontend/                   # React + Vite frontend (separate tsconfig)
+├── docs/                       # This document and friends
 ├── dist/                       # Compiled output (gitignored)
 │   ├── server.js               # Built backend entry point
 │   └── client/                 # Vite frontend build
@@ -95,7 +100,7 @@ Responsible for wiring everything together and starting the HTTP listener.
 1. `import 'dotenv/config'` — must be the first import; loads `.env`
 2. Open SQLite with `journal_mode = WAL`, `foreign_keys = ON`, `busy_timeout = 5000`
 3. `loadAuthConfig()` — reads all required env vars, crashes fast with a clear message if any are missing
-4. Instantiate `SQLiteJobQueue`; `bootstrapWorker()` is commented out until `TaskRepository` is implemented
+4. Instantiate `SQLiteJobQueue` + `bootstrapWorker()` (the worker runs but no job types are registered today — scoring is synchronous; stale jobs of removed types are deleted)
 5. Register Fastify plugins in order:
    - `@fastify/cookie` — required for the auth cookie
    - `@fastify/multipart` — 5 MB file limit, 1 file per request
@@ -103,8 +108,11 @@ Responsible for wiring everything together and starting the HTTP listener.
    - `authPlugin` — JWT decode + `request.user` decoration on every request
 6. In production: register `@fastify/static` serving `dist/client/`; `setNotFoundHandler` sends `index.html` for non-API GETs
 7. Dynamically import and register route modules under `/api/v1`: auth, admin, leagues
-8. Register `SIGTERM` / `SIGINT` graceful shutdown handlers
-9. Listen on `0.0.0.0:PORT`
+8. Run migrations, then the boot scoring sweep: `reprocessStaleSubmissions()` (re-runs the
+   pipeline for tracks stored under an older `SCORER_VERSION`) followed by
+   `rebuildTaskResults` over every non-deleted task
+9. Register `SIGTERM` / `SIGINT` graceful shutdown handlers
+10. Listen on `0.0.0.0:PORT`
 
 **Key constants:**
 
@@ -169,17 +177,17 @@ Called by route handlers, not as middleware:
 
 ---
 
-### `src/pipeline.ts` — IGC Processing Pipeline
+### `src/shared/pipeline.ts` — IGC Processing Pipeline
 
-A purely functional, staged pipeline. Every stage returns `Result<T, E>` and never throws. No database access occurs inside the pipeline — all inputs are passed in by the caller.
+A purely functional, staged pipeline. Every stage returns `Result<T, E>` and never throws. No database access occurs inside the pipeline — all inputs are passed in by the caller. It lives under `src/shared/` because the frontend imports it directly for the upload preview (`frontend/src/lib/previewPipeline.ts`) — client and server run the same code, pinned by the parity tests against `src/shared/pipeline-parity-fixture.ts`. The geometry and GAP scoring formulas live alongside it in `src/shared/task-engine.ts`; the scoring model is documented in `src/shared/SCORING.md`.
 
 See [Section 7](#7-igc-processing-pipeline) for full stage-by-stage documentation.
 
 ---
 
-### `src/job-queue.ts` — Background Job Queue
+### `src/job-queue.ts` — Job Queue Infra + `rebuildTaskResults`
 
-A SQLite-backed job queue with an EventEmitter-woken worker running in the same process.
+A SQLite-backed job queue with an EventEmitter-woken worker running in the same process (currently idle — no registered job types). This module also hosts `rebuildTaskResults`, the synchronous authoritative scoring rebuild.
 
 See [Section 8](#8-job-queue-and-background-workers) for full documentation.
 
@@ -210,9 +218,9 @@ migration 0013 — "closed" is derived from `close_date`.)
 
 ---
 
-### `src/track-replay.ts` — Track Replay
+### Track Replay (`src/routes/leagues.ts`)
 
-Handles `GET .../submissions/:submissionId/track`.
+Handles `GET .../submissions/:submissionId/track` (implemented inside the leagues route module — there is no separate `track-replay.ts`).
 
 **Design decision:** GPS fixes are **not stored** in the database. They are re-parsed from the raw IGC BLOB on every request (~10–30 ms). Storing ~10,000 fixes per submission at club scale (e.g. 200 submissions) would add ~50 MB of rarely-accessed data to SQLite. Turnpoint crossing events (computed at submission time) are loaded from the DB and overlaid on the re-parsed fixes.
 
@@ -588,6 +596,11 @@ runPipeline result
 ---
 
 ## 8. Job Queue and Background Workers
+
+> **Status: idle infrastructure.** No job types are registered today — scoring runs
+> synchronously (`rebuildTaskResults` inline on upload/delete paths, boot-time reprocess in
+> `src/reprocess.ts`, standings as a live SQL aggregate). The queue/worker below is kept for
+> future async work (notifications etc.); the server deletes jobs of removed types at startup.
 
 ### Queue Architecture
 


### PR DESCRIPTION
Closes #69.

## ⚠️ Security note first

The README contained a **plaintext Google OAuth client secret** (`GOCSPX-…`) in a public repo, committed back in c76a7bf as part of the OAuth setup instructions. This PR removes it, but git history retains it, so removal alone is not the fix:

**Action required: rotate the client secret** in Google Cloud Console (admin@nwparagliding.com → APIs & Credentials → the OAuth 2.0 client) and update the local/production `.env` values. After rotation the historical leak is inert; a history rewrite becomes unnecessary. `.env.example` was never affected (placeholders only).

## README

- OAuth section rewritten: obtain credentials from the admin, never commit them.
- Node prerequisite ≥20 → ≥22 (matches `package.json` engines).
- Tech Stack bullet for the job queue replaced with the actual scoring model (fully synchronous, shared client/server pipeline) + SCORING.md link.
- Project structure updated to the real tree (`src/shared/`, `reprocess.ts`, parsers/exporters, `docs/`).
- The 🚧 "Early Development" status list (routes empty, upload unimplemented, worker disabled) replaced with a current feature list.
- Documentation section now links SCORING.md and the architecture doc.

## AGENTS.md

"Current State / Known Issues" was frozen at early development — now reflects reality (everything implemented; job queue idle by design; `/health` still genuinely missing).

## docs/backend-architecture.md

Residual drift beyond what #66 already corrected: repository layout matches the actual tree, the startup sequence documents the boot reprocess + rebuild sweep (and that `bootstrapWorker` runs idle rather than being "commented out until TaskRepository"), Section 8 gets an explicit idle-infrastructure callout, and the module reference headers point at real files (`src/shared/pipeline.ts` with the client-parity note, track replay inside `leagues.ts`).

Docs-only — no runtime changes; lint clean.